### PR TITLE
feat(HelpPopup)!: remove default ofset

### DIFF
--- a/src/components/HelpPopover/HelpPopover.scss
+++ b/src/components/HelpPopover/HelpPopover.scss
@@ -1,7 +1,0 @@
-@use '../variables';
-
-$block: '.#{variables.$ns}help-popover';
-
-#{$block} {
-    position: relative;
-}

--- a/src/components/HelpPopover/HelpPopover.scss
+++ b/src/components/HelpPopover/HelpPopover.scss
@@ -4,5 +4,4 @@ $block: '.#{variables.$ns}help-popover';
 
 #{$block} {
     position: relative;
-    left: 4px;
 }

--- a/src/components/HelpPopover/HelpPopover.tsx
+++ b/src/components/HelpPopover/HelpPopover.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
+import {block} from '../utils/cn';
 import {Popover, PopoverProps} from '../Popover';
 import {Icon} from '../Icon';
 import {QuestionMarkIcon} from '../icons/QuestionMarkIcon';
 import {QAProps} from '../types';
+
+const b = block('help-popover');
 
 /**
  * @see {@link https://github.com/microsoft/TypeScript/issues/28339}
@@ -14,7 +17,7 @@ export type HelpPopoverProps = DistributiveOmit<PopoverProps, 'children'> & QAPr
 
 export function HelpPopover(props: HelpPopoverProps) {
     return (
-        <Popover {...props}>
+        <Popover {...props} className={b(null, props.className)}>
             <Icon data={QuestionMarkIcon} size={16} />
         </Popover>
     );

--- a/src/components/HelpPopover/HelpPopover.tsx
+++ b/src/components/HelpPopover/HelpPopover.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 
-import {block} from '../utils/cn';
 import {Popover, PopoverProps} from '../Popover';
 import {Icon} from '../Icon';
 import {QuestionMarkIcon} from '../icons/QuestionMarkIcon';
 import {QAProps} from '../types';
-
-import './HelpPopover.scss';
-
-const b = block('help-popover');
 
 /**
  * @see {@link https://github.com/microsoft/TypeScript/issues/28339}
@@ -19,7 +14,7 @@ export type HelpPopoverProps = DistributiveOmit<PopoverProps, 'children'> & QAPr
 
 export function HelpPopover(props: HelpPopoverProps) {
     return (
-        <Popover {...props} className={b(null, props.className)}>
+        <Popover {...props}>
             <Icon data={QuestionMarkIcon} size={16} />
         </Popover>
     );

--- a/src/components/HelpPopover/HelpPopover.tsx
+++ b/src/components/HelpPopover/HelpPopover.tsx
@@ -19,7 +19,7 @@ export type HelpPopoverProps = DistributiveOmit<PopoverProps, 'children'> & QAPr
 
 export function HelpPopover(props: HelpPopoverProps) {
     return (
-        <Popover offset={{left: 4}} {...props} className={b(null, props.className)}>
+        <Popover {...props} className={b(null, props.className)}>
             <Icon data={QuestionMarkIcon} size={16} />
         </Popover>
     );


### PR DESCRIPTION
Add css rule `left: 4` by default look like not so good solution.
What if i want render this Popover exactly in place? What if i want add padding with `padding` or `margin` rules?
And another important point is the evidence of behavior. How i should to know that this component is shifted on 4 pixels? 

Summing up the above i suggest remove this default offset at all and add the ability for users to manage the margins themselves 