### PR TITLE
feat(Popover): let action and cancel buttons to wrap on long text

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -37,6 +37,7 @@ $block: '.#{variables.$ns}popover';
         }
 
         &-buttons {
+            align-self: center;
             display: inline-flex;
             flex-wrap: wrap;
             width: 100%;

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -20,6 +20,8 @@ $block: '.#{variables.$ns}popover';
         --yc-popover-close-margin: 8px;
         --yc-popover-close-size: 24px;
 
+        $buttonGap: 5px;
+
         box-sizing: border-box;
         min-height: 40px;
         max-width: var(--yc-popover-max-width);
@@ -41,13 +43,13 @@ $block: '.#{variables.$ns}popover';
             // giving additional -5 margin
             // this is taking into account the margins of buttons
             // to imitate the `gap` property for flexbox
-            margin: 15px -5px -5px;
+            margin: (20px - $buttonGap) (-$buttonGap) (-$buttonGap);
 
             $buttonClass: #{$class}__tooltip-button;
         }
 
         &-button {
-            margin: 5px;
+            margin: $buttonGap;
             flex: 1;
         }
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -39,10 +39,8 @@ $block: '.#{variables.$ns}popover';
             width: 100%;
             margin-top: 20px;
             $buttonClass: #{$class}__tooltip-button;
-
-            #{$buttonClass}:not(:first-child) {
-                margin-left: 10px;
-            }
+            flex-wrap: wrap;
+            gap: 10px;
         }
 
         &-button {

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -36,14 +36,18 @@ $block: '.#{variables.$ns}popover';
 
         &-buttons {
             display: inline-flex;
-            width: 100%;
-            margin-top: 20px;
-            $buttonClass: #{$class}__tooltip-button;
             flex-wrap: wrap;
-            gap: 10px;
+            width: 100%;
+            // giving additional -5 margin
+            // this is taking into account the margins of buttons
+            // to imitate the `gap` property for flexbox
+            margin: 15px -5px -5px;
+
+            $buttonClass: #{$class}__tooltip-button;
         }
 
         &-button {
+            margin: 5px;
             flex: 1;
         }
 

--- a/src/components/Popover/__stories__/Popover.stories.tsx
+++ b/src/components/Popover/__stories__/Popover.stories.tsx
@@ -155,6 +155,24 @@ FullFeatured.args = {
         'Tooltip\'s <b>html</b> content. Learn more <a href="https://example.com" target="_blank">here</a>',
 };
 
+export const WithLongActionItems = FullFeaturedTemplate.bind({});
+WithLongActionItems.args = {
+    autoclosable: false,
+    content: 'There are two actions',
+    tooltipActionButton: {
+        text: 'Action with moderately long text',
+        onClick: () => alert('Action button was clicked'),
+    },
+    tooltipCancelButton: {
+        text: 'Cancel with moderately long text',
+        onClick: () => alert('Cancel button was clicked'),
+    },
+    className: 'demo-icon-tooltip',
+    openOnHover: false,
+    behavior: PopoverBehavior.Delayed,
+    theme: 'info',
+};
+
 const WithCustomAnchorTemplate: Story = () => <WithCustomAnchorExample />;
 export const WithCustomAnchor = WithCustomAnchorTemplate.bind({});
 WithCustomAnchor.args = {


### PR DESCRIPTION
Currently, the buttons with long text will just break the container
![picutre](https://user-images.githubusercontent.com/48627239/232787869-0aedd85b-9a27-41b2-836d-f79b3f69af71.png)
This pull request fixes this behavour by letting the buttons to wrap and to turn into a coloumn
<img width="429" alt="picture" src="https://user-images.githubusercontent.com/48627239/232788501-15137fd8-c9e2-493d-95c4-2f6e02018768.png">
