### PR TITLE
feat(Text): added weight prop to override css font-weight property

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -45,11 +45,15 @@ export const Text: React.FC<TextProps> = ({
     className,
     ellipsis,
     color,
+    weight,
     ...rest
 }) => {
     return (
         <Tag
-            className={text({variant, ellipsis}, color ? colorText({color}, className) : className)}
+            className={text(
+                {variant, ellipsis, weight},
+                color ? colorText({color}, className) : className,
+            )}
             {...rest}
         >
             {children}

--- a/src/components/Text/text/text.scss
+++ b/src/components/Text/text/text.scss
@@ -3,6 +3,15 @@
 
 $block: '.#{variables.$ns}text';
 
+$textFontWeightMap: (
+    'bold' bold,
+    'normal' normal,
+    'lighter' lighter,
+    'bolder' bolder,
+    'inherit' inherit,
+    'unset' unset
+);
+
 #{$block} {
     &_variant_display-1 {
         @include mixins.text-display-1();
@@ -69,5 +78,11 @@ $block: '.#{variables.$ns}text';
     }
     &_ellipsis {
         @include mixins.overflow-ellipsis();
+    }
+
+    @each $mod, $value in $textFontWeightMap {
+        &_weight_#{$mod} {
+            font-weight: $value;
+        }
     }
 }

--- a/src/components/Text/text/text.ts
+++ b/src/components/Text/text/text.ts
@@ -28,6 +28,15 @@ export const TEXT_VARIANTS = [
     'code-inline-1',
 ] as const;
 
+const TEXT_FONT_WEIGHT_VARIANTS = [
+    'bold',
+    'normal',
+    'lighter',
+    'bolder',
+    'inherit',
+    'unset',
+] as const;
+
 export interface TextBaseProps {
     /**
      * Storybook: https://preview.yandexcloud.dev/uikit/?path=/story/typography--common
@@ -62,7 +71,10 @@ export interface TextBaseProps {
      *      - inline-3: font-size: 16px; line-height: 20px; font-weight: 400; font-family: var(--yc-font-family-monospace);
      */
     variant?: typeof TEXT_VARIANTS[number];
-
+    /**
+     * Ability to override "font-weight" css property
+     */
+    weight?: typeof TEXT_FONT_WEIGHT_VARIANTS[number];
     /**
      * hidden overflow content will be displayed with ellipsis `…`
      *
@@ -84,5 +96,5 @@ export interface TextBaseProps {
  * text({variant: 'display-1'}, 'some-class')`
  *```
  */
-export const text = ({variant = 'body-1', ellipsis}: TextBaseProps, className?: string) =>
-    b({variant, ellipsis}, className);
+export const text = ({variant = 'body-1', weight, ellipsis}: TextBaseProps, className?: string) =>
+    b({variant, ellipsis, weight}, className);


### PR DESCRIPTION
Where is ability to override `font-weight` css property.

it is very controversial ability because now you can rich more text variants than the design system provides. It's can provide some issues with migrations later.

But, for my opinion, it's facilitates the use of this component and make is more intuitive and developer friendly

p.s. naming is not final, if you have more suitable names , let's use them
