### PR TITLE
chore: add title props for Text component

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -10,6 +10,7 @@ export interface TextProps extends TextBaseProps, ColorTextBaseProps {
     style?: React.CSSProperties;
     className?: string;
     children?: React.ReactNode;
+    title?: string;
 }
 
 /**

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -10,7 +10,11 @@ export interface TextProps extends TextBaseProps, ColorTextBaseProps {
     style?: React.CSSProperties;
     className?: string;
     children?: React.ReactNode;
-    title?: string;
+
+    /**
+     * Property to set `title` attribute of html tag
+     */
+    titleAttribute?: string;
 }
 
 /**
@@ -52,6 +56,7 @@ export const Text: React.FC<TextProps> = ({
         <Tag
             className={text({variant, ellipsis}, color ? colorText({color}, className) : className)}
             {...rest}
+            title={rest.titleAttribute}
         >
             {children}
         </Tag>


### PR DESCRIPTION
Add `title` property for `Text` component.
`title` is [global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), there is no conflicts with `as` property.
