### PR TITLE
fix(Select): align items by baseline for label and values

### DIFF
--- a/src/components/Select/components/SelectControl/SelectControl.scss
+++ b/src/components/Select/components/SelectControl/SelectControl.scss
@@ -22,6 +22,7 @@ $buttonBlock: '.#{variables.$ns}button';
 
     & #{$buttonBlock}__text {
         display: flex;
+        align-items: baseline;
     }
 
     &__label {


### PR DESCRIPTION
Due to SelectControl label font-weight, label and value don't align correctly

Before
![Screen Shot 2023-05-11 at 17 16 06](https://github.com/gravity-ui/uikit/assets/67755036/eb16344f-1323-4946-92df-b161a864f48d)

After
![Screen Shot 2023-05-11 at 17 16 37](https://github.com/gravity-ui/uikit/assets/67755036/c721a2ca-1ded-4aa9-8f19-c30a0e4786c3)

