### PR TITLE
docs: fixed typo in "must" word

### DIFF
--- a/src/components/layout/Col/Col.tsx
+++ b/src/components/layout/Col/Col.tsx
@@ -17,7 +17,7 @@ export interface ColProps extends MediaPartial<ColSize> {
 
 /**
  * How many columns of you 12-th column layout will take content.
- * Mast be used as a child of `Row` component.
+ * Must be used as a child of `Row` component.
  *
  * By default component takes all available space.
  * If you wont to specify static size to all media queries use `s` prop. In mobile first layout grid is first passible value.

--- a/src/components/layout/Container/Container.tsx
+++ b/src/components/layout/Container/Container.tsx
@@ -40,7 +40,7 @@ export interface ContainerProps {
 /**
  * Center you content in horizontal direction.
  *
- * > In most cases mast be one on the page.
+ * > In most cases must be one on the page.
  *
  * ```tsx
  * import {Container, Row, Col} from '@gravity-ui/uikit';

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -80,7 +80,7 @@ export interface LayoutTheme {
     /**
      * Override default breakpoints values.
      *
-     * @important **you mast override corresponding scss variables**
+     * @important **you must override corresponding scss variables**
      */
     breakpoints: MediaProps<number>;
     /**


### PR DESCRIPTION
There were some typos in docs/code comments ("mast" instead of "must")

By the way, there is [code spell checker plugin](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) for VSCode

---

I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=ru).