### PR TITLE
fix(TextInput)!: remove incorrect resize attribute styles

### DIFF
--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -32,10 +32,7 @@ $block: '.#{$ns}text-input';
 
         &_type {
             &_textarea {
-                &:not([resize]),
-                &[resize='none'] {
-                    resize: none;
-                }
+                resize: none;
                 // fix-bug(firefox): https://bugzilla.mozilla.org/show_bug.cgi?id=33654
                 overflow-x: hidden;
 


### PR DESCRIPTION
textarea does not have resize attribute.

Revert "fix: correctly show textarea resize control"

Reverts yandex-cloud/uikit#33