### PR TITLE
feat(Tabs): add AdjustableTabs for Tabs component

### DIFF
--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -870,6 +870,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
         return (
             <Select
+                className={b('tabs-as-select-control')}
                 onUpdate={this.handleTabsAsSelectUpdate}
                 options={itemsForSelect}
                 value={activeTabID === undefined ? [] : [activeTabID]}

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -56,9 +56,9 @@ const getSortObjectKeysByValuesFunc =
  */
 interface AdjustableTabsProps {
     items: TabsItemProps[];
-    activeTab?: string;
+    activeTab: string | undefined;
     breakpointsConfig: Record<string, number>;
-    onSelectTab?: (tabId: string, event?: React.MouseEvent) => void;
+    onSelectTab: (tabId: string, event?: React.MouseEvent) => void;
     wrapTo?: (item: TabsItemProps, node: React.ReactNode, index: number) => React.ReactNode;
     className?: string;
 }
@@ -114,16 +114,6 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     private selectSwitcherNode = React.createRef<HTMLDivElement>();
     private tabsRootNode = React.createRef<HTMLDivElement>();
     private tabsListNode = React.createRef<HTMLDivElement>();
-
-    get activeTab() {
-        const {activeTab, items} = this.props;
-        if (activeTab) {
-            return activeTab;
-        } else {
-            const [firstTab] = items;
-            return firstTab.id;
-        }
-    }
 
     constructor(props: AdjustableTabsProps) {
         super(props);
@@ -318,7 +308,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
      */
     recalculateTabs = () => {
         // фаза 1 - вычисление индекса первого скрытого таба
-        const activeTabId = this.activeTab;
+        const activeTabId = this.props.activeTab;
         const {
             tabChosenFromSelectId,
             firstHiddenTabIndexBeforeRecollection: prevFirstHiddenTabIndex,
@@ -413,6 +403,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         // последовательности активный таб не должен быть отрендерен, но так как он активный - его нельзя просто так
         // скрыть, поэтому записываем его ID в tabChosenFromSelectId и запускаем перерасчёт
         if (
+            activeTabId &&
             this.state.tabChosenFromSelectId !== activeTabId &&
             activeTabIndex >= firstHiddenTabIndex
         ) {
@@ -560,7 +551,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         );
     };
 
-    selectTab(tabId: string, event?: React.MouseEvent) {
+    onSelectTab(tabId: string, event?: React.MouseEvent) {
         if (this.props.onSelectTab) {
             this.props.onSelectTab(tabId, event);
         }
@@ -615,18 +606,18 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
     onChooseTabFromSelect = (tabChosenFromSelectIds: string[]) => {
         const tabChosenFromSelectId = tabChosenFromSelectIds?.[0];
-        this.selectTab(tabChosenFromSelectId);
+        this.props.onSelectTab(tabChosenFromSelectId);
 
         this.setState({tabChosenFromSelectId});
         this.recollectDimensions();
     };
 
     onTabClick = (tabId: string, event?: React.MouseEvent<Element, MouseEvent>) => {
-        if (tabId === this.activeTab) {
+        if (tabId === this.props.activeTab) {
             return;
         }
 
-        this.selectTab(tabId, event);
+        this.props.onSelectTab(tabId, event);
     };
 
     /*
@@ -680,8 +671,8 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
     renderSwitcherForTabsAsSelect = (switcherProps: RenderControlProps) => {
         const {items} = this.props;
-        const activeTab = items.find((item) => item.id === this.activeTab);
-        const activeTabIndex = items.findIndex((item) => item.id === this.activeTab);
+        const activeTab = items.find((item) => item.id === this.props.activeTab);
+        const activeTabIndex = items.findIndex((item) => item.id === this.props.activeTab);
         const hint = activeTab ? activeTab.title || activeTab.id : items[0].title || items[0].id;
 
         return this.renderSwitcher({
@@ -760,7 +751,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
     renderTabItem = (item: TabsItemProps, tabIndex: number) => {
         const {items, wrapTo} = this.props;
-        const activeTabID = this.activeTab;
+        const activeTabID = this.props.activeTab;
         const {dimensionsWereCollected, currentContainerWidthName} = this.state;
 
         const needSetMaxWidth =
@@ -795,7 +786,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     };
 
     renderSelect() {
-        const activeTabID = this.activeTab;
+        const activeTabID = this.props.activeTab;
         const {firstHiddenTabIndex, tabChosenFromSelectId} = this.state;
         const {items} = this.props;
 
@@ -825,12 +816,12 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
     handleTabsAsSelectUpdate = (tabIds: string[]) => {
         const tabId = tabIds?.[0];
-        this.selectTab(tabId);
+        this.props.onSelectTab(tabId);
         this.setState({tabChosenFromSelectId: tabId});
     };
 
     renderTabsAsSelect() {
-        const activeTabID = this.activeTab;
+        const activeTabID = this.props.activeTab;
         const {items} = this.props;
 
         const itemsForSelect = items.map((item) => ({

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -10,6 +10,7 @@ import './Tabs.scss';
 import {Icon} from '../Icon';
 import {ChevronDownIcon} from '../icons';
 import {Select, SelectProps} from '../Select';
+import {TabsItemProps} from './Tabs';
 
 const SMALL_CONTAINER_WIDTH_NAME = 'small';
 const LARGE_CONTAINER_WIDTH_NAME = 'large';
@@ -81,14 +82,10 @@ class Tab extends React.Component<TabProps> {
 }
 
 interface AdjustableTabsProps {
-    items: {
-        id: string;
-        title: string;
-        disabled?: boolean;
-    }[];
+    items: TabsItemProps[];
     activeTab?: string;
     breakpointsConfig: Record<string, number>;
-    onSelectTab: (tabId: string, event?: React.MouseEvent) => void;
+    onSelectTab?: (tabId: string, event?: React.MouseEvent) => void;
     wrapTo: (
         isActive: boolean | undefined,
         node: React.ReactNode,
@@ -617,10 +614,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         порядок и тайтл что и предыдущие. В случае, если это не так будет вызван метод collectDimensions, чтобы
         запомнить снять новые замеры и запустить последующие фазы пересчёта лэйаута
      */
-    wasItemsListUpdated = (
-        currentItems: {title: string; id: string}[],
-        prevItems: {title: string; id: string}[],
-    ) => {
+    wasItemsListUpdated = (currentItems: TabsItemProps[], prevItems: TabsItemProps[]) => {
         if (currentItems.length !== prevItems.length) {
             return true;
         }
@@ -732,7 +726,11 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         const activeTab = items.find((item) => item.id === this.activeTab);
         const hint = activeTab ? activeTab.title || activeTab.id : items[0].title || items[0].id;
 
-        return this.renderSwitcher({...switcherProps, text: hint, active: Boolean(activeTab)});
+        return this.renderSwitcher({
+            ...switcherProps,
+            text: hint as string,
+            active: Boolean(activeTab),
+        });
     };
 
     renderSwitcher = (
@@ -793,7 +791,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             );
     };
 
-    renderTabItem = (item: {id: string; title: string}, tabIndex: number) => {
+    renderTabItem = (item: TabsItemProps, tabIndex: number) => {
         const {items, wrapTo} = this.props;
         const activeTabID = this.activeTab;
         const {dimensionsWereCollected, currentContainerWidthName} = this.state;

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
-import block from 'bem-cn-lite';
 import difference from 'lodash/difference';
 import throttle from 'lodash/throttle';
 import ResizeObserver from 'resize-observer-polyfill';
 
 import i18n from './i18n';
-
-import './Tabs.scss';
+import {TabsItemProps} from './Tabs';
 import {Icon} from '../Icon';
 import {ChevronDownIcon} from '../icons';
 import {Select, SelectProps} from '../Select';
-import {TabsItemProps} from './Tabs';
+import {block} from '../utils/cn';
+
+import './Tabs.scss';
 
 const SMALL_CONTAINER_WIDTH_NAME = 'small';
 const LARGE_CONTAINER_WIDTH_NAME = 'large';
 const READY_STATE_COMPLETE = 'complete';
 const OUT_OF_SCREEN_POSITION = -99999;
 
-const b = block('adjustable-tabs');
+const b = block('tabs');
 const TAB_CLASS_NAME = b('tab');
 
 type RenderControlProps = Parameters<NonNullable<SelectProps['renderControl']>>[0];

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -5,6 +5,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 
 import i18n from './i18n';
 import {TabsItemProps} from './Tabs';
+import {TabsItem} from './TabsItem';
 import {Icon} from '../Icon';
 import {ChevronDownIcon} from '../icons';
 import {Select, SelectProps} from '../Select';
@@ -53,34 +54,6 @@ const getSortObjectKeysByValuesFunc =
         прочее) и две основные фазы:) 1) нахождение индекса первого непоместившегося таба и 2) подстройка ширины
         переполненных табов под ширину контейнера (в дальнейшем фазы 1 и 2)
  */
-
-interface TabProps {
-    id: string;
-    title: string | React.ReactNode;
-    hint?: string;
-    active?: boolean;
-    disabled?: boolean;
-    onClick?: (id: string, event: React.MouseEvent) => void;
-}
-
-class Tab extends React.Component<TabProps> {
-    onClick = (event: React.MouseEvent) => {
-        this.props.onClick?.(this.props.id, event);
-    };
-    render() {
-        const {active, disabled, hint, title = this.props.id} = this.props;
-        return (
-            <div
-                className={b('tab', {active, disabled})}
-                title={String(hint || title || '')}
-                onClick={this.onClick}
-            >
-                {title}
-            </div>
-        );
-    }
-}
-
 interface AdjustableTabsProps {
     items: TabsItemProps[];
     activeTab?: string;
@@ -752,7 +725,14 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         );
 
         const switcherTabProps = {title, hint: text, id: 'switcher-tab'};
-        const tabItemNode = <Tab {...switcherTabProps} active={Boolean(active)} />;
+        const tabItemNode = (
+            <TabsItem
+                {...switcherTabProps}
+                className={b('tab', {active})}
+                active={Boolean(active)}
+                onClick={() => {}}
+            />
+        );
 
         return (
             <div
@@ -815,7 +795,12 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             >
                 {wrapTo(
                     item.id === activeTabID,
-                    <Tab {...item} active={item.id === activeTabID} onClick={this.onTabClick} />,
+                    <TabsItem
+                        {...item}
+                        className={b('tab', {active: item.id === activeTabID})}
+                        active={item.id === activeTabID}
+                        onClick={this.onTabClick}
+                    />,
                     item.id,
                 )}
             </div>

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -4,7 +4,7 @@ import throttle from 'lodash/throttle';
 import ResizeObserver from 'resize-observer-polyfill';
 
 import i18n from './i18n';
-import {TabsItemProps} from './Tabs';
+import {TabsItemProps, TabsSize} from './Tabs';
 import {TabsItem} from './TabsItem';
 import {Icon} from '../Icon';
 import {ChevronDownIcon} from '../icons';
@@ -61,6 +61,7 @@ interface AdjustableTabsProps {
     onSelectTab: (tabId: string, event?: React.MouseEvent) => void;
     wrapTo?: (item: TabsItemProps, node: React.ReactNode, index: number) => React.ReactNode;
     className?: string;
+    size?: TabsSize;
 }
 
 interface AdjustableTabsState {
@@ -848,7 +849,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     }
 
     render() {
-        const {wrapTo, items, className} = this.props;
+        const {wrapTo, items, className, size} = this.props;
         const isDefaultRender = !wrapTo;
 
         return (
@@ -857,6 +858,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
                 className={b(
                     {
                         adjustable: true,
+                        size,
                         visible: this.state.dimensionsWereCollected,
                         'is-default-render': isDefaultRender,
                     },

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -12,11 +12,13 @@ import {Select, SelectProps} from '../Select';
 import {block} from '../utils/cn';
 
 import './Tabs.scss';
-
-const SMALL_CONTAINER_WIDTH_NAME = 'small';
-const LARGE_CONTAINER_WIDTH_NAME = 'large';
-const READY_STATE_COMPLETE = 'complete';
-const OUT_OF_SCREEN_POSITION = -99999;
+import {
+    DEFAULT_BREAKPOINTS_CONFIG,
+    LARGE_CONTAINER_WIDTH_NAME,
+    OUT_OF_SCREEN_POSITION,
+    READY_STATE_COMPLETE,
+    SMALL_CONTAINER_WIDTH_NAME,
+} from './constants';
 
 const b = block('tabs');
 const TAB_CLASS_NAME = b('tab');
@@ -78,18 +80,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         // контейнера от 401px до 500px максимальная ширина таба составит 33%, при ширине от 501px до 700px 30% и т.д.)
         // при ширине контейнера минимального из значений определённых в ключах объекта (в дефолтном случае 400)
         // вместо табов рендерится селект занимающий всю ширину контейнера.
-        breakpointsConfig: {
-            '400': 33,
-            '500': 30,
-            '700': 27,
-            '800': 26,
-            '900': 25,
-            '1000': 24,
-            '1100': 23,
-            '1200': 22,
-            '1300': 21,
-            '1400': 20,
-        },
+        breakpointsConfig: DEFAULT_BREAKPOINTS_CONFIG,
     };
 
     private breakpoints: number[];

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -856,6 +856,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
                 ref={this.tabsRootNode}
                 className={b(
                     {
+                        adjustable: true,
                         visible: this.state.dimensionsWereCollected,
                         'is-default-render': isDefaultRender,
                     },

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -96,9 +96,9 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         breakpointsConfig: DEFAULT_BREAKPOINTS_CONFIG,
     };
 
-    private breakpoints: number[];
-    private tabMaxWidthInPercentsForScreenSize: Record<string, number>;
-    private throttledHandleResize: () => void;
+    private readonly breakpoints: number[];
+    private readonly tabMaxWidthInPercentsForScreenSize: Record<string, number>;
+    private readonly throttledHandleResize: () => void;
     private resizeObserver?: ResizeObserver;
     private tabItemPaddingRight = 0;
     private switcherWidth = 0;

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -1,0 +1,922 @@
+import React from 'react';
+import block from 'bem-cn-lite';
+import difference from 'lodash/difference';
+import throttle from 'lodash/throttle';
+import ResizeObserver from 'resize-observer-polyfill';
+
+import i18n from './i18n';
+
+import './Tabs.scss';
+import {Icon} from '../Icon';
+import {ChevronDownIcon} from '../icons';
+import {Select, SelectProps} from '../Select';
+
+const SMALL_CONTAINER_WIDTH_NAME = 'small';
+const LARGE_CONTAINER_WIDTH_NAME = 'large';
+const READY_STATE_COMPLETE = 'complete';
+const OUT_OF_SCREEN_POSITION = -99999;
+
+const b = block('adjustable-tabs');
+const TAB_CLASS_NAME = b('tab');
+
+type RenderControlProps = Parameters<NonNullable<SelectProps['renderControl']>>[0];
+type OpenChangeProps = Parameters<NonNullable<SelectProps['onOpenChange']>>[0];
+const defaultWrapToFunc = (_isActive: boolean, node: any) => node;
+
+const getSortObjectKeysByValuesFunc =
+    (objectToSort: Record<string, any>) => (a: string, b: string) => {
+        if (objectToSort[a] > objectToSort[b]) {
+            return 1;
+        }
+        if (objectToSort[a] < objectToSort[b]) {
+            return -1;
+        }
+        return 0;
+    };
+
+/*
+    ОБЩИЕ ПРИНЦИПЫ РАБОТЫ КОМПОНЕНТА:
+    - Если все табы не помещаются в ширину контейнера, непоместившиеся скрываются и появляется свитчер с текстом
+        "Ещё N", где N - количество непоместившихся табов, по клику появляется выпадающий список в котором можно
+        выбрать один из непоместившихся табов при этом выбранный таб "встанет" на место последнего видимого.
+
+    - Имеются две тесно связанные фичи:
+        1 - конфигурируемая максимально допустимая ширина таба (текст таба скрывается за "…" если не помещается -
+            будем в дальнейшем называть такие табы "переполненными")
+        2 - использование всей ширины контейнера - подстройка ширины переполненных табов, чтобы заполнить всю ширину
+            контейнера (на практике это выражется в том, что при выборе через свитчер максимально широкого из
+            непоместившихся табов, отрендеренные табы + свитчер займут всю ширину контейнера).
+        Поэтому, при расчёте лэйаута, логически выделяются: этап подготовки (в дальнейшем "снятие замеров") - вычисление
+        ширины табов с учётом активного брейкпоинта (максимальной ширины на данном брейкпоинте), вычисление реальной
+        ширины табов (без ограничения максимальной ширины), вычисление ширины свитчера, величины отступа между табами и
+        прочее) и две основные фазы:) 1) нахождение индекса первого непоместившегося таба и 2) подстройка ширины
+        переполненных табов под ширину контейнера (в дальнейшем фазы 1 и 2)
+ */
+
+interface TabProps {
+    id: string;
+    title: string | React.ReactNode;
+    hint?: string;
+    active?: boolean;
+    disabled?: boolean;
+    onClick?: (id: string, event: React.MouseEvent) => void;
+}
+
+class Tab extends React.Component<TabProps> {
+    onClick = (event: React.MouseEvent) => {
+        this.props.onClick?.(this.props.id, event);
+    };
+    render() {
+        const {active, disabled, hint, title = this.props.id} = this.props;
+        return (
+            <div
+                className={b('tab', {active, disabled})}
+                title={String(hint || title || '')}
+                onClick={this.onClick}
+            >
+                {title}
+            </div>
+        );
+    }
+}
+
+interface AdjustableTabsProps {
+    items: {
+        id: string;
+        title: string;
+        disabled?: boolean;
+    }[];
+    activeTab?: string;
+    breakpointsConfig: Record<string, number>;
+    onSelectTab: (tabId: string, event?: React.MouseEvent) => void;
+    wrapTo: (
+        isActive: boolean | undefined,
+        node: React.ReactNode,
+        tabId?: string,
+    ) => React.ReactNode;
+    className?: string;
+}
+
+interface AdjustableTabsState {
+    dimensionsWereCollected: boolean;
+    firstHiddenTabIndex: number;
+    firstHiddenTabIndexBeforeRecollection: number | null;
+    tabChosenFromSelectId: string | null;
+    currentContainerWidthName: string | null | undefined;
+    // flag for opened/closed status of select
+    isSelectOpened: boolean;
+}
+
+class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabsState> {
+    static defaultProps = {
+        wrapTo: defaultWrapToFunc,
+        // дефолтные значения конфигурации брейкпоинтов - объект где ключ - ширина элемента контейнера,  значение -
+        // максимальная ширина таба в процентах от ширины контейнера, (так, для дефолтных значений, при ширине
+        // контейнера от 401px до 500px максимальная ширина таба составит 33%, при ширине от 501px до 700px 30% и т.д.)
+        // при ширине контейнера минимального из значений определённых в ключах объекта (в дефолтном случае 400)
+        // вместо табов рендерится селект занимающий всю ширину контейнера.
+        breakpointsConfig: {
+            '400': 33,
+            '500': 30,
+            '700': 27,
+            '800': 26,
+            '900': 25,
+            '1000': 24,
+            '1100': 23,
+            '1200': 22,
+            '1300': 21,
+            '1400': 20,
+        },
+    };
+
+    private breakpoints: number[];
+    private tabMaxWidthInPercentsForScreenSize: Record<string, number>;
+    private throttledHandleResize: () => void;
+    private resizeObserver?: ResizeObserver;
+    private tabItemPaddingRight = 0;
+    private switcherWidth = 0;
+
+    // для удобства вычислений потребуется три объекта, у которых ключи - индексы табов, а значения - ширина табов,
+    // при этом отдельно рассматривается реальная ширина табов (как если бы не было ограничений на max width)
+    // и текущая ширина табов (с учётом ограничений по max width и подстройки ширины):
+
+    // - реальная ширина табов, запишутся значения для всех табов
+    private tabsRealWidth: Record<string, number> = {};
+
+    // - то же, но запишутся только значения для переполненных табов (иметь такой объект только со значениями
+    // переполненных табов необходимо для вычислений подстройки ширины переполненных табов)
+    private overflownTabsRealWidth: Record<string, number> = {};
+
+    // - текущая ширина табов, опять же, только для переполненных табов
+    private overflownTabsCurrentWidth: Record<string, number> = {};
+
+    // помимо этого, в массиве будем хранить текущую ширину всех табов, массив здесь удобен для вычисления
+    // ширины N видимых табов, например, с первого по пятый.
+    private tabsWidth: number[] = [];
+
+    // флаг указывающий, что первоначальное снятие необходимых для дальнейших рассчётов размеров уже произошло
+    private dimensionsWereInitiallyCollected = true;
+
+    private selectSwitcherNode = React.createRef<HTMLDivElement>();
+    private tabsRootNode = React.createRef<HTMLDivElement>();
+    private tabsListNode = React.createRef<HTMLDivElement>();
+
+    get activeTab() {
+        const {activeTab, items} = this.props;
+        if (activeTab) {
+            return activeTab;
+        } else {
+            const [firstTab] = items;
+            return firstTab.id;
+        }
+    }
+
+    constructor(props: AdjustableTabsProps) {
+        super(props);
+
+        this.state = {
+            // флаг указывающий на то, произошёл ли этап "снятия замеров"
+            dimensionsWereCollected: false,
+            // индекс первого скрытого таба
+            firstHiddenTabIndex: this.props.items.length,
+            // в определённом случае есть необходимость знать предыдущее значение индекса первого скрытого таба
+            firstHiddenTabIndexBeforeRecollection: null,
+            // так как после того, как посредством свитчера выбран один из непоместившихся табов и выбранный таб "встал"
+            // на место последнего видимого, список видимых (в данный момент отрендеренных табов) будет НЕ в
+            // последовательном порядке (например, будут отрендерены 1-й, 2-й и 5-й (выбранный через свитчер) табы,
+            // а 3-й и 4-й будут скрыты), поэтому нам нужно хранить ID выбранного через свитчер таба
+            tabChosenFromSelectId: null,
+            // "имя" текущей ширины контейнера - для определения активного брейкоинта, зависит от значения в свойстве
+            // "breakpointsConfig" (например, если, breakpointsConfig={ '400': 33, '1200': 22 }, при ширине контейнера
+            // <= 400 currentContainerWidthName будет "small", при > 1200 - "large", а при ширине контейнера между 400 и
+            // 1200 - "400-1200")
+            currentContainerWidthName: null,
+            isSelectOpened: false,
+        };
+
+        this.breakpoints = Object.keys(props.breakpointsConfig)
+            .map(Number)
+            .sort((a, b) => a - b);
+
+        // сохраняем объект, где ключи - "имя" текущей ширины контейнера, значения - максимальная ширина таба для
+        // соответствующей ширины контейнера (в процентах от ширины контейнера)
+        this.tabMaxWidthInPercentsForScreenSize = this.breakpoints.reduce(
+            (accum: Record<string, number>, currentBreakpointWidth, index, breakpointsArray) => {
+                const nextBreakpointWidth = breakpointsArray[index + 1];
+
+                let breakpointName = `${currentBreakpointWidth}-${nextBreakpointWidth}`;
+
+                if (!nextBreakpointWidth) {
+                    breakpointName = LARGE_CONTAINER_WIDTH_NAME;
+                }
+
+                accum[breakpointName] = props.breakpointsConfig[currentBreakpointWidth] || 100;
+
+                return accum;
+            },
+            {},
+        );
+
+        this.handleResize = this.handleResize.bind(this);
+        this.throttledHandleResize = throttle(this.handleResize, 350);
+    }
+
+    componentDidMount() {
+        this.setState({currentContainerWidthName: this.getCurrentContainerWidthName()});
+
+        if (this.tabsRootNode.current!.clientWidth > this.breakpoints[0]) {
+            if ((document as any).fonts) {
+                (document as any).fonts.ready.then(this.initialCollectDimensions);
+            } else if ((document as any).readyState === READY_STATE_COMPLETE) {
+                setTimeout(this.initialCollectDimensions, 0);
+            } else {
+                window.addEventListener('load', this.initialCollectDimensions);
+            }
+        } else {
+            this.subscribeForResize();
+        }
+    }
+
+    subscribeForResize = () => {
+        this.resizeObserver = new ResizeObserver(this.throttledHandleResize);
+
+        this.resizeObserver.observe(this.tabsRootNode.current!);
+    };
+
+    componentDidUpdate(prevProps: AdjustableTabsProps) {
+        if (!this.dimensionsWereInitiallyCollected) {
+            return;
+        }
+
+        if (this.wasItemsListUpdated(this.props.items, prevProps.items)) {
+            this.setState(
+                {
+                    dimensionsWereCollected: false,
+                    firstHiddenTabIndex: this.props.items.length,
+                    firstHiddenTabIndexBeforeRecollection: null,
+                },
+                () => {
+                    if (this.state.currentContainerWidthName !== SMALL_CONTAINER_WIDTH_NAME) {
+                        this.collectDimensions();
+                    }
+                },
+            );
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+        }
+
+        window.removeEventListener('load', this.collectDimensions);
+    }
+
+    initialCollectDimensions = () => {
+        // так как мы ожидаем прогрузки шрифтов для замера размеров табов и подписки на ресайз контейнера, возможен
+        // случай, что к моменту загрузки шрифтов, компонент уже unmounted, поэтому, нужно проверять, что ref у корневой
+        // ноды существует
+        if (this.tabsRootNode.current) {
+            this.dimensionsWereInitiallyCollected = true;
+            this.recollectDimensions();
+            this.subscribeForResize();
+        }
+    };
+
+    /*
+        Этап "снятия замеров". Разово высчитывается ширина табов и некоторые сопутствующие размеры/отступы
+     */
+    collectDimensions = () => {
+        const tabsListNode = this.tabsListNode.current!;
+        const tabs = tabsListNode.children;
+
+        this.tabsWidth = [];
+
+        const tabElement = tabsListNode.firstElementChild;
+
+        if (tabElement) {
+            const paddingRightValue = window
+                .getComputedStyle(tabElement)
+                .getPropertyValue('padding-right');
+
+            // сохраняем значение правого padding-a (расстояние между табами которое может быть различным в зависимости
+            // от значения css переменной --dl-tabs-space-between)
+            this.tabItemPaddingRight = paddingRightValue ? parseInt(paddingRightValue, 10) : 0;
+        }
+
+        this.overflownTabsRealWidth = {};
+        this.tabsRealWidth = {};
+
+        // обходя в цикле все табы записываем текущую ширину каждого таба в массив this.tabsWidth
+        // "наполняем" объекты this.tabsRealWidth и this.overflownTabsRealWidth
+        for (let i = 0; i < tabs.length; i++) {
+            const {width} = tabs[i].getBoundingClientRect();
+
+            const tabTextNode = tabs[i].querySelector(`.${TAB_CLASS_NAME}`)!;
+
+            if (tabTextNode.scrollWidth > tabTextNode.clientWidth) {
+                // если весь текст не поместился и появилось "…"
+                const widthCorrector = i === tabs.length - 1 ? 0 : this.tabItemPaddingRight;
+                this.overflownTabsRealWidth[i] = tabTextNode.scrollWidth + widthCorrector;
+                this.tabsRealWidth[i] = this.overflownTabsRealWidth[i];
+            } else {
+                this.tabsRealWidth[i] = width;
+            }
+
+            this.tabsWidth[i] = width;
+        }
+
+        this.switcherWidth = this.selectSwitcherNode.current!.getBoundingClientRect().width; // ширина элемента-свитчера
+
+        this.setState({dimensionsWereCollected: true});
+
+        this.recalculateTabs();
+    };
+
+    getCurrentContainerWidthName = () => {
+        for (let index = 0; index < this.breakpoints.length; index++) {
+            const breakpointWidth = this.breakpoints[index];
+            const prevBreakpointWidth = this.breakpoints[index - 1];
+            const nextBreakpointWidth = this.breakpoints[index + 1];
+
+            const containerWidth = this.tabsRootNode.current!.clientWidth;
+            const containerWidthLowerOrEqualThanBreakpointWidth = containerWidth <= breakpointWidth;
+            const containerWidthBiggerThanBreakpointWidth = containerWidth > breakpointWidth;
+            const containerWidthBiggerThanPrevBreakpointWidth = containerWidth < breakpointWidth;
+
+            if (containerWidthLowerOrEqualThanBreakpointWidth && !prevBreakpointWidth) {
+                return SMALL_CONTAINER_WIDTH_NAME;
+            } else if (containerWidthBiggerThanBreakpointWidth && !nextBreakpointWidth) {
+                return LARGE_CONTAINER_WIDTH_NAME;
+            } else if (
+                containerWidthBiggerThanPrevBreakpointWidth &&
+                containerWidthLowerOrEqualThanBreakpointWidth
+            ) {
+                return `${prevBreakpointWidth}-${breakpointWidth}`;
+            }
+        }
+
+        return;
+    };
+
+    /*
+        Перерасчёт лэйаута - фазы 1 и 2
+     */
+    recalculateTabs = () => {
+        // фаза 1 - вычисление индекса первого скрытого таба
+        const activeTabId = this.activeTab;
+        const {
+            tabChosenFromSelectId,
+            firstHiddenTabIndexBeforeRecollection: prevFirstHiddenTabIndex,
+        } = this.state;
+        // activeTabId - это ID активного таба, tabChosenFromSelectId - ID таба выбранного через свитчер,
+        // таб выбранный через свитчер сразу после выбора становится активным (в этом случае, эти значения совпадают)
+        // но если после юзер переключится (кликнул) на соседний таб, они снова будут отличаться
+
+        const {items} = this.props;
+        const {width: tabsRootNodeWidth} = this.tabsRootNode.current!.getBoundingClientRect();
+
+        const activeTabIndex = items.findIndex((item) => item.id === activeTabId);
+        const tabChosenFromSelectIndex = items.findIndex(
+            (item) => item.id === tabChosenFromSelectId,
+        );
+
+        let renderedTabsSumWidth = 0;
+
+        // firstHiddenTabIndexForSequentialCase - индекс первого скрытого таба для случая, когда табы расположены в
+        // порядковой последовательности и без учёта максимальной ширины скрытого таба (необходим только для
+        // промежуточных вычислений)
+        // firstHiddenTabIndex - индекс первого скрытого таба в конкретной ситуации (с учётом шириный таба выбранного
+        // через свитчер и максимальной ширины среди непоместившихся табов (будет храниться в стейте)
+
+        // сначала, при обходе в цикле всех табов запоминается firstHiddenTabIndexForSequentialCase и максимальная
+        // ширина среди скрытых табов, после этого в обратном цикле, начиная со значения таба с индексом
+        // firstHiddenTabIndexForSequentialCase - 1 определяется сколько табов необходимо "переместить" в
+        // непоместившееся, чтобы даже при выборе через свитчер таба с максимальной шириной, его ширина + ширина видимых
+        // табов не превысила бы ширину контейнера
+        let firstHiddenTabIndexForSequentialCase = null;
+        let firstHiddenTabIndex = items.length;
+        // если обойдя все значения ширин табов, мы так и не превысим ширину контейнера, в firstHiddenTabIndex
+        // запишется значение равное количеству табов, таком образом будут отрендерены все табы
+
+        let maxHiddenTabWidth = 0;
+        let emptySpace = 0;
+
+        // в цикле будут обходиться и суммироваться все значения ширины табов пока суммарная величина + значение
+        // ширины свитчера не превысит ширину контейнера
+        for (let i = 0; i < this.tabsWidth.length; i++) {
+            renderedTabsSumWidth = renderedTabsSumWidth + this.tabsWidth[i];
+            const switcherWidthCorrection = i >= items.length - 1 ? 0 : this.switcherWidth;
+            const isOverflown = renderedTabsSumWidth + switcherWidthCorrection > tabsRootNodeWidth;
+
+            if (firstHiddenTabIndexForSequentialCase === null && isOverflown) {
+                firstHiddenTabIndexForSequentialCase = i;
+                // emptySpace - "пустое" пространство в пикселях - разница между шириной контейнера и шириной
+                // отрендеренных табов и свитчера
+                emptySpace =
+                    tabsRootNodeWidth -
+                    (renderedTabsSumWidth - this.tabsWidth[i] + this.switcherWidth);
+            }
+
+            if (firstHiddenTabIndexForSequentialCase !== null) {
+                const currentTabWidth =
+                    this.tabsWidth[i] + (i === items.length - 1 ? this.tabItemPaddingRight : 0);
+
+                maxHiddenTabWidth = Math.max(maxHiddenTabWidth, currentTabWidth);
+            }
+        }
+
+        if (maxHiddenTabWidth) {
+            let rightSpace = maxHiddenTabWidth - emptySpace;
+
+            for (let j = firstHiddenTabIndexForSequentialCase! - 1; j >= 0; j--) {
+                rightSpace = rightSpace - this.tabsWidth[j];
+
+                if (rightSpace < 0) {
+                    firstHiddenTabIndex = j + (tabChosenFromSelectIndex > j ? 0 : 1);
+
+                    break;
+                }
+            }
+        }
+
+        const activeTabWasNotChosenBySelect =
+            tabChosenFromSelectId && tabChosenFromSelectId !== activeTabId;
+        const newFirstHiddenTabIndexLowerThanPrevious =
+            firstHiddenTabIndex < prevFirstHiddenTabIndex!;
+
+        // имеются два узких кейса, которые возникают при ресайзе и требуют изменения значения tabChosenFromSelectId и
+        // перерасчёта лёйаута:
+        // 1) ранее выбрав один из скрытых табов через свитчер пользователь переключился кликом на другой таб и уменьшил
+        // экран таким образом, что выбранный ранее через свитчер таб перестал помещаться, в этом случае обнуляем
+        // значение tabChosenFromSelectId и запускаем перерасчёт
+        if (activeTabWasNotChosenBySelect && newFirstHiddenTabIndexLowerThanPrevious) {
+            this.setState({tabChosenFromSelectId: null}, this.recalculateTabs);
+            return false;
+        }
+
+        // 2) активный таб выбран не через свитчер, размер экрана уменьшен таким образом, что при стандартной порядковой
+        // последовательности активный таб не должен быть отрендерен, но так как он активный - его нельзя просто так
+        // скрыть, поэтому записываем его ID в tabChosenFromSelectId и запускаем перерасчёт
+        if (
+            this.state.tabChosenFromSelectId !== activeTabId &&
+            activeTabIndex >= firstHiddenTabIndex
+        ) {
+            this.setState({tabChosenFromSelectId: activeTabId}, this.recalculateTabs);
+            return false;
+        }
+
+        this.setState({firstHiddenTabIndex});
+
+        // фаза 1 завершена, вызываем метод подстройки ширины переполненных табов, чтобы заполнить всю ширину контейнера
+        this.setUpOverflownTabs(firstHiddenTabIndex, activeTabIndex, tabsRootNodeWidth);
+
+        return;
+    };
+
+    setUpOverflownTabs(
+        firstHiddenTabIndex: number,
+        _activeTabIndex: number,
+        tabsRootNodeWidth: number,
+    ) {
+        const {tabChosenFromSelectId} = this.state;
+        const {items} = this.props;
+        const tabChosenFromSelectIndex = items.findIndex(
+            (item) => item.id === tabChosenFromSelectId,
+        );
+        const allTabsWillBeVisible = firstHiddenTabIndex === items.length;
+        const withTabChosenFromSelect = tabChosenFromSelectIndex >= firstHiddenTabIndex;
+        // firstTabParticipatedInShiftingIndex - индекс первого таба который участвует в смене выбранного таба при
+        // использовании свитчера (другими словами может оказаться в выпадающем списке при текущей ширине контейнера)
+        // - это либо последний видимый таб (если выбор через свитчер еще ни произошёл) либо первый из скрытых
+        // (в обратном случае)
+        const firstTabParticipatedInShiftingIndex =
+            firstHiddenTabIndex - (withTabChosenFromSelect ? 0 : 1);
+
+        const alwaysVisibleTabsWidth = this.tabsWidth
+            .slice(
+                0,
+                firstHiddenTabIndex - (allTabsWillBeVisible || withTabChosenFromSelect ? 0 : 1),
+            )
+            .reduce((sum, val) => sum + val, 0);
+
+        // индекс самого широкого (реальная ширина) таба, из тех, что участвуют в смене выбранного таба
+        let widestTabParticipatedInShiftingIndex: number | null = null;
+        let widestHiddenTabRealWidth = 0;
+
+        for (let i = firstTabParticipatedInShiftingIndex; i < items.length; i++) {
+            const currentHiddenTabWidth = this.tabsRealWidth[i];
+            widestHiddenTabRealWidth = Math.max(currentHiddenTabWidth, widestHiddenTabRealWidth);
+
+            if (widestHiddenTabRealWidth === currentHiddenTabWidth) {
+                widestTabParticipatedInShiftingIndex = i;
+            }
+        }
+
+        const switcherAndMaxHiddenTabWidth = allTabsWillBeVisible
+            ? 0
+            : this.tabsWidth[widestTabParticipatedInShiftingIndex!] + this.switcherWidth;
+
+        const overflownTabsKeys = Object.keys(this.overflownTabsRealWidth);
+
+        // необходимо иметь отдельно массив индексов переполненных табов которые в настоящий момент
+        // видимы (overflownAndVisibleTabsKeys) и отдельно массив индексов переполненных табов в настоящий момент не
+        // видимых (overflownAndHiddenTabsKeys)
+        const overflownAndVisibleTabsKeys = overflownTabsKeys.filter(
+            (tabIndex) =>
+                Number(tabIndex) < firstTabParticipatedInShiftingIndex ||
+                Number(tabIndex) === widestTabParticipatedInShiftingIndex,
+        );
+
+        const isLastTabChosenFromSelectAndOverflown =
+            tabChosenFromSelectIndex === items.length - 1 &&
+            overflownAndVisibleTabsKeys.indexOf(String(tabChosenFromSelectIndex)) >= 0;
+
+        // главная идея подстройки ширины переполненных табов, для заполнения всей ширины контейнера - высчитать,
+        // какое "пустое" пространство останется, если пользователь выбрал таб с максимальной шириной через свитчер и
+        // разделить это пространство среди переполненных табов - т.е. увеличить их ширину, чтобы занять всю ширину
+        // контейнера
+        let emptySpace = tabsRootNodeWidth - alwaysVisibleTabsWidth - switcherAndMaxHiddenTabWidth;
+
+        if (isLastTabChosenFromSelectAndOverflown) {
+            emptySpace = emptySpace - this.tabItemPaddingRight;
+        }
+
+        const overflownAndHiddenTabsKeys = difference(
+            overflownTabsKeys,
+            overflownAndVisibleTabsKeys,
+        );
+
+        const overflownAndVisibleTabsIndexesSortedByWidth = overflownAndVisibleTabsKeys
+            .sort(getSortObjectKeysByValuesFunc(this.overflownTabsRealWidth))
+            .map(Number);
+
+        // additionPixelsToFitEmptySpace - значение сколько пикселей будет прибавлено к ширине переполненных табов
+        let additionPixelsToFitEmptySpace = emptySpace / overflownAndVisibleTabsKeys.length;
+        let numberOfTabsToShareEmptySpace = overflownAndVisibleTabsKeys.length;
+
+        this.overflownTabsCurrentWidth = {};
+
+        overflownAndVisibleTabsIndexesSortedByWidth.forEach((overflownTabIndex) => {
+            const realTabWidth = this.overflownTabsRealWidth[overflownTabIndex];
+            const tabWidthWithAdditional =
+                this.tabsWidth[overflownTabIndex] + additionPixelsToFitEmptySpace;
+
+            if (realTabWidth < tabWidthWithAdditional) {
+                // может случиться, что значение "текущая ширина переполненного таба + additionPixelsToFitEmptySpace"
+                // окажется больше реальной ширины таба, в таком случае текущая ширина становится равной реальной, а
+                // это значит, что мы использовали не всё пиксели из того значения что мы собрались разделить среди
+                // переполненных табов и тогда мы передаём эти пиксели (diff) для оставшихся табов, т.е. тех, чью ширину
+                // к данной итерации  ещё не увеличили (если они есть)
+                numberOfTabsToShareEmptySpace--;
+                const diff = tabWidthWithAdditional - realTabWidth;
+                additionPixelsToFitEmptySpace =
+                    additionPixelsToFitEmptySpace + diff / numberOfTabsToShareEmptySpace;
+                this.tabsWidth[overflownTabIndex] = realTabWidth;
+            } else {
+                this.tabsWidth[overflownTabIndex] = tabWidthWithAdditional;
+            }
+
+            this.overflownTabsCurrentWidth[overflownTabIndex] = this.tabsWidth[overflownTabIndex];
+        });
+
+        overflownAndHiddenTabsKeys.map(Number).forEach((overflownTabIndex) => {
+            const realTabWidth = this.overflownTabsRealWidth[overflownTabIndex];
+            const tabWidthWithAdditional =
+                this.tabsWidth[overflownTabIndex] + additionPixelsToFitEmptySpace;
+
+            if (realTabWidth < tabWidthWithAdditional) {
+                this.tabsWidth[overflownTabIndex] = realTabWidth;
+            } else {
+                this.tabsWidth[overflownTabIndex] = tabWidthWithAdditional;
+            }
+
+            this.overflownTabsCurrentWidth[overflownTabIndex] = this.tabsWidth[overflownTabIndex];
+        });
+    }
+
+    recollectDimensions = () => {
+        this.setState(
+            (state) => ({
+                dimensionsWereCollected: false,
+                firstHiddenTabIndex: this.props.items.length,
+                firstHiddenTabIndexBeforeRecollection: state.firstHiddenTabIndex,
+            }),
+            this.collectDimensions,
+        );
+    };
+
+    selectTab(tabId: string, event?: React.MouseEvent) {
+        if (this.props.onSelectTab) {
+            this.props.onSelectTab(tabId, event);
+        }
+    }
+
+    /*
+        Проверка вызывающаяся в методе componentDidUpdate и проверяющая что табы "пришедшие" с новыми props имеют тот же
+        порядок и тайтл что и предыдущие. В случае, если это не так будет вызван метод collectDimensions, чтобы
+        запомнить снять новые замеры и запустить последующие фазы пересчёта лэйаута
+     */
+    wasItemsListUpdated = (
+        currentItems: {title: string; id: string}[],
+        prevItems: {title: string; id: string}[],
+    ) => {
+        if (currentItems.length !== prevItems.length) {
+            return true;
+        }
+
+        for (let i = 0; i < currentItems.length; i++) {
+            const currentItem = currentItems[i];
+            const prevItem = prevItems[i];
+            const currentItemTitle = currentItem.title || currentItem.id;
+            const prevItemTitle = prevItem.title || prevItem.id;
+
+            if (currentItemTitle !== prevItemTitle) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    handleResize = () => {
+        if (this.state.isSelectOpened) {
+            // https://github.com/gravity-ui/uikit/issues/553
+            this.selectSwitcherNode.current?.click();
+        }
+
+        const newContainerWidthName = this.getCurrentContainerWidthName();
+
+        if (this.state.currentContainerWidthName !== newContainerWidthName) {
+            this.setState({currentContainerWidthName: newContainerWidthName}, () => {
+                if (newContainerWidthName !== SMALL_CONTAINER_WIDTH_NAME) {
+                    this.recollectDimensions();
+                }
+            });
+        } else if (newContainerWidthName !== SMALL_CONTAINER_WIDTH_NAME) {
+            this.recollectDimensions();
+        }
+    };
+
+    handleOpenSelectChange = (isSelectOpened: OpenChangeProps) => {
+        this.setState({isSelectOpened});
+    };
+
+    onChooseTabFromSelect = (tabChosenFromSelectIds: string[]) => {
+        const tabChosenFromSelectId = tabChosenFromSelectIds?.[0];
+        this.selectTab(tabChosenFromSelectId);
+
+        this.setState({tabChosenFromSelectId});
+        this.recollectDimensions();
+    };
+
+    onTabClick = (tabId: string, event?: React.MouseEvent<Element, MouseEvent>) => {
+        if (tabId === this.activeTab) {
+            return;
+        }
+
+        this.selectTab(tabId, event);
+    };
+
+    /*
+        Высчитывается какое значение свойста left необходимо задать абсолютно спозиционированному свитчеру при
+        текущем наборе отрендеренных табов
+     */
+    calcSelectSwitcherLeftPosition = () => {
+        const {tabChosenFromSelectId, firstHiddenTabIndex} = this.state;
+        const {items} = this.props;
+        let tabChosenFromSelectIndex = null;
+
+        if (tabChosenFromSelectId) {
+            tabChosenFromSelectIndex = this.props.items.findIndex(
+                (item) => item.id === tabChosenFromSelectId,
+            );
+        }
+
+        let widthCorrection =
+            tabChosenFromSelectId && tabChosenFromSelectIndex! > firstHiddenTabIndex
+                ? this.tabsWidth[tabChosenFromSelectIndex!]
+                : 0;
+
+        // если выбран самый последний таб, необходимо учесть значение правого маржина, так как в положении, когда
+        // все табы помещаюся в ширину контейнера и свитчера нет, последнему табу не нужен правый маржин, но если
+        // не все табы помещаются и справа от этого таба есть свитчер, то маржин нужен, чтобы свитчер не был вплотную
+        if (tabChosenFromSelectIndex === items.length - 1) {
+            widthCorrection = widthCorrection + this.tabItemPaddingRight;
+        }
+
+        return this.tabsWidth && firstHiddenTabIndex < items.length
+            ? this.tabsWidth
+                  .slice(0, firstHiddenTabIndex)
+                  .reduce((sum, val) => sum + val, widthCorrection)
+            : OUT_OF_SCREEN_POSITION;
+    };
+
+    renderSwitcherForMoreSelect = (switcherProps: RenderControlProps) => {
+        const {firstHiddenTabIndex, tabChosenFromSelectId} = this.state;
+        const {items} = this.props;
+        const tabChosenFromSelectIndex = items.findIndex(
+            (item) => item.id === tabChosenFromSelectId,
+        );
+        const itemsNum =
+            items.length -
+            firstHiddenTabIndex -
+            (tabChosenFromSelectIndex > firstHiddenTabIndex ? 1 : 0);
+        const hint = i18n('label_more', {count: itemsNum});
+
+        return this.renderSwitcher({...switcherProps, text: hint});
+    };
+
+    renderSwitcherForTabsAsSelect = (switcherProps: RenderControlProps) => {
+        const {items} = this.props;
+        const activeTab = items.find((item) => item.id === this.activeTab);
+        const hint = activeTab ? activeTab.title || activeTab.id : items[0].title || items[0].id;
+
+        return this.renderSwitcher({...switcherProps, text: hint, active: Boolean(activeTab)});
+    };
+
+    renderSwitcher = (
+        switcherProps: RenderControlProps & {
+            text: string;
+            active?: boolean;
+        },
+    ) => {
+        const {wrapTo} = this.props;
+        const {text, active = false, onClick, ref} = switcherProps;
+
+        const title = (
+            <div className={b('switcher-tab-content')}>
+                <span className={b('switcher-tab-text')}>{text}</span>
+                <span className={b('switcher-tab-icon')}>
+                    <Icon data={ChevronDownIcon} className={b('chevron-icon')} />
+                </span>
+            </div>
+        );
+
+        const switcherTabProps = {title, hint: text, id: 'switcher-tab'};
+        const tabItemNode = <Tab {...switcherTabProps} active={Boolean(active)} />;
+
+        return (
+            <div
+                key="switcher"
+                className={b('tab-container', {'switcher-tab': true})}
+                onClick={onClick}
+                ref={ref as React.LegacyRef<HTMLDivElement>} // https://github.com/gravity-ui/uikit/issues/552
+            >
+                {wrapTo ? wrapTo(undefined, tabItemNode, undefined) : tabItemNode}
+            </div>
+        );
+    };
+
+    renderTabs = () => {
+        const {items} = this.props;
+        const {firstHiddenTabIndex, tabChosenFromSelectId} = this.state;
+        let tabChosenFromSelectIndex: number | null = null;
+
+        if (tabChosenFromSelectId) {
+            tabChosenFromSelectIndex = this.props.items.findIndex(
+                (item) => item.id === tabChosenFromSelectId,
+            );
+        }
+
+        const needToAddTabChosenFromSelect =
+            tabChosenFromSelectId && tabChosenFromSelectIndex! > firstHiddenTabIndex;
+
+        return items
+            .slice(0, firstHiddenTabIndex)
+            .concat(needToAddTabChosenFromSelect ? items[tabChosenFromSelectIndex!] : [])
+            .map((item, index) =>
+                this.renderTabItem(
+                    item,
+                    index < firstHiddenTabIndex ? index : tabChosenFromSelectIndex!,
+                ),
+            );
+    };
+
+    renderTabItem = (item: {id: string; title: string}, tabIndex: number) => {
+        const {items, wrapTo} = this.props;
+        const activeTabID = this.activeTab;
+        const {dimensionsWereCollected, currentContainerWidthName} = this.state;
+
+        const needSetMaxWidth =
+            dimensionsWereCollected && tabIndex in this.overflownTabsCurrentWidth;
+        const isLastTab = item.id === items[items.length - 1].id && tabIndex === items.length - 1;
+        const noOverflow =
+            needSetMaxWidth &&
+            this.overflownTabsRealWidth[tabIndex] === this.overflownTabsCurrentWidth[tabIndex];
+
+        const maxWidth = dimensionsWereCollected
+            ? this.overflownTabsCurrentWidth[tabIndex]
+            : `${this.tabMaxWidthInPercentsForScreenSize[currentContainerWidthName!]}%`;
+
+        return (
+            <div
+                key={item.id}
+                style={{maxWidth: items.length > 1 ? maxWidth : '100%'}}
+                className={b('tab-container', {'last-tab': isLastTab, 'no-overflow': noOverflow})}
+            >
+                {wrapTo(
+                    item.id === activeTabID,
+                    <Tab {...item} active={item.id === activeTabID} onClick={this.onTabClick} />,
+                    item.id,
+                )}
+            </div>
+        );
+    };
+
+    renderSelect() {
+        const activeTabID = this.activeTab;
+        const {firstHiddenTabIndex, tabChosenFromSelectId} = this.state;
+        const {items} = this.props;
+
+        const itemsForSelect = items
+            .slice(firstHiddenTabIndex, items.length)
+            .filter((item) => {
+                return item.id !== activeTabID && item.id !== tabChosenFromSelectId;
+            })
+            .map((item) => ({
+                value: item.id,
+                content: item.title || item.id,
+                key: item.id,
+                disabled: item.disabled,
+            }));
+
+        return (
+            <Select
+                onUpdate={this.onChooseTabFromSelect}
+                options={itemsForSelect}
+                value={[]}
+                filterable={false}
+                renderControl={this.renderSwitcherForMoreSelect}
+                onOpenChange={this.handleOpenSelectChange}
+            />
+        );
+    }
+
+    handleTabsAsSelectUpdate = (tabIds: string[]) => {
+        const tabId = tabIds?.[0];
+        this.selectTab(tabId);
+        this.setState({tabChosenFromSelectId: tabId});
+    };
+
+    renderTabsAsSelect() {
+        const activeTabID = this.activeTab;
+        const {items} = this.props;
+
+        const itemsForSelect = items.map((item) => ({
+            value: item.id,
+            content: item.title || item.id,
+            key: item.id,
+            disabled: item.disabled,
+        }));
+
+        return (
+            <Select
+                onUpdate={this.handleTabsAsSelectUpdate}
+                options={itemsForSelect}
+                value={activeTabID === undefined ? [] : [activeTabID]}
+                filterable={false}
+                renderControl={this.renderSwitcherForTabsAsSelect}
+                onOpenChange={this.handleOpenSelectChange}
+            />
+        );
+    }
+
+    render() {
+        const {wrapTo, items, className} = this.props;
+        const isDefaultRender = !wrapTo || wrapTo === defaultWrapToFunc;
+
+        return (
+            <div
+                ref={this.tabsRootNode}
+                className={b(
+                    {
+                        visible: this.state.dimensionsWereCollected,
+                        'is-default-render': isDefaultRender,
+                    },
+                    className,
+                )}
+            >
+                {this.state.currentContainerWidthName === SMALL_CONTAINER_WIDTH_NAME &&
+                items.length > 1 ? (
+                    this.renderTabsAsSelect()
+                ) : (
+                    <React.Fragment>
+                        <div ref={this.tabsListNode} className={b('tabs-list')}>
+                            {this.renderTabs()}
+                        </div>
+                        <div
+                            ref={this.selectSwitcherNode}
+                            className={b('select-switcher')}
+                            style={{left: this.calcSelectSwitcherLeftPosition()}}
+                        >
+                            {this.renderSelect()}
+                        </div>
+                    </React.Fragment>
+                )}
+            </div>
+        );
+    }
+}
+
+export default AdjustableTabs;

--- a/src/components/Tabs/AdjustableTabs.tsx
+++ b/src/components/Tabs/AdjustableTabs.tsx
@@ -37,22 +37,22 @@ const getSortObjectKeysByValuesFunc =
     };
 
 /*
-    ОБЩИЕ ПРИНЦИПЫ РАБОТЫ КОМПОНЕНТА:
-    - Если все табы не помещаются в ширину контейнера, непоместившиеся скрываются и появляется свитчер с текстом
-        "Ещё N", где N - количество непоместившихся табов, по клику появляется выпадающий список в котором можно
-        выбрать один из непоместившихся табов при этом выбранный таб "встанет" на место последнего видимого.
+    THE GENERAL PRINCIPLES OF THE COMPONENT:
+    - If all the tabs do not fit into the width of the container, the incomplete tabs will be hidden and a switcher will appear with the text
+        "N more", where N - the number of tabs that don't fit, and when you click on it you will see a dropdown list where you can
+        Select one of the tabs that didn't fit, and the selected tab will "stand" in place of the last visible one.
 
-    - Имеются две тесно связанные фичи:
-        1 - конфигурируемая максимально допустимая ширина таба (текст таба скрывается за "…" если не помещается -
-            будем в дальнейшем называть такие табы "переполненными")
-        2 - использование всей ширины контейнера - подстройка ширины переполненных табов, чтобы заполнить всю ширину
-            контейнера (на практике это выражется в том, что при выборе через свитчер максимально широкого из
-            непоместившихся табов, отрендеренные табы + свитчер займут всю ширину контейнера).
-        Поэтому, при расчёте лэйаута, логически выделяются: этап подготовки (в дальнейшем "снятие замеров") - вычисление
-        ширины табов с учётом активного брейкпоинта (максимальной ширины на данном брейкпоинте), вычисление реальной
-        ширины табов (без ограничения максимальной ширины), вычисление ширины свитчера, величины отступа между табами и
-        прочее) и две основные фазы:) 1) нахождение индекса первого непоместившегося таба и 2) подстройка ширины
-        переполненных табов под ширину контейнера (в дальнейшем фазы 1 и 2)
+    - There are two closely related features:
+        1 - configurable maximum width of the tab (tab text is hidden behind "..." if it does not fit -
+            we will further call such tabs "overflowing")
+        2 - use the whole width of the container - adjust the width of the overflowing tabs to fill the whole width
+            of the container width (in practice this means that if you choose the widest of
+            to fill the whole width of the container).
+        Therefore, when calculating the layout, the following stages are logically separated: the preparation stage (hereinafter referred to as "measuring") - calculation
+        tabs width taking into account the active breakpoint (maximum width at this breakpoint), calculation of the real
+        tabs width (without the maximum width restriction), calculation of the switcher width, the tabs indentation value, and
+        etc.) and two main phases:) 1) finding the index of the first tab that doesn't fit, and 2) adjusting the width
+        2) adjusting the width of the overflowing tabs to the width of the container (hereinafter phases 1 and 2)
  */
 interface AdjustableTabsProps {
     items: TabsItemProps[];
@@ -64,22 +64,35 @@ interface AdjustableTabsProps {
 }
 
 interface AdjustableTabsState {
+    /* a flag indicating whether the "unmetered" stage has occurred */
     dimensionsWereCollected: boolean;
+    /* index of the first hidden tab */
     firstHiddenTabIndex: number;
+    /* in a certain case, there is a need to know the previous index value of the first hidden tab */
     firstHiddenTabIndexBeforeRecollection: number | null;
+    /* because after one of the incomplete tabs has been selected by the switcher and the selected tab is "inserted"
+     in place of the last visible tab, the list of visible (currently rendered tabs) will NOT be in
+     consecutive order (for example, the 1st, 2nd and 5th (chosen by the switcher) tabs will be rendered,
+     the 3rd and 4th are hidden), therefore we need to store the ID of switched on tab */
     tabChosenFromSelectId: string | null;
+    /*
+    the "name" of the current container width - to determine the active breakpoint, depends on the value in the
+    "breakpointsConfig" property (for example, if breakpointsConfig={ '400': 33, '1200': 22 }, if the width of the container
+    <= 400 currentContainerWidthName would be "small", at > 1200 it would be "large", and at container widths between 400 and
+    1200 - "400-1200")
+    */
     currentContainerWidthName: string | null | undefined;
-    // flag for opened/closed status of select
+    /* flag for opened/closed status of select */
     isSelectOpened: boolean;
 }
 
 class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabsState> {
     static defaultProps = {
-        // дефолтные значения конфигурации брейкпоинтов - объект где ключ - ширина элемента контейнера,  значение -
-        // максимальная ширина таба в процентах от ширины контейнера, (так, для дефолтных значений, при ширине
-        // контейнера от 401px до 500px максимальная ширина таба составит 33%, при ширине от 501px до 700px 30% и т.д.)
-        // при ширине контейнера минимального из значений определённых в ключах объекта (в дефолтном случае 400)
-        // вместо табов рендерится селект занимающий всю ширину контейнера.
+        /* default values of breakpoint configuration - object where the key is the width of the container element, the value is
+         maximum width of tab as a percentage of the container width, (so, for default values, if the width of
+         container width from 401px to 500px the maximum tab width will be 33%, from 501px to 700px 30%, etc.)
+         the width of the container is the minimum of the values defined in the object keys (the default value is 400)
+         instead of tabs, select is rendered occupying the entire width of the container. */
         breakpointsConfig: DEFAULT_BREAKPOINTS_CONFIG,
     };
 
@@ -90,25 +103,24 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     private tabItemPaddingRight = 0;
     private switcherWidth = 0;
 
-    // для удобства вычислений потребуется три объекта, у которых ключи - индексы табов, а значения - ширина табов,
-    // при этом отдельно рассматривается реальная ширина табов (как если бы не было ограничений на max width)
-    // и текущая ширина табов (с учётом ограничений по max width и подстройки ширины):
-
-    // - реальная ширина табов, запишутся значения для всех табов
+    /* for the convenience of calculations, you will need three objects, whose keys are tab indices and values are tab widths,
+     the real width of tabs is considered separately (as if there were no max width limitations)
+     and the current tabs width (taking into account max width constraints and width adjustment):
+     - real width of the tabs, the values for all tabs will be written */
     private tabsRealWidth: Record<string, number> = {};
 
-    // - то же, но запишутся только значения для переполненных табов (иметь такой объект только со значениями
-    // переполненных табов необходимо для вычислений подстройки ширины переполненных табов)
+    /* - the same, but only values for overflowing tabs will be written (it is necessary to have such an object with the values of
+     of the overflowed tabs is necessary for calculations of width adjustment of the overflowed tabs) */
     private overflownTabsRealWidth: Record<string, number> = {};
 
-    // - текущая ширина табов, опять же, только для переполненных табов
+    /* - current width of tabs, again, only for crowded tabs */
     private overflownTabsCurrentWidth: Record<string, number> = {};
 
-    // помимо этого, в массиве будем хранить текущую ширину всех табов, массив здесь удобен для вычисления
-    // ширины N видимых табов, например, с первого по пятый.
+    /* in addition, the array will store the current width of all the tabs, the array is convenient for calculating
+     the width of N visible tabs, for example, from the first to the fifth. */
     private tabsWidth: number[] = [];
 
-    // флаг указывающий, что первоначальное снятие необходимых для дальнейших рассчётов размеров уже произошло
+    /* a flag indicating that the initial acquisition of the dimensions required for further calculations has already taken place */
     private dimensionsWereInitiallyCollected = true;
 
     private selectSwitcherNode = React.createRef<HTMLDivElement>();
@@ -119,21 +131,10 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         super(props);
 
         this.state = {
-            // флаг указывающий на то, произошёл ли этап "снятия замеров"
             dimensionsWereCollected: false,
-            // индекс первого скрытого таба
             firstHiddenTabIndex: this.props.items.length,
-            // в определённом случае есть необходимость знать предыдущее значение индекса первого скрытого таба
             firstHiddenTabIndexBeforeRecollection: null,
-            // так как после того, как посредством свитчера выбран один из непоместившихся табов и выбранный таб "встал"
-            // на место последнего видимого, список видимых (в данный момент отрендеренных табов) будет НЕ в
-            // последовательном порядке (например, будут отрендерены 1-й, 2-й и 5-й (выбранный через свитчер) табы,
-            // а 3-й и 4-й будут скрыты), поэтому нам нужно хранить ID выбранного через свитчер таба
             tabChosenFromSelectId: null,
-            // "имя" текущей ширины контейнера - для определения активного брейкоинта, зависит от значения в свойстве
-            // "breakpointsConfig" (например, если, breakpointsConfig={ '400': 33, '1200': 22 }, при ширине контейнера
-            // <= 400 currentContainerWidthName будет "small", при > 1200 - "large", а при ширине контейнера между 400 и
-            // 1200 - "400-1200")
             currentContainerWidthName: null,
             isSelectOpened: false,
         };
@@ -142,8 +143,8 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             .map(Number)
             .sort((a, b) => a - b);
 
-        // сохраняем объект, где ключи - "имя" текущей ширины контейнера, значения - максимальная ширина таба для
-        // соответствующей ширины контейнера (в процентах от ширины контейнера)
+        /* save the object, where the keys are the "name" of the current container width, the values are the maximum width of the tab for
+         the corresponding container width (in percent of the container width) */
         this.tabMaxWidthInPercentsForScreenSize = this.breakpoints.reduce(
             (accum: Record<string, number>, currentBreakpointWidth, index, breakpointsArray) => {
                 const nextBreakpointWidth = breakpointsArray[index + 1];
@@ -217,9 +218,9 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     }
 
     initialCollectDimensions = () => {
-        // так как мы ожидаем прогрузки шрифтов для замера размеров табов и подписки на ресайз контейнера, возможен
-        // случай, что к моменту загрузки шрифтов, компонент уже unmounted, поэтому, нужно проверять, что ref у корневой
-        // ноды существует
+        /* Because we are expecting fonts to be loaded to measure tab sizes and subscribe to container resize, it is possible
+         case that by the time the fonts are loaded the component is already unmounted, so it's necessary to check that the ref at the root
+         node exists */
         if (this.tabsRootNode.current) {
             this.dimensionsWereInitiallyCollected = true;
             this.recollectDimensions();
@@ -228,7 +229,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     };
 
     /*
-        Этап "снятия замеров". Разово высчитывается ширина табов и некоторые сопутствующие размеры/отступы
+        The "taking measurements" stage. Once the width of the tabs and some associated dimensions/indentation are calculated
      */
     collectDimensions = () => {
         const tabsListNode = this.tabsListNode.current!;
@@ -243,16 +244,16 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
                 .getComputedStyle(tabElement)
                 .getPropertyValue('padding-right');
 
-            // сохраняем значение правого padding-a (расстояние между табами которое может быть различным в зависимости
-            // от значения css переменной --dl-tabs-space-between)
+            /* save the value of the right padding (the distance between tabs, which can be different depending on
+             the value of css variable --yc-tabs-gap) */
             this.tabItemPaddingRight = paddingRightValue ? parseInt(paddingRightValue, 10) : 0;
         }
 
         this.overflownTabsRealWidth = {};
         this.tabsRealWidth = {};
 
-        // обходя в цикле все табы записываем текущую ширину каждого таба в массив this.tabsWidth
-        // "наполняем" объекты this.tabsRealWidth и this.overflownTabsRealWidth
+        /* bypass all the tabs in the loop and write the current width of each tab to the array this.tabsWidth
+        "fill" the objects this.tabsRealWidth and this.overflownTabsRealWidth */
         for (let i = 0; i < tabs.length; i++) {
             const {width} = tabs[i].getBoundingClientRect();
 
@@ -304,18 +305,18 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     };
 
     /*
-        Перерасчёт лэйаута - фазы 1 и 2
+        Recalculating the Layout - Phases 1 and 2
      */
     recalculateTabs = () => {
-        // фаза 1 - вычисление индекса первого скрытого таба
+        /*Phase 1 - calculation of the index of the first hidden tab*/
         const activeTabId = this.props.activeTab;
         const {
             tabChosenFromSelectId,
             firstHiddenTabIndexBeforeRecollection: prevFirstHiddenTabIndex,
         } = this.state;
-        // activeTabId - это ID активного таба, tabChosenFromSelectId - ID таба выбранного через свитчер,
-        // таб выбранный через свитчер сразу после выбора становится активным (в этом случае, эти значения совпадают)
-        // но если после юзер переключится (кликнул) на соседний таб, они снова будут отличаться
+        /* activeTabId is ID of the active tab, tabChosenFromSelectId is ID of the tab selected via the switch,
+         the tab selected via the switcher becomes active immediately after selection (in this case, these values coincide)
+         but if after the user switches (clicks) to the neighboring tab, they will be different again */
 
         const {items} = this.props;
         const {width: tabsRootNodeWidth} = this.tabsRootNode.current!.getBoundingClientRect();
@@ -327,27 +328,28 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
         let renderedTabsSumWidth = 0;
 
-        // firstHiddenTabIndexForSequentialCase - индекс первого скрытого таба для случая, когда табы расположены в
-        // порядковой последовательности и без учёта максимальной ширины скрытого таба (необходим только для
-        // промежуточных вычислений)
-        // firstHiddenTabIndex - индекс первого скрытого таба в конкретной ситуации (с учётом шириный таба выбранного
-        // через свитчер и максимальной ширины среди непоместившихся табов (будет храниться в стейте)
+        /* firstHiddenTabIndexForSequentialCase - index of the first hidden tab for the case when the tabs are located in
+         serial sequence and without taking into account the maximal width of the hidden tab (it is necessary only for
+         intermediate calculations)
+         firstHiddenTabIndex - index of the first hidden tab in a particular situation (taking into account the width of the tab selected
+         through the switch
+         by the switcher and the maximum width of the missing tabs (to be stored in the stack)
 
-        // сначала, при обходе в цикле всех табов запоминается firstHiddenTabIndexForSequentialCase и максимальная
-        // ширина среди скрытых табов, после этого в обратном цикле, начиная со значения таба с индексом
-        // firstHiddenTabIndexForSequentialCase - 1 определяется сколько табов необходимо "переместить" в
-        // непоместившееся, чтобы даже при выборе через свитчер таба с максимальной шириной, его ширина + ширина видимых
-        // табов не превысила бы ширину контейнера
+         firstHiddenTabIndexForSequentialCase and the maximal
+         width among the hidden tabs, then in the reverse loop, starting from the tab with the index
+         firstHiddenTabIndexForSequentialCase - 1, it is determined how many tabs should be "moved" into
+         incomplete, so that even if a tab with the maximum width is chosen by the switcher, its width + width of the visible
+         tabs would not exceed the width of the container */
         let firstHiddenTabIndexForSequentialCase = null;
         let firstHiddenTabIndex = items.length;
-        // если обойдя все значения ширин табов, мы так и не превысим ширину контейнера, в firstHiddenTabIndex
-        // запишется значение равное количеству табов, таком образом будут отрендерены все табы
+        /* if we have bypassed all the widths of the tabs without exceeding the container width, the firstHiddenTabIndex
+         value equal to the number of tabs will be written, in this way all the tabs will be rendered */
 
         let maxHiddenTabWidth = 0;
         let emptySpace = 0;
 
-        // в цикле будут обходиться и суммироваться все значения ширины табов пока суммарная величина + значение
-        // ширины свитчера не превысит ширину контейнера
+        /* all tab width values will be bypassed in the loop and summed up until the sum + value of
+         of the switcher width will not exceed the width of the container */
         for (let i = 0; i < this.tabsWidth.length; i++) {
             renderedTabsSumWidth = renderedTabsSumWidth + this.tabsWidth[i];
             const switcherWidthCorrection = i >= items.length - 1 ? 0 : this.switcherWidth;
@@ -355,8 +357,8 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
             if (firstHiddenTabIndexForSequentialCase === null && isOverflown) {
                 firstHiddenTabIndexForSequentialCase = i;
-                // emptySpace - "пустое" пространство в пикселях - разница между шириной контейнера и шириной
-                // отрендеренных табов и свитчера
+                /* emptySpace - "empty" space in pixels - the difference between the width of the container and the width
+                 of the rendered tabs and the switcher */
                 emptySpace =
                     tabsRootNodeWidth -
                     (renderedTabsSumWidth - this.tabsWidth[i] + this.switcherWidth);
@@ -389,19 +391,19 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         const newFirstHiddenTabIndexLowerThanPrevious =
             firstHiddenTabIndex < prevFirstHiddenTabIndex!;
 
-        // имеются два узких кейса, которые возникают при ресайзе и требуют изменения значения tabChosenFromSelectId и
-        // перерасчёта лёйаута:
-        // 1) ранее выбрав один из скрытых табов через свитчер пользователь переключился кликом на другой таб и уменьшил
-        // экран таким образом, что выбранный ранее через свитчер таб перестал помещаться, в этом случае обнуляем
-        // значение tabChosenFromSelectId и запускаем перерасчёт
+        /* there are two narrow cases that arise during resizing that require changing the value of tabChosenFromSelectId and
+         recalculate the layout:
+         1) previously selecting one of the hidden tabs via the switcher, the user switched by click to another tab and reduced
+         screen so that the tab chosen earlier by the switcher would no longer fit; in such a case, we reset
+         tabChosenFromSelectId value and start recalculation */
         if (activeTabWasNotChosenBySelect && newFirstHiddenTabIndexLowerThanPrevious) {
             this.setState({tabChosenFromSelectId: null}, this.recalculateTabs);
             return false;
         }
 
-        // 2) активный таб выбран не через свитчер, размер экрана уменьшен таким образом, что при стандартной порядковой
-        // последовательности активный таб не должен быть отрендерен, но так как он активный - его нельзя просто так
-        // скрыть, поэтому записываем его ID в tabChosenFromSelectId и запускаем перерасчёт
+        /* 2) the active tab is not selected via a switcher, the screen size is reduced so that the standard
+         sequence, the active tab should not be rendered, but because it is active, it simply can't be
+         hide it, so we write its ID into tabChosenFromSelectId and start recalculation */
         if (
             activeTabId &&
             this.state.tabChosenFromSelectId !== activeTabId &&
@@ -413,7 +415,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
         this.setState({firstHiddenTabIndex});
 
-        // фаза 1 завершена, вызываем метод подстройки ширины переполненных табов, чтобы заполнить всю ширину контейнера
+        /*phase 1 is complete, call the method of adjusting the width of the overflowing tabs to fill the entire width of the container*/
         this.setUpOverflownTabs(firstHiddenTabIndex, activeTabIndex, tabsRootNodeWidth);
 
         return;
@@ -431,10 +433,10 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
         );
         const allTabsWillBeVisible = firstHiddenTabIndex === items.length;
         const withTabChosenFromSelect = tabChosenFromSelectIndex >= firstHiddenTabIndex;
-        // firstTabParticipatedInShiftingIndex - индекс первого таба который участвует в смене выбранного таба при
-        // использовании свитчера (другими словами может оказаться в выпадающем списке при текущей ширине контейнера)
-        // - это либо последний видимый таб (если выбор через свитчер еще ни произошёл) либо первый из скрытых
-        // (в обратном случае)
+        /* firstTabParticipatedInShiftingIndex - index of the first tab which participates in the change of the selected tab when
+         it is the index of the first tab which participates in switching of the selected tab (in other words it can appear in the dropdown list at the current width of the container)
+         it is either the last visible tab (if the selection is not made by the switcher yet) or the first of hidden tabs.
+         (otherwise) */
         const firstTabParticipatedInShiftingIndex =
             firstHiddenTabIndex - (withTabChosenFromSelect ? 0 : 1);
 
@@ -445,7 +447,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             )
             .reduce((sum, val) => sum + val, 0);
 
-        // индекс самого широкого (реальная ширина) таба, из тех, что участвуют в смене выбранного таба
+        /*index of the widest (real width) tab of those that participate in the change of the selected tab*/
         let widestTabParticipatedInShiftingIndex: number | null = null;
         let widestHiddenTabRealWidth = 0;
 
@@ -464,9 +466,9 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
 
         const overflownTabsKeys = Object.keys(this.overflownTabsRealWidth);
 
-        // необходимо иметь отдельно массив индексов переполненных табов которые в настоящий момент
-        // видимы (overflownAndVisibleTabsKeys) и отдельно массив индексов переполненных табов в настоящий момент не
-        // видимых (overflownAndHiddenTabsKeys)
+        /* it is necessary to have a separate array of indexes of overflown tabs which at the moment
+         visible (overflownAndVisibleTabsKeys) and separately an array of indexes of overflown tabs which are not currently
+         visible (overflownAndHiddenTabsKeys) */
         const overflownAndVisibleTabsKeys = overflownTabsKeys.filter(
             (tabIndex) =>
                 Number(tabIndex) < firstTabParticipatedInShiftingIndex ||
@@ -477,10 +479,10 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             tabChosenFromSelectIndex === items.length - 1 &&
             overflownAndVisibleTabsKeys.indexOf(String(tabChosenFromSelectIndex)) >= 0;
 
-        // главная идея подстройки ширины переполненных табов, для заполнения всей ширины контейнера - высчитать,
-        // какое "пустое" пространство останется, если пользователь выбрал таб с максимальной шириной через свитчер и
-        // разделить это пространство среди переполненных табов - т.е. увеличить их ширину, чтобы занять всю ширину
-        // контейнера
+        /* the main idea of adjusting the width of overflowing tabs, to fill the entire width of the container - calculate,
+         what "empty" space will be left if the user chose the tab with the maximum width through the switcher and
+         divide this space among the overflowing tabs - i.e. increase their width to occupy the full width
+         container */
         let emptySpace = tabsRootNodeWidth - alwaysVisibleTabsWidth - switcherAndMaxHiddenTabWidth;
 
         if (isLastTabChosenFromSelectAndOverflown) {
@@ -496,7 +498,7 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
             .sort(getSortObjectKeysByValuesFunc(this.overflownTabsRealWidth))
             .map(Number);
 
-        // additionPixelsToFitEmptySpace - значение сколько пикселей будет прибавлено к ширине переполненных табов
+        /*additionPixelsToFitEmptySpace - the value of how many pixels will be added to the width of the crowded tabs */
         let additionPixelsToFitEmptySpace = emptySpace / overflownAndVisibleTabsKeys.length;
         let numberOfTabsToShareEmptySpace = overflownAndVisibleTabsKeys.length;
 
@@ -508,11 +510,11 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
                 this.tabsWidth[overflownTabIndex] + additionPixelsToFitEmptySpace;
 
             if (realTabWidth < tabWidthWithAdditional) {
-                // может случиться, что значение "текущая ширина переполненного таба + additionPixelsToFitEmptySpace"
-                // окажется больше реальной ширины таба, в таком случае текущая ширина становится равной реальной, а
-                // это значит, что мы использовали не всё пиксели из того значения что мы собрались разделить среди
-                // переполненных табов и тогда мы передаём эти пиксели (diff) для оставшихся табов, т.е. тех, чью ширину
-                // к данной итерации  ещё не увеличили (если они есть)
+                /* It can happen that the value "current width of the overflowing tab + additionPixelsToFitEmptySpace"
+                 is greater than the real width of the tab, in which case the current width becomes equal to the real width, and
+                 it means that we haven't used all the pixels from the
+                 overflowing tabs and then we pass those pixels (diff) for the remaining tabs, i.e. those whose width
+                 have not been incremented by the current iteration (if there are any). */
                 numberOfTabsToShareEmptySpace--;
                 const diff = tabWidthWithAdditional - realTabWidth;
                 additionPixelsToFitEmptySpace =
@@ -558,9 +560,9 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     }
 
     /*
-        Проверка вызывающаяся в методе componentDidUpdate и проверяющая что табы "пришедшие" с новыми props имеют тот же
-        порядок и тайтл что и предыдущие. В случае, если это не так будет вызван метод collectDimensions, чтобы
-        запомнить снять новые замеры и запустить последующие фазы пересчёта лэйаута
+        A check which is called in the componentDidUpdate method and checks if the tabs "come" with new props have the same
+        order and title as the previous ones. If this is not the case, the collectDimensions method will be called to
+        memorize the new props and run the subsequent phases of recalculating the layout
      */
     wasItemsListUpdated = (currentItems: TabsItemProps[], prevItems: TabsItemProps[]) => {
         if (currentItems.length !== prevItems.length) {
@@ -621,8 +623,8 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
     };
 
     /*
-        Высчитывается какое значение свойста left необходимо задать абсолютно спозиционированному свитчеру при
-        текущем наборе отрендеренных табов
+        Calculates what value of the left property should be set to the absolutely positioned switcher at
+        the current set of rendered tabs
      */
     calcSelectSwitcherLeftPosition = () => {
         const {tabChosenFromSelectId, firstHiddenTabIndex} = this.state;
@@ -640,9 +642,10 @@ class AdjustableTabs extends React.Component<AdjustableTabsProps, AdjustableTabs
                 ? this.tabsWidth[tabChosenFromSelectIndex!]
                 : 0;
 
-        // если выбран самый последний таб, необходимо учесть значение правого маржина, так как в положении, когда
-        // все табы помещаюся в ширину контейнера и свитчера нет, последнему табу не нужен правый маржин, но если
-        // не все табы помещаются и справа от этого таба есть свитчер, то маржин нужен, чтобы свитчер не был вплотную
+        /* if the last tab is selected, the right margin must be taken into account, because in the position where
+         all tabs fit into the container width and there is no switcher, the right margin is not needed for the last tab.
+         all tabs do not fit into the container width and there is a switcher to the right of this tab,
+         then a margin is needed to prevent the switcher from being flattened */
         if (tabChosenFromSelectIndex === items.length - 1) {
             widthCorrection = widthCorrection + this.tabItemPaddingRight;
         }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -263,10 +263,6 @@ $block: '.#{variables.$ns}tabs';
         &:not(&_switcher-tab):only-child {
             #{$block}__tab {
                 cursor: auto;
-
-                .dl-draggable-handle-element.dashkit-plugin-widget__tabs_edit-mode & {
-                    cursor: move;
-                }
             }
         }
 

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -189,9 +189,9 @@ $block: '.#{variables.$ns}tabs';
     }
 
     // Adjustable tabs styles
-    --dl-tabs-space-between: 20px;
-    --dl-tabs-border-width: 2px;
-    --dl-tabs-height: 36px;
+    --yc-tabs-gap: 20px;
+    --yc-tabs-border-width: 2px;
+    --yc-tabs-height: 36px;
 
     position: relative;
     overflow: hidden;
@@ -201,8 +201,8 @@ $block: '.#{variables.$ns}tabs';
         box-shadow: inset 0 -1px 0 0 var(--dl-tabs-color-divider);
 
         .adjustable-tabs__tab {
-            border-bottom: var(--dl-tabs-border-width) solid transparent;
-            padding: var(--dl-tabs-border-width) 1px 0;
+            border-bottom: var(--yc-tabs-border-width) solid transparent;
+            padding: var(--yc-tabs-border-width) 1px 0;
 
             &_active {
                 border-color: var(--dl-tabs-color-border-active);
@@ -216,7 +216,7 @@ $block: '.#{variables.$ns}tabs';
     }
 
     &__tabs-list {
-        max-height: calc(var(--dl-tabs-height) + var(--dl-tabs-border-width) * 2);
+        max-height: calc(var(--yc-tabs-height) + var(--yc-tabs-border-width) * 2);
         display: flex;
         align-items: flex-end;
         overflow: hidden;
@@ -250,7 +250,7 @@ $block: '.#{variables.$ns}tabs';
 
     &__tab-container {
         overflow: hidden;
-        padding-right: var(--dl-tabs-space-between);
+        padding-right: var(--yc-tabs-gap);
 
         &:not(&_switcher-tab):only-child {
             .adjustable-tabs__tab {
@@ -287,7 +287,7 @@ $block: '.#{variables.$ns}tabs';
     &__tab {
         box-sizing: border-box;
         text-decoration: none;
-        line-height: var(--dl-tabs-height);
+        line-height: var(--yc-tabs-height);
         color: var(--dl-tabs-color-text-inactive);
         text-overflow: ellipsis;
         overflow: hidden;

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -187,4 +187,125 @@ $block: '.#{variables.$ns}tabs';
             }
         }
     }
+
+    // Adjustable tabs styles
+    --dl-tabs-space-between: 20px;
+    --dl-tabs-border-width: 2px;
+    --dl-tabs-height: 36px;
+
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+
+    &_is-default-render {
+        box-shadow: inset 0 -1px 0 0 var(--dl-tabs-color-divider);
+
+        .adjustable-tabs__tab {
+            border-bottom: var(--dl-tabs-border-width) solid transparent;
+            padding: var(--dl-tabs-border-width) 1px 0;
+
+            &_active {
+                border-color: var(--dl-tabs-color-border-active);
+                color: var(--dl-tabs-color-text-active);
+            }
+        }
+    }
+
+    &_visible {
+        opacity: initial;
+    }
+
+    &__tabs-list {
+        max-height: calc(var(--dl-tabs-height) + var(--dl-tabs-border-width) * 2);
+        display: flex;
+        align-items: flex-end;
+        overflow: hidden;
+        flex-wrap: wrap;
+    }
+
+    &__select-switcher {
+        position: absolute;
+        top: 0;
+        will-change: left;
+
+        .adjustable-tabs__tab-container .adjustable-tabs__tab {
+            margin-right: 0;
+        }
+    }
+
+    &__switcher-tab-content {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
+    }
+
+    &__switcher-tab-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    &__switcher-tab-icon {
+        display: flex;
+    }
+
+    &__tab-container {
+        overflow: hidden;
+        padding-right: var(--dl-tabs-space-between);
+
+        &:not(&_switcher-tab):only-child {
+            .adjustable-tabs__tab {
+                cursor: auto;
+
+                .dl-draggable-handle-element.dashkit-plugin-widget__tabs_edit-mode & {
+                    cursor: move;
+                }
+            }
+        }
+
+        &_last-tab {
+            padding-right: 0;
+        }
+
+        &_switcher-tab {
+            padding-right: 0;
+            max-width: 100%;
+
+            .adjustable-tabs__tab {
+                width: auto;
+                display: inline-flex;
+                max-width: 100%;
+            }
+        }
+
+        &_no-overflow {
+            .adjustable-tabs__tab {
+                overflow: initial;
+            }
+        }
+    }
+
+    &__tab {
+        box-sizing: border-box;
+        text-decoration: none;
+        line-height: var(--dl-tabs-height);
+        color: var(--dl-tabs-color-text-inactive);
+        text-overflow: ellipsis;
+        overflow: hidden;
+        width: 100%;
+
+        cursor: pointer;
+        user-select: none;
+        outline: none;
+        white-space: nowrap;
+
+        &_disabled {
+            pointer-events: none;
+            cursor: auto;
+            color: var(--dl-tabs-color-text-disabled);
+        }
+    }
+
+    &__chevron-icon {
+        margin-left: 10px;
+    }
 }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -200,12 +200,12 @@ $block: '.#{variables.$ns}tabs';
     &_is-default-render {
         box-shadow: inset 0 -1px 0 0 var(--dl-tabs-color-divider);
 
-        .adjustable-tabs__tab {
+        .yc-tabs__tab {
             border-bottom: var(--yc-tabs-border-width) solid transparent;
             padding: var(--yc-tabs-border-width) 1px 0;
 
             &_active {
-                border-color: var(--dl-tabs-color-border-active);
+                border-color: var(--yc-color-base-special);
                 color: var(--dl-tabs-color-text-active);
             }
         }
@@ -228,7 +228,7 @@ $block: '.#{variables.$ns}tabs';
         top: 0;
         will-change: left;
 
-        .adjustable-tabs__tab-container .adjustable-tabs__tab {
+        .yc-tabs__tab-container .yc-tabs__tab {
             margin-right: 0;
         }
     }
@@ -253,7 +253,7 @@ $block: '.#{variables.$ns}tabs';
         padding-right: var(--yc-tabs-gap);
 
         &:not(&_switcher-tab):only-child {
-            .adjustable-tabs__tab {
+            .yc-tabs__tab {
                 cursor: auto;
 
                 .dl-draggable-handle-element.dashkit-plugin-widget__tabs_edit-mode & {
@@ -270,7 +270,7 @@ $block: '.#{variables.$ns}tabs';
             padding-right: 0;
             max-width: 100%;
 
-            .adjustable-tabs__tab {
+            .yc-tabs__tab {
                 width: auto;
                 display: inline-flex;
                 max-width: 100%;
@@ -278,7 +278,7 @@ $block: '.#{variables.$ns}tabs';
         }
 
         &_no-overflow {
-            .adjustable-tabs__tab {
+            .yc-tabs__tab {
                 overflow: initial;
             }
         }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -193,9 +193,11 @@ $block: '.#{variables.$ns}tabs';
     --yc-tabs-border-width: 2px;
     --yc-tabs-height: 36px;
 
-    position: relative;
-    overflow: hidden;
-    width: 100%;
+    &_adjustable {
+        position: relative;
+        overflow: hidden;
+        width: 100%;
+    }
 
     &_is-default-render {
         > :not(#{$block}__tabs-as-select-control) {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -198,15 +198,17 @@ $block: '.#{variables.$ns}tabs';
     width: 100%;
 
     &_is-default-render {
-        box-shadow: inset 0 -1px 0 0 var(--dl-tabs-color-divider);
+        > :not(#{$block}__tabs-as-select-control) {
+            box-shadow: inset 0 -1px 0 0 var(--yc-color-line-generic);
+        }
 
-        .yc-tabs__tab {
+        #{$block}__tab {
             border-bottom: var(--yc-tabs-border-width) solid transparent;
             padding: var(--yc-tabs-border-width) 1px 0;
 
             &_active {
                 border-color: var(--yc-color-base-special);
-                color: var(--dl-tabs-color-text-active);
+                color: var(--yc-color-text-primary);
             }
         }
     }
@@ -228,8 +230,14 @@ $block: '.#{variables.$ns}tabs';
         top: 0;
         will-change: left;
 
-        .yc-tabs__tab-container .yc-tabs__tab {
+        #{$block}__tab-container #{$block}__tab {
             margin-right: 0;
+        }
+    }
+
+    &__tabs-as-select-control {
+        #{$block}__tab {
+            border: none;
         }
     }
 
@@ -253,7 +261,7 @@ $block: '.#{variables.$ns}tabs';
         padding-right: var(--yc-tabs-gap);
 
         &:not(&_switcher-tab):only-child {
-            .yc-tabs__tab {
+            #{$block}__tab {
                 cursor: auto;
 
                 .dl-draggable-handle-element.dashkit-plugin-widget__tabs_edit-mode & {
@@ -270,7 +278,7 @@ $block: '.#{variables.$ns}tabs';
             padding-right: 0;
             max-width: 100%;
 
-            .yc-tabs__tab {
+            #{$block}__tab {
                 width: auto;
                 display: inline-flex;
                 max-width: 100%;
@@ -278,7 +286,7 @@ $block: '.#{variables.$ns}tabs';
         }
 
         &_no-overflow {
-            .yc-tabs__tab {
+            #{$block}__tab {
                 overflow: initial;
             }
         }
@@ -288,7 +296,7 @@ $block: '.#{variables.$ns}tabs';
         box-sizing: border-box;
         text-decoration: none;
         line-height: var(--yc-tabs-height);
-        color: var(--dl-tabs-color-text-inactive);
+        color: var(--yc-color-text-secondary);
         text-overflow: ellipsis;
         overflow: hidden;
         width: 100%;
@@ -301,7 +309,7 @@ $block: '.#{variables.$ns}tabs';
         &_disabled {
             pointer-events: none;
             cursor: auto;
-            color: var(--dl-tabs-color-text-disabled);
+            color: var(--yc-color-text-hint);
         }
     }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -38,7 +38,10 @@ export interface TabsProps extends QAProps {
     onSelectTab?(tabId: string, event?: React.MouseEvent): void;
     /** Allows to wrap `TabItem` into another component or render custom tab  */
     wrapTo?(item: TabsItemProps, node: React.ReactNode, index: number): React.ReactNode;
+    /** Switch between default and adjustable tabs */
     adjustable?: boolean;
+    /** Config for AdjustableTabs where the key is the width of the container element, the value is
+     maximum width of tab as a percentage of the container width */
     breakpointsConfig?: Record<string, number>;
 }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -36,6 +36,8 @@ export interface TabsProps extends QAProps {
     onSelectTab?(tabId: string): void;
     /** Allows to wrap `TabItem` into another component or render custom tab  */
     wrapTo?(item: TabsItemProps, node: React.ReactNode, index: number): React.ReactNode;
+    adjustable?: boolean;
+    breakpointsConfig?: Record<string, number>;
 }
 
 export const Tabs = forwardRef<HTMLDivElement, TabsProps>(

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -81,7 +81,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
             return (
                 <AdjustableTabs
                     activeTab={activeTabId}
-                    onSelectTab={onSelectTab}
+                    onSelectTab={handleTabClick}
                     items={items}
                     breakpointsConfig={breakpointsConfig}
                     className={className}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -3,6 +3,7 @@ import {block} from '../utils/cn';
 import {QAProps} from '../types';
 import {TabsItem, TabsItemProps as TabsItemInternalProps} from './TabsItem';
 import './Tabs.scss';
+import AdjustableTabs from './AdjustableTabs';
 
 const b = block('tabs');
 
@@ -33,7 +34,7 @@ export interface TabsProps extends QAProps {
     /** Additional CSS-class */
     className?: string;
     /** Select tab handler */
-    onSelectTab?(tabId: string): void;
+    onSelectTab?(tabId: string, event?: React.MouseEvent): void;
     /** Allows to wrap `TabItem` into another component or render custom tab  */
     wrapTo?(item: TabsItemProps, node: React.ReactNode, index: number): React.ReactNode;
     adjustable?: boolean;
@@ -52,6 +53,8 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
             onSelectTab,
             wrapTo,
             qa,
+            adjustable,
+            breakpointsConfig,
         },
         ref,
     ) => {
@@ -67,11 +70,23 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
             return items[0].id;
         }, [activeTab, allowNotSelected, items]);
 
-        const handleTabClick = (tabId: string) => {
+        const handleTabClick = (tabId: string, event?: React.MouseEvent) => {
             if (onSelectTab) {
-                onSelectTab(tabId);
+                onSelectTab(tabId, event);
             }
         };
+
+        if (adjustable) {
+            return (
+                <AdjustableTabs
+                    activeTab={activeTabId}
+                    onSelectTab={onSelectTab}
+                    items={items}
+                    breakpointsConfig={breakpointsConfig}
+                    className={className}
+                />
+            );
+        }
 
         return (
             <div role="tablist" className={b({direction, size}, className)} data-qa={qa} ref={ref}>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -89,6 +89,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
                     breakpointsConfig={breakpointsConfig}
                     className={className}
                     wrapTo={wrapTo}
+                    size={size}
                 />
             );
         }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -85,6 +85,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
                     items={items}
                     breakpointsConfig={breakpointsConfig}
                     className={className}
+                    wrapTo={wrapTo}
                 />
             );
         }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -2,8 +2,9 @@ import React, {forwardRef, useMemo} from 'react';
 import {block} from '../utils/cn';
 import {QAProps} from '../types';
 import {TabsItem, TabsItemProps as TabsItemInternalProps} from './TabsItem';
-import './Tabs.scss';
 import AdjustableTabs from './AdjustableTabs';
+
+import './Tabs.scss';
 
 const b = block('tabs');
 

--- a/src/components/Tabs/__stories__/Tabs.stories.tsx
+++ b/src/components/Tabs/__stories__/Tabs.stories.tsx
@@ -91,7 +91,14 @@ const Template: Story<
         [args.withIcon, args.withCounter, args.withLabel, args.withOverflow],
     );
 
-    return <Tabs {...args} items={items} onSelectTab={setActiveTab} activeTab={activeTab} />;
+    return (
+        <Tabs
+            {...args}
+            items={args.items || items}
+            onSelectTab={setActiveTab}
+            activeTab={activeTab}
+        />
+    );
 };
 
 const AdjustableTabsTemplate: Story<
@@ -102,15 +109,85 @@ const AdjustableTabsTemplate: Story<
         withOverflow?: boolean;
     }
 > = (args) => {
+    const items: TabsProps['items'] = React.useMemo(
+        () => [
+            {
+                id: 'first',
+                title: 'First Tab Item Long Name',
+                icon: args.withIcon ? gearIcon : undefined,
+                counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,
+                label: args.withLabel ? {content: 'Normal', theme: 'normal'} : undefined,
+                hasOverflow: args.withOverflow,
+                extraProps: {
+                    style: {
+                        maxWidth: args.withOverflow ? '100px' : 'auto',
+                    },
+                },
+            },
+            {
+                id: 'second',
+                title: 'Second Tab',
+                icon: args.withIcon ? gearIcon : undefined,
+                counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,
+                label: args.withLabel ? {content: 'Warning', theme: 'warning'} : undefined,
+                hasOverflow: args.withOverflow,
+                extraProps: {
+                    style: {
+                        maxWidth: args.withOverflow ? '100px' : 'auto',
+                    },
+                },
+            },
+            {
+                id: 'third',
+                title: 'Third Tab Item Long Name',
+                icon: args.withIcon ? gearIcon : undefined,
+                counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,
+                label: args.withLabel ? {content: 'Danger', theme: 'danger'} : undefined,
+                hasOverflow: args.withOverflow,
+                extraProps: {
+                    style: {
+                        maxWidth: args.withOverflow ? '100px' : 'auto',
+                    },
+                },
+            },
+            {
+                id: 'fourth',
+                title: 'Fourth Tab Item Long Name',
+                icon: args.withIcon ? gearIcon : undefined,
+                counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,
+                label: args.withLabel ? {content: 'Danger', theme: 'danger'} : undefined,
+                hasOverflow: args.withOverflow,
+                extraProps: {
+                    style: {
+                        maxWidth: args.withOverflow ? '100px' : 'auto',
+                    },
+                },
+            },
+            {
+                id: 'fifth',
+                title: 'Fifth Tab Item Long Name',
+                icon: args.withIcon ? gearIcon : undefined,
+                counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,
+                label: args.withLabel ? {content: 'Danger', theme: 'danger'} : undefined,
+                hasOverflow: args.withOverflow,
+                extraProps: {
+                    style: {
+                        maxWidth: args.withOverflow ? '100px' : 'auto',
+                    },
+                },
+            },
+        ],
+        [args.withIcon, args.withCounter, args.withLabel, args.withOverflow],
+    );
     const props: TabsProps & {
         withIcon?: boolean;
         withCounter?: boolean;
         withLabel?: boolean;
         withOverflow?: boolean;
-    } = {...args, adjustable: true};
+    } = {...args, adjustable: true, items};
 
     return (
-        <div style={{resize: 'horizontal', overflow: 'auto', width: 340}}>
+        <div style={{resize: 'horizontal', overflow: 'auto', width: 515}}>
             <Template {...props} />
         </div>
     );

--- a/src/components/Tabs/__stories__/Tabs.stories.tsx
+++ b/src/components/Tabs/__stories__/Tabs.stories.tsx
@@ -94,6 +94,28 @@ const Template: Story<
     return <Tabs {...args} items={items} onSelectTab={setActiveTab} activeTab={activeTab} />;
 };
 
+const AdjustableTabsTemplate: Story<
+    TabsProps & {
+        withIcon?: boolean;
+        withCounter?: boolean;
+        withLabel?: boolean;
+        withOverflow?: boolean;
+    }
+> = (args) => {
+    const props: TabsProps & {
+        withIcon?: boolean;
+        withCounter?: boolean;
+        withLabel?: boolean;
+        withOverflow?: boolean;
+    } = {...args, adjustable: true};
+
+    return (
+        <div style={{resize: 'horizontal', overflow: 'auto', width: 340}}>
+            <Template {...props} />
+        </div>
+    );
+};
+
 export const Default = Template.bind({});
 
 Default.argTypes = {
@@ -123,5 +145,29 @@ export const WithWrapTo = Template.bind({});
 WithWrapTo.args = {
     wrapTo(_item: TabsItemProps, node: React.ReactNode) {
         return <a href="#">{node}</a>;
+    },
+};
+
+export const AdjustableTabs = AdjustableTabsTemplate.bind({});
+Default.argTypes = {
+    withIcon: {
+        name: 'Icons',
+        type: 'boolean',
+        default: false,
+    },
+    withCounter: {
+        name: 'Counters',
+        type: 'boolean',
+        default: false,
+    },
+    withLabel: {
+        name: 'Labels',
+        type: 'boolean',
+        default: false,
+    },
+    withOverflow: {
+        name: 'Overflow',
+        type: 'boolean',
+        default: false,
     },
 };

--- a/src/components/Tabs/__stories__/Tabs.stories.tsx
+++ b/src/components/Tabs/__stories__/Tabs.stories.tsx
@@ -112,7 +112,7 @@ const AdjustableTabsTemplate: Story<
     const items: TabsProps['items'] = React.useMemo(
         () => [
             {
-                id: 'first',
+                id: 'active',
                 title: 'First Tab Item Long Name',
                 icon: args.withIcon ? gearIcon : undefined,
                 counter: args.withCounter ? Math.floor(Math.random() * 5 + 1) : undefined,

--- a/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -102,10 +102,10 @@ test('should call onSelectTab on tab click', async () => {
     const tabComponent2 = screen.getByTitle(tabTitle2);
 
     await user.click(tabComponent2);
-    expect(onSelectTabFn).toBeCalledWith(tabId2);
+    expect(onSelectTabFn).toBeCalledWith(tabId2, undefined);
 
     await user.click(tabComponent1);
-    expect(onSelectTabFn).toBeCalledWith(tabId1);
+    expect(onSelectTabFn).toBeCalledWith(tabId1, undefined);
 });
 
 test('should wrap tabs', () => {

--- a/src/components/Tabs/constants.ts
+++ b/src/components/Tabs/constants.ts
@@ -1,0 +1,16 @@
+export const SMALL_CONTAINER_WIDTH_NAME = 'small';
+export const LARGE_CONTAINER_WIDTH_NAME = 'large';
+export const READY_STATE_COMPLETE = 'complete';
+export const OUT_OF_SCREEN_POSITION = -99999;
+export const DEFAULT_BREAKPOINTS_CONFIG = {
+    '400': 33,
+    '500': 30,
+    '700': 27,
+    '800': 26,
+    '900': 25,
+    '1000': 24,
+    '1100': 23,
+    '1200': 22,
+    '1300': 21,
+    '1400': 20,
+};

--- a/src/components/Tabs/i18n/en.json
+++ b/src/components/Tabs/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "label-more": "More {{count}}"
+}

--- a/src/components/Tabs/i18n/en.json
+++ b/src/components/Tabs/i18n/en.json
@@ -1,3 +1,3 @@
 {
-  "label-more": "More {{count}}"
+  "label_more": "More {{count}}"
 }

--- a/src/components/Tabs/i18n/index.ts
+++ b/src/components/Tabs/i18n/index.ts
@@ -1,0 +1,7 @@
+import {registerKeyset} from '../../utils/registerKeyset';
+import en from './en.json';
+import ru from './ru.json';
+
+const COMPONENT = 'Tabs';
+
+export default registerKeyset({en, ru}, COMPONENT);

--- a/src/components/Tabs/i18n/ru.json
+++ b/src/components/Tabs/i18n/ru.json
@@ -1,0 +1,3 @@
+{
+  "label-more": "Еще {{count}}"
+}

--- a/src/components/Tabs/i18n/ru.json
+++ b/src/components/Tabs/i18n/ru.json
@@ -1,3 +1,3 @@
 {
-  "label-more": "Еще {{count}}"
+  "label_more": "Еще {{count}}"
 }


### PR DESCRIPTION
Introduce new way to render Tabs when space is not enough for full bar render. 

AdjustableTabs renders only when respective props (**adjustable**) provided. It will calc the width of container and determine how to hide tabs. 

There are 2 way to do it: 
1. Hide behind the Select
2. Hide behind the More button

Also new optional property was added for tabs - **breakpointsConfig**. It is relevant only for AdjustableTabs and will affect how the free space for tabs will be calculated