### PR TITLE
fix(StoriesGroup): fix click area

### DIFF
--- a/src/components/StoriesGroup/StoriesGroup.tsx
+++ b/src/components/StoriesGroup/StoriesGroup.tsx
@@ -31,7 +31,7 @@ export const StoriesGroup = ({
     open,
     groups,
     onItemSelect,
-    disableOutsideClick,
+    disableOutsideClick = true,
     initialStoryIndex = [0, 0],
     maxSliderItemsCount = DEFAULT_MAX_SLIDER_ITEMS_COUNT,
     onClose,

--- a/src/components/StoriesGroup/StoriesGroup.tsx
+++ b/src/components/StoriesGroup/StoriesGroup.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {Modal, ModalCloseReason} from '../Modal';
 import {IndexType, StoriesLayout} from '../Stories/components/StoriesLayout/StoriesLayout';
 import {StoriesPreview} from './components';
-import {StoriesGroupItem} from './types';
 
 import {block} from '../utils/cn';
 import './StoriesGroup.scss';
+import {StoriesGroupItem} from './types';
 
 const DEFAULT_MAX_SLIDER_ITEMS_COUNT = 12;
 
@@ -156,6 +156,7 @@ export const StoriesGroup = ({
                 groups={groups}
                 groupIndex={groupIndex}
                 onGroupSelect={onGroupSelect}
+                onClose={disableOutsideClick ? undefined : handleClose}
             />
             <StoriesLayout
                 storyIndex={itemIndex}

--- a/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.scss
+++ b/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.scss
@@ -4,7 +4,7 @@ $block: '.#{variables.$ns}stories-group-preview';
 
 #{$block} {
     user-select: none;
-    margin-bottom: 16px;
+    padding-bottom: 16px;
 
     display: flex;
     justify-content: center;

--- a/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.tsx
+++ b/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.tsx
@@ -8,8 +8,8 @@ import {Button, ButtonProps} from '../../../Button';
 
 import {block} from '../../../utils/cn';
 import './StoriesPreview.scss';
-import {ModalCloseReason} from 'src/components/Modal';
-import {StoriesItemMedia} from 'src/components/Stories/types';
+import {ModalCloseReason} from '../../../Modal';
+import {StoriesItemMedia} from '../../../Stories/types';
 
 const PREVIEW_ITEM_SIZE = 40;
 const PREVIEW_LIST_GAP = 8;

--- a/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.tsx
+++ b/src/components/StoriesGroup/components/StoriesPreview/StoriesPreview.tsx
@@ -4,12 +4,50 @@ import {MediaRenderer} from '../../../Stories/components';
 
 import {StoriesGroupItem} from '../../types';
 import {Chevron} from '../../../icons/Chevron';
-import {Button} from '../../../Button';
+import {Button, ButtonProps} from '../../../Button';
 
 import {block} from '../../../utils/cn';
 import './StoriesPreview.scss';
+import {ModalCloseReason} from 'src/components/Modal';
+import {StoriesItemMedia} from 'src/components/Stories/types';
+
+const PREVIEW_ITEM_SIZE = 40;
+const PREVIEW_LIST_GAP = 8;
 
 const b = block('stories-group-preview');
+
+type PreviewItemProps = {
+    groupIndex: number;
+
+    active: boolean;
+    disabled: boolean;
+
+    media?: StoriesItemMedia;
+    onSelectGroup?: (groupIndex: number) => void;
+};
+const PreviewItem = ({active, disabled, groupIndex, media, onSelectGroup}: PreviewItemProps) => {
+    const onClick = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
+        (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            onSelectGroup?.(groupIndex);
+        },
+        [onSelectGroup, groupIndex],
+    );
+
+    return (
+        <div
+            className={b('stories-preview-item', {
+                active,
+                disabled,
+            })}
+            onClick={onClick}
+        >
+            {media && <MediaRenderer media={media} />}
+        </div>
+    );
+};
 
 type StoriesPreviewListProps = {
     groups: StoriesGroupItem[];
@@ -27,36 +65,35 @@ const StoriesPreviewList = ({
         <React.Fragment>
             {groups.map(({thumbnailMedia, items}, i) => {
                 const media = thumbnailMedia || items[0]?.media;
+                const currentGroupIndex = offset + i;
 
                 return (
-                    <div
+                    <PreviewItem
                         key={i}
-                        className={b('stories-preview-item', {
-                            active: offset + i === groupIndex,
-                            disabled: items.length === 0,
-                        })}
-                        onClick={items.length === 0 ? undefined : () => onGroupSelect(offset + i)}
-                    >
-                        {media && <MediaRenderer media={media} />}
-                    </div>
+                        groupIndex={currentGroupIndex}
+                        active={currentGroupIndex === groupIndex}
+                        disabled={items.length === 0}
+                        media={media}
+                        onSelectGroup={onGroupSelect}
+                    />
                 );
             })}
         </React.Fragment>
     );
 };
 
-type StoriesPreviewWithSliderProps = {
+type StoriesPreviewListWithSliderProps = {
     groups: StoriesGroupItem[];
     groupIndex: number;
     onGroupSelect: (groupIndex: number) => void;
     maxSliderItemsCount: number;
 };
-const StoriesPreviewWithSlider = ({
+const StoriesPreviewListWithSlider = ({
     groupIndex,
     groups,
     onGroupSelect,
     maxSliderItemsCount,
-}: StoriesPreviewWithSliderProps) => {
+}: StoriesPreviewListWithSliderProps) => {
     const [offset, setOffset] = React.useState(0);
 
     React.useEffect(() => {
@@ -64,20 +101,32 @@ const StoriesPreviewWithSlider = ({
         setOffset(currentOffset);
     }, [groupIndex, maxSliderItemsCount]);
 
-    const setPreviewOffset = React.useCallback(() => {
-        setOffset((currentOffset) => {
-            return currentOffset - maxSliderItemsCount;
-        });
-    }, [maxSliderItemsCount]);
+    const setPreviewOffset = React.useCallback<NonNullable<ButtonProps['onClick']>>(
+        (event) => {
+            event.preventDefault();
+            event.stopPropagation();
 
-    const setNextOffset = React.useCallback(() => {
-        setOffset((currentOffset) => {
-            return currentOffset + maxSliderItemsCount;
-        });
-    }, [maxSliderItemsCount]);
+            setOffset((currentOffset) => {
+                return currentOffset - maxSliderItemsCount;
+            });
+        },
+        [maxSliderItemsCount],
+    );
+
+    const setNextOffset = React.useCallback<NonNullable<ButtonProps['onClick']>>(
+        (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            setOffset((currentOffset) => {
+                return currentOffset + maxSliderItemsCount;
+            });
+        },
+        [maxSliderItemsCount],
+    );
 
     return (
-        <div className={b()}>
+        <React.Fragment>
             {groups.length > maxSliderItemsCount && (
                 <div className={b('slider-button-wrapper')}>
                     {offset !== 0 && (
@@ -89,7 +138,12 @@ const StoriesPreviewWithSlider = ({
             )}
             <div
                 className={b('slider-preview-list-wrapper')}
-                style={{width: `${40 * maxSliderItemsCount + 8 * (maxSliderItemsCount - 1)}px`}}
+                style={{
+                    width: `${
+                        PREVIEW_ITEM_SIZE * maxSliderItemsCount +
+                        PREVIEW_LIST_GAP * (maxSliderItemsCount - 1)
+                    }px`,
+                }}
             >
                 <StoriesPreviewList
                     groupIndex={groupIndex}
@@ -107,7 +161,7 @@ const StoriesPreviewWithSlider = ({
                     )}
                 </div>
             )}
-        </div>
+        </React.Fragment>
     );
 };
 
@@ -116,17 +170,31 @@ export type StoriesPreviewProps = {
     groupIndex: number;
     onGroupSelect: (groupIndex: number) => void;
     maxSliderItemsCount: number;
+    onClose?: (
+        event: MouseEvent | KeyboardEvent | React.MouseEvent<HTMLElement, MouseEvent>,
+        reason: ModalCloseReason,
+    ) => void;
 };
+
+// all onClick handlers of StoriesPreview childrens should have preventDefault() and stopPropagation() callings
 
 export const StoriesPreview = ({
     groups,
     groupIndex,
     onGroupSelect,
     maxSliderItemsCount,
+    onClose,
 }: StoriesPreviewProps) => {
+    const handleClose = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
+        (event) => {
+            onClose?.(event, 'outsideClick');
+        },
+        [onClose],
+    );
+
     if (groups.length < maxSliderItemsCount) {
         return (
-            <div className={b()}>
+            <div className={b()} onClick={handleClose}>
                 <StoriesPreviewList
                     groupIndex={groupIndex}
                     groups={groups}
@@ -137,11 +205,13 @@ export const StoriesPreview = ({
     }
 
     return (
-        <StoriesPreviewWithSlider
-            maxSliderItemsCount={maxSliderItemsCount}
-            groupIndex={groupIndex}
-            groups={groups}
-            onGroupSelect={onGroupSelect}
-        />
+        <div className={b()} onClick={handleClose}>
+            <StoriesPreviewListWithSlider
+                maxSliderItemsCount={maxSliderItemsCount}
+                groupIndex={groupIndex}
+                groups={groups}
+                onGroupSelect={onGroupSelect}
+            />
+        </div>
     );
 };


### PR DESCRIPTION
Space between PreviewItems were disabled for user clicking and it is impossible to close StoriesGroup by clicking on area of PreviewItems