### PR TITLE
feat(Popover): updated anchorRef prop, added strategy prop to Popover

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -13,7 +13,6 @@ import {Trigger} from './components/Trigger/Trigger';
 import {useOpen} from './hooks/useOpen';
 import {cnPopover} from './Popover.classname';
 import type {PopoverInstanceProps, PopoverProps} from './types';
-import {PopperProps} from '../utils/usePopper';
 import {PopoverBehavior} from './config';
 import './Popover.scss';
 
@@ -50,7 +49,7 @@ export const Popover = forwardRef(function (
         anchorRef,
         strategy,
         qa,
-    }: Omit<PopperProps, 'offset' | 'modifiers'> & PopoverProps & QAProps,
+    }: PopoverProps & QAProps,
     ref: ForwardedRef<PopoverInstanceProps | undefined>,
 ) {
     const controlRef = useRef<HTMLDivElement>(null);

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -13,6 +13,7 @@ import {Trigger} from './components/Trigger/Trigger';
 import {useOpen} from './hooks/useOpen';
 import {cnPopover} from './Popover.classname';
 import type {PopoverInstanceProps, PopoverProps} from './types';
+import {PopperProps} from '../utils/usePopper';
 import {PopoverBehavior} from './config';
 import './Popover.scss';
 
@@ -47,8 +48,9 @@ export const Popover = forwardRef(function (
         onCloseClick,
         onClick,
         anchorRef,
+        strategy,
         qa,
-    }: PopoverProps & QAProps,
+    }: Omit<PopperProps, 'offset' | 'modifiers'> & PopoverProps & QAProps,
     ref: ForwardedRef<PopoverInstanceProps | undefined>,
 ) {
     const controlRef = useRef<HTMLDivElement>(null);
@@ -93,6 +95,7 @@ export const Popover = forwardRef(function (
 
     const tooltip = (
         <Popup
+            strategy={strategy}
             anchorRef={anchorRef || controlRef}
             className={cnPopover(
                 'tooltip',

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,3 +1,3 @@
 export * from './Popover';
-export {PopoverButtonProps, PopoverProps, PopoverInstanceProps} from './types';
+export {PopoverButtonProps, PopoverProps, PopoverInstanceProps, PopoverAnchorRef} from './types';
 export {PopoverBehavior} from './config';

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -1,10 +1,10 @@
 import React from 'react';
-import {PopupPlacement} from '../Popup';
 import {ButtonsProps} from './components/Buttons/Buttons';
 import {ContentProps} from './components/Content/Content';
 import {LinksProps} from './components/Links/Links';
 import {TriggerProps} from './components/Trigger/Trigger';
 import {PopoverBehavior} from './config';
+import {PopperAnchorRef} from '../utils/usePopper';
 
 export type PopoverButtonProps = {
     /**
@@ -18,8 +18,6 @@ export type PopoverButtonProps = {
 };
 
 export type PopoverExternalProps = {
-    /** Allows to use custom anchor and disables `openByHover` and `onClick` for the component */
-    anchorRef?: React.RefObject<HTMLElement>;
     /** Tooltip's trigger content over which the tooltip is shown */
     children?: TriggerProps['children'];
     /** Tooltip's title */
@@ -81,6 +79,7 @@ export type PopoverBehaviorProps = {
 };
 
 export type PopoverTheme = 'info' | 'special' | 'announcement';
+export type PopoverAnchorRef = PopperAnchorRef;
 
 export type PopoverDefaultProps = {
     /** Whether the tooltip initially opened */
@@ -96,8 +95,6 @@ export type PopoverDefaultProps = {
         top?: number;
         left?: number;
     };
-    /** Tooltip's placement */
-    placement: PopupPlacement;
     /** Whether the tooltip has a tail */
     hasArrow: boolean;
     /** Whether the tooltip has a close button */

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -107,7 +107,7 @@ export type PopoverDefaultProps = {
     size: 's' | 'l';
 };
 
-export type PopoverProps = Omit<PopperProps, 'offset' | 'modifiers'> &
+export type PopoverProps = Pick<PopperProps, 'anchorRef' | 'strategy' | 'placement'> &
     PopoverExternalProps &
     PopoverBehaviorProps &
     Partial<PopoverDefaultProps>;

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -4,7 +4,7 @@ import {ContentProps} from './components/Content/Content';
 import {LinksProps} from './components/Links/Links';
 import {TriggerProps} from './components/Trigger/Trigger';
 import {PopoverBehavior} from './config';
-import {PopperAnchorRef} from '../utils/usePopper';
+import {PopperAnchorRef, PopperProps} from '../utils/usePopper';
 
 export type PopoverButtonProps = {
     /**
@@ -107,7 +107,8 @@ export type PopoverDefaultProps = {
     size: 's' | 'l';
 };
 
-export type PopoverProps = PopoverExternalProps &
+export type PopoverProps = Omit<PopperProps, 'offset' | 'modifiers'> &
+    PopoverExternalProps &
     PopoverBehaviorProps &
     Partial<PopoverDefaultProps>;
 

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -3,8 +3,8 @@ import {ButtonsProps} from './components/Buttons/Buttons';
 import {ContentProps} from './components/Content/Content';
 import {LinksProps} from './components/Links/Links';
 import {TriggerProps} from './components/Trigger/Trigger';
+import {PopupProps, PopupAnchorRef} from '../Popup';
 import {PopoverBehavior} from './config';
-import {PopperAnchorRef, PopperProps} from '../utils/usePopper';
 
 export type PopoverButtonProps = {
     /**
@@ -79,7 +79,7 @@ export type PopoverBehaviorProps = {
 };
 
 export type PopoverTheme = 'info' | 'special' | 'announcement';
-export type PopoverAnchorRef = PopperAnchorRef;
+export type PopoverAnchorRef = PopupAnchorRef;
 
 export type PopoverDefaultProps = {
     /** Whether the tooltip initially opened */
@@ -107,7 +107,7 @@ export type PopoverDefaultProps = {
     size: 's' | 'l';
 };
 
-export type PopoverProps = Pick<PopperProps, 'anchorRef' | 'strategy' | 'placement'> &
+export type PopoverProps = Pick<PopupProps, 'anchorRef' | 'strategy' | 'placement'> &
     PopoverExternalProps &
     PopoverBehaviorProps &
     Partial<PopoverDefaultProps>;

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -6,10 +6,11 @@ import {Portal} from '../Portal';
 import {useLayer, LayerExtendableProps} from '../utils/useLayer';
 import {
     usePopper,
-    PopperProps,
+    PopperAnchorRef,
+    PopperModifiers,
     PopperOffset,
     PopperPlacement,
-    PopperModifiers,
+    PopperProps,
 } from '../utils/usePopper';
 import {PopupArrow} from './PopupArrow';
 import {usePreviousValue} from '../utils/usePreviousValue';
@@ -19,6 +20,7 @@ import {useForkRef} from '../utils/useForkRef';
 import './Popup.scss';
 
 export type PopupPlacement = PopperPlacement;
+export type PopupAnchorRef = PopperAnchorRef;
 
 export interface PopupProps extends DOMProps, LayerExtendableProps, PopperProps, QAProps {
     open?: boolean;

--- a/src/components/utils/usePopper.ts
+++ b/src/components/utils/usePopper.ts
@@ -5,9 +5,10 @@ import popper from '@popperjs/core';
 export type PopperPlacement = popper.Placement | popper.Placement[];
 export type PopperOffset = [number, number];
 export type PopperModifiers = Modifier<unknown, Record<string, unknown>>[];
+export type PopperAnchorRef = React.RefObject<Element | popper.VirtualElement>;
 
 export interface PopperProps {
-    anchorRef?: React.RefObject<Element | popper.VirtualElement>;
+    anchorRef?: PopperAnchorRef;
     placement?: PopperPlacement;
     offset?: [number, number];
     modifiers?: PopperModifiers;


### PR DESCRIPTION
The Popover component calls Popup internally. Updated the Popover props type so that it can accept the strategy prop and pass it to the Popup. In addition, replaced the Anchor property type so that a virtual anchor could be set. Also, in order to be able to type the transmitted value, created an exported Anchor type