### PR TITLE
feat(Table): add onMouseDown action for Table tr

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -93,6 +93,8 @@ export interface TableProps<I> extends QAProps {
         index: number,
         event: React.MouseEvent<HTMLTableRowElement>,
     ) => void;
+    /** Row mousedown handler. */
+    onRowMouseDown?: (item: I, index: number, event: React.MouseEvent<HTMLTableRowElement>) => void;
     /** Message returned if data is missing. By default: "No data". */
     emptyMessage?: string;
     /** Table CSS-class. */
@@ -383,6 +385,7 @@ export class Table<I extends TableDataItem = Record<string, string>> extends Rea
             onRowClick,
             onRowMouseEnter,
             onRowMouseLeave,
+            onRowMouseDown,
             getRowClassNames,
             verticalAlign,
             edgePadding,
@@ -407,6 +410,11 @@ export class Table<I extends TableDataItem = Record<string, string>> extends Rea
                 onMouseLeave={
                     !disabled && onRowMouseLeave
                         ? onRowMouseLeave.bind(null, item, rowIndex)
+                        : undefined
+                }
+                onMouseDown={
+                    !disabled && onRowMouseDown
+                        ? onRowMouseDown.bind(null, item, rowIndex)
                         : undefined
                 }
                 className={b(

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -46,6 +46,12 @@ const OnRowClickTemplate: Story<TableProps<DataItem>> = (args) => <Table {...arg
 export const OnRowClick = OnRowClickTemplate.bind({});
 OnRowClick.args = {
     onRowClick: (item) => alert(JSON.stringify(item)),
+    onRowMouseDown: (item, _, event) => {
+        const isMiddleButtonClicked = event.button === 1;
+        if (isMiddleButtonClicked) {
+            alert(JSON.stringify(item));
+        }
+    },
 };
 
 // ---------------------------------


### PR DESCRIPTION
I had added an onMouseDown action for Table row to handle middle mouse button clicks and etc. OnClick works good at Safari and EI, but at Chromium ones we can handle MBC only throw onMouseDown