### PR TITLE
fix(Icon): use href attribute in <use> element

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -110,9 +110,11 @@ export function Icon({
     }
 
     if (isSpriteData(data)) {
+        const href = Icon.prefix + (data.url || `#${data.id}`);
+
         return (
             <svg {...props} viewBox={viewBox}>
-                <use xlinkHref={Icon.prefix + (data.url || `#${data.id}`)} />
+                <use href={href} xlinkHref={href} />
             </svg>
         );
     }


### PR DESCRIPTION
As stated in https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href xlink:href is deprecated.