### PR TITLE
fix: change border Button view outlined

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -232,7 +232,7 @@ $block: '.#{variables.$ns}button';
             @include button-text-color(var(--yc-color-text-primary));
 
             &::before {
-                border: 1px solid var(--yc-color-line-generic-accent);
+                border: 1px solid var(--yc-color-line-generic);
             }
         }
 


### PR DESCRIPTION
The current border of the `outlined` `Button` does not match the color of the `Select`:
<img width="261" alt="Снимок экрана 2023-02-21 в 11 56 46" src="https://user-images.githubusercontent.com/11226935/220297617-fbfaec49-e05b-4c90-826b-a73cdf24ab78.png">

After the changes:
<img width="255" alt="Снимок экрана 2023-02-21 в 11 56 26" src="https://user-images.githubusercontent.com/11226935/220297741-87b7267b-2d71-4722-ace1-94c42ebacbe9.png">
