### PR TITLE
fix: loose i18n typings

### DIFF
--- a/src/components/utils/configure.ts
+++ b/src/components/utils/configure.ts
@@ -4,7 +4,7 @@ export enum Lang {
 }
 
 interface Config {
-    lang: Lang;
+    lang: `${Lang}`;
 }
 
 type Subscriber = (config: Config) => void;


### PR DESCRIPTION
Instead of:
```ts
import {configure, Lang} from '@gravity-ui/uikit';

configure({lang: Lang.En});
```

it's able to write:
```ts
import {configure} from '@gravity-ui/uikit';

configure({lang: 'en'});
```