### PR TITLE
fix(DialogFooter): updated button style

### DIFF
--- a/src/components/Dialog/DialogFooter/DialogFooter.scss
+++ b/src/components/Dialog/DialogFooter/DialogFooter.scss
@@ -20,8 +20,11 @@ $block: '.#{variables.$ns}dialog-footer';
 
     &__button {
         min-width: 128px;
-        margin-left: 10px;
         position: relative;
+    }
+
+    &__bts-wrapper > &__button {
+        margin-left: 10px;
     }
 
     &__error {


### PR DESCRIPTION
There are cases when the Popup component can be applied to the button wrapper via the anchorRef attribute. In this case, the Popup is centred relative to the wrapper, and will be moved to the left due to the fact that the button contains an extra margin.

In general in the case when dialog with custom buttons renderer is used, the margin must be added by the user manually in the wrapper.