### PR TITLE
feat(List): remove pointer-events from disabled items

### DIFF
--- a/src/components/List/List.scss
+++ b/src/components/List/List.scss
@@ -55,10 +55,6 @@ $block: '.#{variables.$ns}list';
             background: var(--yc-color-base-selection);
         }
 
-        &_inactive {
-            pointer-events: none;
-        }
-
         &_sort-handle-align_right {
             flex-direction: row-reverse;
 

--- a/src/components/List/components/ListItem.tsx
+++ b/src/components/List/components/ListItem.tsx
@@ -47,7 +47,7 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
                     itemClassName,
                 )}
                 style={style}
-                onClick={this.onClick}
+                onClick={item.disabled ? undefined : this.onClick}
                 onMouseEnter={this.onMouseEnter}
                 onMouseLeave={this.onMouseLeave}
                 ref={this.ref}
@@ -82,7 +82,8 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
         this.props.onClick?.(this.props.item, this.props.itemIndex);
     };
 
-    private onMouseEnter = () => this.props.onActivate(this.props.itemIndex);
+    private onMouseEnter = () =>
+        !this.props.item.disabled && this.props.onActivate(this.props.itemIndex);
 
     private onMouseLeave = () => this.props.onActivate(undefined);
 }

--- a/src/components/Select/__stories__/SelectShowcase.tsx
+++ b/src/components/Select/__stories__/SelectShowcase.tsx
@@ -3,6 +3,7 @@ import range from 'lodash/range';
 import {block} from '../../utils/cn';
 import {ClipboardButton} from '../../ClipboardButton';
 import {RadioButton, RadioButtonOption} from '../../RadioButton';
+import {Tooltip} from '../../Tooltip';
 import {Button} from '../../Button';
 import {Select, SelectProps, SelectOption} from '..';
 import {
@@ -12,6 +13,7 @@ import {
     EXAMPLE_GROUP_CHILDREN_OPTIONS,
     EXAMPLE_USER_OPTIONS,
     EXAMPLE_USER_CONTROL,
+    EXAMPLE_CUSTOM_RENDERER_WITH_DISABLED_ITEM,
 } from './constants';
 
 import './SelectShowcase.scss';
@@ -178,6 +180,27 @@ export const SelectShowcase = (props: SelectProps) => {
                     options: generateItems(1000),
                 }}
             />
+            <ExampleItem
+                title="Select with custom renderer & tooltip at disabled item"
+                code={[EXAMPLE_CUSTOM_RENDERER_WITH_DISABLED_ITEM]}
+                selectProps={{
+                    ...props,
+                    renderOption: (option) => {
+                        return option.disabled ? (
+                            <Tooltip content="Tooltip">
+                                <span style={{color: option.disabled ? 'gray' : 'inherit'}}>
+                                    Hover here
+                                </span>
+                            </Tooltip>
+                        ) : (
+                            <span>{option.content}</span>
+                        );
+                    },
+                }}
+            >
+                <Select.Option value="1" content="1" />
+                <Select.Option value="2" content="2" disabled />
+            </ExampleItem>
         </div>
     );
 };

--- a/src/components/Select/__stories__/constants.ts
+++ b/src/components/Select/__stories__/constants.ts
@@ -142,3 +142,25 @@ export const EXAMPLE_USER_CONTROL = `const [value, setValue] = React.useState<st
     <Select.Option value="val4" content="Value4" />
 </Select>
 `;
+
+export const EXAMPLE_CUSTOM_RENDERER_WITH_DISABLED_ITEM = `import {Tooltip} from '@gravity-ui/uikit';
+
+const [value, setValue] = React.useState<string[]>([]);
+
+<Select
+  value={value}
+  renderOption={(option) => {
+    return option.disabled ? (
+        <Tooltip content="Tooltip">
+            <span style={{color: option.disabled ? 'gray' : 'inherit'}}>
+                Hover here
+            </span>
+        </Tooltip>
+    ) : (
+        <span>{option.content}</span>
+    )}
+  }>
+    <Select.Option value="1" content="1" />
+    <Select.Option value="2" content="2" disabled />
+</Select>
+`;

--- a/src/components/Select/__tests__/Select.single.test.tsx
+++ b/src/components/Select/__tests__/Select.single.test.tsx
@@ -9,7 +9,10 @@ import {
     setup,
 } from './utils';
 
-afterEach(cleanup);
+afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+});
 
 const onUpdate = jest.fn();
 const onOpenChange = jest.fn();
@@ -55,6 +58,24 @@ describe('Select single mode actions', () => {
             await user.keyboard(`[${key}]`);
             expect(onUpdate).toHaveBeenCalledWith([selectedOption.value]);
             expect(selectControl).not.toHaveClass(SELECT_CONTROL_OPEN_CLASS);
+        });
+    });
+
+    describe('ignore disabled element selection by clicking in', () => {
+        test('flat list', async () => {
+            const searchText = 'Disabled option';
+            const options = [{content: searchText, value: '1', disabled: true}];
+            const {getByTestId, getByText} = setup({options, onUpdate, onOpenChange});
+            const user = userEvent.setup();
+            const selectControl = getByTestId(TEST_QA);
+            // open select popup
+            await user.click(selectControl);
+            expect(selectControl).toHaveClass(SELECT_CONTROL_OPEN_CLASS);
+            const option = getByText(searchText);
+            // select option
+            await user.click(option);
+            expect(onUpdate).not.toBeCalled();
+            expect(selectControl).toHaveClass(SELECT_CONTROL_OPEN_CLASS);
         });
     });
 });


### PR DESCRIPTION
Changed strategy for disabling items in List component. We won't apply `pointer-events: none` therefore the component would be more flexible, e.g. it will be possible to add `<Tooltip />`component as a custom renderer for disabled items.