### PR TITLE
fix(Portal): add condition for default container for Portal

### DIFF
--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -9,5 +9,8 @@ export interface PortalProps {
 
 export function Portal({container, children}: PortalProps) {
     const defaultContainer = usePortalContainer();
-    return ReactDOM.createPortal(children, container ?? defaultContainer);
+
+    const containerNode = container ?? defaultContainer;
+
+    return containerNode ? ReactDOM.createPortal(children, containerNode) : null;
 }

--- a/src/components/utils/usePortalContainer.ts
+++ b/src/components/utils/usePortalContainer.ts
@@ -1,7 +1,14 @@
 import {useContext} from 'react';
 import {PortalContext} from './PortalProvider';
 
-export function usePortalContainer(): HTMLElement {
+export function usePortalContainer(): HTMLElement | null {
     const context = useContext(PortalContext);
-    return context.current ?? document.body;
+
+    let defaultContainer = null;
+
+    if (typeof window === 'object') {
+        defaultContainer = window.document.body;
+    }
+
+    return context.current ?? defaultContainer;
 }


### PR DESCRIPTION
In my Next.js app on SSR i a have an exception 
`
Server Error
ReferenceError: document is not defined
This error happened while generating the page. Any console logs will be displayed in the terminal window.
Call Stack
usePortalContainer
file:///..../node_modules/@gravity-ui/uikit/build/cjs/components/utils/usePortalContainer.js (9:68)
Portal
file:///..../node_modules/@gravity-ui/uikit/build/cjs/components/Portal/Portal.js (8:74)
`