### PR TITLE
feat(Popup): add wrapper class name

### DIFF
--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -39,6 +39,7 @@ export interface PopupProps extends DOMProps, LayerExtendableProps, PopperProps,
     container?: HTMLElement;
     restoreFocus?: boolean;
     restoreFocusRef?: React.RefObject<HTMLElement>;
+    wrapperClassName?: string;
 }
 
 const b = block('popup');
@@ -57,6 +58,7 @@ export function Popup({
     disableLayer,
     style,
     className,
+    wrapperClassName,
     modifiers = [],
     children,
     onEscapeKeyDown,
@@ -125,7 +127,7 @@ export function Popup({
                     style={styles.popper}
                     {...attributes.popper}
                     {...containerProps}
-                    className={bWrapper({open})}
+                    className={bWrapper({open}, wrapperClassName)}
                 >
                     <div
                         onClick={onClick}


### PR DESCRIPTION
Prerequisite: to operate z-index for wrapper. 
Real case: project has sticky header and popup wrapper should be under that header. On the other hand, increasing header z-index > 1000 makes it over .yc-modal, that is not suitable too.`wrapperClassName` will allow to set  appropriate z-index.