### PR TITLE
fix: use native scrollbar on mobile devices

### DIFF
--- a/src/components/mobile/MobileProvider.tsx
+++ b/src/components/mobile/MobileProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {MobileContext, MobileContextProps, History, Location} from './MobileContext';
-import {Platform} from './constants';
+import {Platform, rootMobileClassName} from './constants';
 
 function useHistoryMock(): History {
     return {action: '', replace() {}, push() {}, goBack() {}};
@@ -47,6 +47,8 @@ export function MobileProvider({
         },
         [useHistory],
     );
+
+    document.body.classList.toggle(rootMobileClassName, mobileValue);
 
     const state: MobileContextProps = React.useMemo(() => {
         return {

--- a/src/components/mobile/constants.ts
+++ b/src/components/mobile/constants.ts
@@ -1,5 +1,10 @@
+import {block} from '../utils/cn';
+
 export enum Platform {
     IOS = 'ios',
     ANDROID = 'android',
     BROWSER = 'browser',
 }
+
+const b = block('root');
+export const rootMobileClassName = b({mobile: true}).split(/\s+/)[1];

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -14,6 +14,7 @@ interface ThemeProviderDefaultProps {
     theme: Theme;
     systemLightTheme: RealTheme;
     systemDarkTheme: RealTheme;
+    nativeScrollbar: boolean;
 }
 
 export interface ThemeProviderProps
@@ -25,6 +26,7 @@ export function ThemeProvider({
     theme: themeProp = DEFAULT_THEME,
     systemLightTheme: systemLightThemeProp = DEFAULT_LIGHT_THEME,
     systemDarkTheme: systemDarkThemeProp = DEFAULT_DARK_THEME,
+    nativeScrollbar = false,
     children,
 }: ThemeProviderProps) {
     const [theme, setTheme] = useState<Theme>(themeProp);
@@ -47,8 +49,8 @@ export function ThemeProvider({
     const themeValue = theme === 'system' ? systemTheme : theme;
 
     useEffect(() => {
-        updateBodyClassName(themeValue);
-    }, [themeValue]);
+        updateBodyClassName(themeValue, {'native-scrollbar': nativeScrollbar});
+    }, [nativeScrollbar, themeValue]);
 
     const contextValue = useMemo(
         () => ({

--- a/src/components/theme/updateBodyClassName.ts
+++ b/src/components/theme/updateBodyClassName.ts
@@ -4,11 +4,22 @@ import {RealTheme} from './types';
 const b = block('root');
 const rootClassName = b();
 
+export type BodyClassNameModifiers = {
+    'native-scrollbar': boolean;
+};
+
+const defaultModifiers: BodyClassNameModifiers = {
+    'native-scrollbar': false,
+};
+
 function modifier(className: string) {
     return className.split(/\s+/)[1];
 }
 
-export function updateBodyClassName(newTheme: RealTheme) {
+export function updateBodyClassName(
+    newTheme: RealTheme,
+    modifiers?: Partial<BodyClassNameModifiers>,
+) {
     const bodyEl = document.body;
 
     if (!bodyEl.classList.contains(rootClassName)) {
@@ -21,4 +32,8 @@ export function updateBodyClassName(newTheme: RealTheme) {
         }
     });
     bodyEl.classList.add(modifier(b({theme: newTheme})));
+
+    for (const [key, value] of Object.entries({...defaultModifiers, ...modifiers})) {
+        bodyEl.classList.toggle(modifier(b({[key]: true})), value);
+    }
 }

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -104,7 +104,7 @@
     }
 }
 
-body.yc-root {
+body.yc-root:not(.yc-root_mobile):not(.yc-root_native-scrollbar) {
     &::-webkit-scrollbar,
     *::-webkit-scrollbar {
         width: var(--yc-scrollbar-width);


### PR DESCRIPTION
On Android devices a custom scrollbar is not ignored, we need to disable it.

- MobileContext automatically adds the `yc-root_mobile` class.
- The existence of the `yc-root_mobile` or `yc-root_native-scrollbar` class disables the custom scrollbar.
