### PR TITLE
feat(Popup): add popup wrapper class

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -29,6 +29,7 @@ export const Popover = forwardRef(function (
         offset = {},
         tooltipOffset,
         tooltipClassName,
+        zIndex,
         theme = 'info',
         size = 's',
         hasArrow = true,
@@ -106,6 +107,7 @@ export const Popover = forwardRef(function (
                 },
                 tooltipClassName,
             )}
+            zIndex={zIndex}
             open={isOpen}
             placement={placement}
             hasArrow={hasArrow}

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -44,6 +44,8 @@ export type PopoverExternalProps = {
     tooltipOffset?: [number, number];
     /** Tooltip's css class */
     tooltipClassName?: string;
+    /** Tooltip's wrapper z-index */
+    zIndex?: number;
     /** css class for the control */
     className?: string;
     /**

--- a/src/components/Popup/Popup.scss
+++ b/src/components/Popup/Popup.scss
@@ -77,7 +77,6 @@ $transition-distance: 10px;
 }
 
 #{$blockWrapper} {
-    z-index: 1000;
     visibility: hidden;
 
     &_open,

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -38,6 +38,7 @@ export interface PopupProps extends DOMProps, LayerExtendableProps, PopperProps,
     container?: HTMLElement;
     restoreFocus?: boolean;
     restoreFocusRef?: React.RefObject<HTMLElement>;
+    zIndex?: number;
 }
 
 const b = block('popup');
@@ -56,6 +57,7 @@ export function Popup({
     disableLayer,
     style,
     className,
+    zIndex = 1000,
     modifiers = [],
     children,
     onEscapeKeyDown,
@@ -121,7 +123,7 @@ export function Popup({
             >
                 <div
                     ref={handleRef}
-                    style={styles.popper}
+                    style={{...styles.popper, zIndex}}
                     {...attributes.popper}
                     {...containerProps}
                     className={bWrapper({open})}

--- a/src/components/Select/components/SelectPopup/SelectPopup.tsx
+++ b/src/components/Select/components/SelectPopup/SelectPopup.tsx
@@ -16,11 +16,13 @@ export const SelectPopup = ({
     controlRef,
     children,
     className,
+    zIndex,
     disablePortal,
     virtualized,
 }: SelectPopupProps) => (
     <Popup
         className={b(null, className)}
+        zIndex={zIndex}
         qa={SelectQa.POPUP}
         anchorRef={controlRef}
         placement={['bottom-start', 'bottom-end', 'top-start', 'top-end']}

--- a/src/components/Select/components/SelectPopup/types.ts
+++ b/src/components/Select/components/SelectPopup/types.ts
@@ -7,6 +7,7 @@ export type SelectPopupProps = {
     controlRef?: React.RefObject<HTMLElement>;
     children?: React.ReactNode;
     className?: string;
+    zIndex?: number;
     disablePortal?: boolean;
     virtualized?: boolean;
 };

--- a/src/components/SharePopover/SharePopover.tsx
+++ b/src/components/SharePopover/SharePopover.tsx
@@ -35,6 +35,8 @@ export interface SharePopoverProps extends ShareListProps, Partial<SharePopoverD
     iconClass?: string;
     /** tooltip mixin */
     tooltipClassName?: string;
+    /** tooltip z-index */
+    zIndex?: string;
     /** sitcher mixin */
     switcherClassName?: string;
     /** custom icon */
@@ -92,6 +94,7 @@ export class SharePopover extends React.PureComponent<SharePopoverInnerProps> {
             iconSize,
             iconClass,
             tooltipClassName,
+            zIndex,
             switcherClassName,
             className,
             direction,
@@ -128,6 +131,7 @@ export class SharePopover extends React.PureComponent<SharePopoverInnerProps> {
                 delayClosing={closeDelay}
                 content={content}
                 className={b(null, className)}
+                zIndex={zIndex}
                 tooltipClassName={b('tooltip', tooltipClassName)}
                 onClick={this.handleClick}
             >

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ export interface TooltipProps extends TooltipDelayProps {
     placement?: PopupPlacement;
     children: React.ReactElement;
     className?: string;
+    zIndex?: number;
     contentClassName?: string;
 }
 
@@ -33,6 +34,7 @@ export const Tooltip = (props: TooltipProps) => {
         return (
             <Popup
                 className={b(null, props.className)}
+                zIndex={props.zIndex}
                 open={tooltipVisible && !disabled}
                 placement={placement}
                 anchorRef={{current: anchorElement}}


### PR DESCRIPTION
Added the possibility to provide a class name to the popup wrapper, because sometimes it is needed to override the default styles, for example to add a custom z-index. 