### PR TITLE
fix(storybook): remove RE_RENDER event from theme addon

### DIFF
--- a/.storybook/theme-addon/register.tsx
+++ b/.storybook/theme-addon/register.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {addons, types} from '@storybook/addons';
 import {useGlobals, type API} from '@storybook/api';
-import {FORCE_RE_RENDER} from '@storybook/core-events';
 import {themes} from '../theme';
 import {getThemeType} from '../../src/components/theme/getThemeType';
 
@@ -22,7 +21,6 @@ function Tool({api}: {api: API}) {
     const [{theme}] = useGlobals();
     React.useEffect(() => {
         api.setOptions({theme: themes[getThemeType(theme)]});
-        addons.getChannel().emit(FORCE_RE_RENDER);
     }, [theme]);
     return null;
 }


### PR DESCRIPTION
We have a theme addon for storybook which syncs preview theme and manager theme (once you pick dark theme, it should be applied globally, not only to the previewed component). Previously this addon emitted `FORCE_RE_RENDER` event after setting the theme, which caused stories to mount twice. The effect of double mount can be seen here: https://preview.gravity-ui.com/uikit/?path=/story/components-portal--default (portal text is rendered twice or sometimes even thrice). 

My guess is that emitting `FORCE_RE_RENDER` in the middle of first render makes Storybook create another React root, which leads to second mount of a Preview. 

I tried removing this event from theme addon, since theme should be updated through `ThemeProvider` already. Everything works and no more double mounts. Yay!

There may be weird cases of components not receiving the new theme once it is switched via toolbar (because I believe this FORCE_RE_RENDER was put there on purpose), but I never saw any while testing.