### PR TITLE
fix(Menu.Item): remove `onClick` from disabled items

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -42,7 +42,7 @@ const PureMenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(function Men
 ) {
     const commonProps = {
         title,
-        onClick,
+        onClick: disabled ? undefined : onClick,
         style,
         tabIndex: disabled ? -1 : 0,
         className: b('item', {disabled, active, theme}, className),


### PR DESCRIPTION
In case `<Menu.Item/>` got some elements with `pointer-events: all` clicks on such elements is propagated to `<Menu.Item>` `onClick` handler.