### PR TITLE
feat(typography): do not use SF Mono

### DIFF
--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -1,6 +1,6 @@
 @mixin yc-typography {
     --yc-font-family-sans: 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
-    --yc-font-family-monospace: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', 'Ubuntu Mono',
+    --yc-font-family-monospace: 'Menlo', 'Monaco', 'Consolas', 'Ubuntu Mono',
         'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', 'Courier', monospace;
 
     --yc-text-body-font-family: var(--yc-font-family-sans);

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -1,7 +1,7 @@
 @mixin yc-typography {
     --yc-font-family-sans: 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
-    --yc-font-family-monospace: 'Menlo', 'Monaco', 'Consolas', 'Ubuntu Mono',
-        'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', 'Courier', monospace;
+    --yc-font-family-monospace: 'Menlo', 'Monaco', 'Consolas', 'Ubuntu Mono', 'Liberation Mono',
+        'DejaVu Sans Mono', 'Courier New', 'Courier', monospace;
 
     --yc-text-body-font-family: var(--yc-font-family-sans);
     --yc-text-code-font-family: var(--yc-font-family-monospace);


### PR DESCRIPTION
Request from designers: Menlo is looking better than SF Mono for our use-cases.