### PR TITLE
fix: base-generic-ultralight color in dark-hc theme

### DIFF
--- a/styles/colors/base/dark-hc.scss
+++ b/styles/colors/base/dark-hc.scss
@@ -8,7 +8,7 @@
     --yc-color-base-generic-accent: var(--yc-color-private-white-200);
     --yc-color-base-generic-accent-disabled: var(--yc-color-private-white-150);
 
-    --yc-color-base-generic-ultralight: var(--yc-color-private-white-150-solid);
+    --yc-color-base-generic-ultralight: var(--yc-color-private-white-50);
 
     --yc-color-base-simple-hover: var(--yc-color-private-white-250);
     --yc-color-base-simple-hover-solid: var(--yc-color-private-white-250-solid);


### PR DESCRIPTION
Updated color value for base-generic-ultralight in dark-hc theme