### PR TITLE
fix(List): remove focus from list on Tab key

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -8,6 +8,7 @@ import {block} from '../utils/cn';
 import {MobileContext} from '../mobile';
 import {TextInput} from '../TextInput';
 import {ListItem, SimpleContainer} from './components';
+import {listNavigationIgnoredKeys} from './constants';
 import type {ListProps, ListItemData, ListSortParams} from './types';
 
 import './List.scss';
@@ -146,6 +147,10 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
     // FIXME: BREAKING CHANGE. Rename to "handleKeyDown"
     onKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
         const {activeItem, pageSize} = this.state;
+
+        if (listNavigationIgnoredKeys.includes(event.key)) {
+            return;
+        }
 
         switch (event.key) {
             case 'ArrowDown': {

--- a/src/components/List/constants.ts
+++ b/src/components/List/constants.ts
@@ -1,8 +1,10 @@
+import {KeyCode} from '../constants';
+
 export const ListQa = {
     ACTIVE_ITEM: 'list-active-item',
 };
 
 export const listNavigationIgnoredKeys = [
     // Tab key should focus the next element
-    'Tab',
+    KeyCode.TAB,
 ];

--- a/src/components/List/constants.ts
+++ b/src/components/List/constants.ts
@@ -1,3 +1,8 @@
 export const ListQa = {
     ACTIVE_ITEM: 'list-active-item',
 };
+
+export const listNavigationIgnoredKeys = [
+    // Tab key should focus the next element
+    'Tab',
+];

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,6 +1,7 @@
 export const KeyCode = {
     BACKSPACE: 'Backspace',
     ENTER: 'Enter',
+    TAB: 'Tab',
     // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#whitespace_keys
     SPACEBAR: ' ',
 };


### PR DESCRIPTION
If you enter something in the search field, a value deletion button will appear and it will be impossible to move to the next element using the Tab key, since the component intercepts pressing any key and blocks focus