### PR TITLE
fix: use background-size as percent value for loading button for safari

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -453,7 +453,7 @@ $block: '.#{variables.$ns}button';
             var(--yc-button-loading-color-2) 4px,
             var(--yc-button-loading-color-2) 8px
         );
-        background-size: 34px;
+        background-size: 150%;
         background-clip: padding-box;
         animation: #{variables.$ns}button-loading 0.5s linear infinite;
     }


### PR DESCRIPTION
<img width="321" alt="image" src="https://user-images.githubusercontent.com/24455680/189547066-a8297ef1-90a5-43e6-9f83-abe8060ea888.png">

This happens because height is 34px, making it 150% (100% is not enough because of animation) fixes this issue and doesn't break how it looks in other browsers.