### PR TITLE
feat(Layout): stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,6 @@
             "require": "./build/cjs/toaster-singleton-react-18.js",
             "import": "./build/esm/toaster-singleton-react-18.js"
         },
-        "./unstable_layout": {
-            "types": "./build/esm/unstable_layout.d.ts",
-            "require": "./build/cjs/unstable_layout.js",
-            "import": "./build/esm/unstable_layout.js"
-        },
         "./styles/*": "./styles/*"
     },
     "main": "./build/cjs/index.js",
@@ -43,9 +38,6 @@
             ],
             "toaster-singleton-react-18": [
                 "./build/esm/toaster-singleton-react-18.d.ts"
-            ],
-            "unstable_layout": [
-                "./build/esm/unstable_layout.d.ts"
             ]
         }
     },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -48,6 +48,7 @@ export * from './Toaster';
 export * from './Tooltip';
 export * from './User';
 export * from './UserAvatar';
+export * from './layout';
 
 export * from './utils/class-transform';
 export * from './utils/event-broker';

--- a/src/components/layout/Col/Col.tsx
+++ b/src/components/layout/Col/Col.tsx
@@ -36,6 +36,8 @@ export interface ColProps extends MediaPartial<ColSize> {
  *  <Col s="2" l="1">col 2</Col>
  * </Row>
  * ```
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#col
  */
 export const Col = ({children, style, className, ...media}: ColProps) => {
     const mods = Object.entries(media).reduce<Record<string, string>>((acc, [mod, modSize]) => {

--- a/src/components/layout/Col/__stories__/Col.stories.tsx
+++ b/src/components/layout/Col/__stories__/Col.stories.tsx
@@ -7,7 +7,7 @@ import {Container} from '../../Container/Container';
 import {Row} from '../../Row/Row';
 
 export default {
-    title: 'Layout (unstable)/Col',
+    title: 'Layout/Col',
     component: Col,
 } as Meta;
 

--- a/src/components/layout/Container/Container.tsx
+++ b/src/components/layout/Container/Container.tsx
@@ -56,6 +56,8 @@ export interface ContainerProps {
  *  </Row>
  * </Container>
  * ```
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#container
  */
 export const Container = ({
     children,

--- a/src/components/layout/Container/__stories__/Container.stories.tsx
+++ b/src/components/layout/Container/__stories__/Container.stories.tsx
@@ -6,7 +6,7 @@ import {Box, LayoutPresenter} from '../../demo';
 import {Row} from '../../Row/Row';
 
 export default {
-    title: 'Layout (unstable)/Container',
+    title: 'Layout/Container',
     component: Container,
 } as Meta;
 

--- a/src/components/layout/Container/useContainerThemeProps.ts
+++ b/src/components/layout/Container/useContainerThemeProps.ts
@@ -24,8 +24,6 @@ export const useContainerThemeProps = () => {
 
     const containerThemeProps = React.useMemo(
         () => ({
-            ...pickContainerProps(theme.common),
-            ...pickContainerProps(getClosestMediaProps(theme.common?.media)),
             ...pickContainerProps(theme.components?.container),
             ...pickContainerProps(getClosestMediaProps(theme.components?.container?.media)),
         }),

--- a/src/components/layout/Flex/Flex.tsx
+++ b/src/components/layout/Flex/Flex.tsx
@@ -112,6 +112,8 @@ export interface FlexProps<T extends React.ElementType = 'div'> extends QAProps 
  *  {...}
  * </Flex>
  * ```
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#flex
  */
 export const Flex = React.forwardRef(function Flex<T extends React.ElementType = 'div'>(
     props: Omit<FlexProps<T>, 'ref'>,

--- a/src/components/layout/Flex/__stories__/Flex.stories.tsx
+++ b/src/components/layout/Flex/__stories__/Flex.stories.tsx
@@ -9,7 +9,7 @@ import {Text} from '../../../Text';
 import {Button} from '../../../Button/Button';
 
 export default {
-    title: 'Layout (unstable)/Flex',
+    title: 'Layout/Flex',
     component: Flex,
 } as Meta;
 

--- a/src/components/layout/LayoutProvider/LayoutProvider.tsx
+++ b/src/components/layout/LayoutProvider/LayoutProvider.tsx
@@ -16,6 +16,8 @@ interface LayoutProviderProps {
 
 /**
  * Provide context for layout components and current media queries.
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#layoutprovider-and-layouttheme
  */
 export const LayoutProvider: React.FC<LayoutProviderProps> = ({
     children,

--- a/src/components/layout/LayoutProvider/__stories__/Layout.docs.mdx
+++ b/src/components/layout/LayoutProvider/__stories__/Layout.docs.mdx
@@ -1,11 +1,11 @@
 import {ArgsTable} from '@storybook/addon-docs';
 
-# Layout Components (unstable)
+# Layout Components
 
 Components to describe relations between elements on the page.
 
 ```tsx
-import {Container, Row, Col, Flex} from '@gravity-ui/uikit/unstable_layout';
+import {Container, Row, Col, Flex} from '@gravity-ui/uikit';
 
 <Container>
     <Row space="5">
@@ -23,17 +23,6 @@ import {Container, Row, Col, Flex} from '@gravity-ui/uikit/unstable_layout';
 
 **All components supports `jsdoc` on hover feature. Just hover over the component or components prop in you favorite editor to see documentation**
 
-### How to start using?
-
-Just wrap you app with `LayoutProvider`.
-
-```tsx
-import {LayoutProvider} from '@gravity-ui/uikit/unstable_layout';
-
-<LayoutProvider>
-    <App />
-</LayoutProvider>;
-```
 
 ### Base concepts:
 
@@ -84,7 +73,7 @@ _You can override default values on project level:_
 ```
 
 ```tsx
-import {LayoutProvider, LayoutTheme} from '@gravity-ui/uikit/unstable_layout';
+import {LayoutProvider, LayoutTheme} from '@gravity-ui/uikit';
 
 const layoutTheme: LayoutTheme = {
     spaceBaseSize: 5,
@@ -106,7 +95,7 @@ Very often during developing process you have to specify relative position betwe
 For such purposes, you can use `spacing` utility to generate predefined class names:
 
 ```tsx
-import {spacing} from '@gravity-ui/uikit/unstable_layout';
+import {spacing} from '@gravity-ui/uikit';
 
 <>
     <Button className={spacing({mr: 5})}>button 1</Button>
@@ -131,9 +120,7 @@ We use `mobile-first` approach. It means that you should adapt you app to deskto
 
 Through `LayoutProvider` components can get default props which are corresponding to different screen sizes.
 
-Also you can manage `spacings` in `LayoutTheme` and override default behavior in specific screen size.
-
-In most cases you can use layout components without common props specified directly
+Usage of `LayoutProvider` is optional. Use it if you need to override default spacing or add default behaviour to connected to theme compoennts (now only `Container`)
 
 ### props:
 
@@ -141,19 +128,9 @@ In most cases you can use layout components without common props specified direc
 -   `initialMediaQuery` - use can directly pass initial
 
 ```tsx
-import {LayoutProvider, LayoutTheme} from '@gravity-ui/uikit/unstable_layout';
+import {LayoutProvider, LayoutTheme} from '@gravity-ui/uikit';
 
 export const APP_LAYOUT_THEME: LayoutTheme = {
-    common: {
-        // default prop for all screen size
-        space: '3',
-        media: {
-            l: {
-                // override value starting from `l` breakpoint
-                space: '5',
-            },
-        },
-    },
     spaceBaseSize: 4,
     components: {
         container: {
@@ -182,7 +159,7 @@ Base components to describe 12-th column layout grid for you app.
 Supports nested grids. This should be used when you have mobile and desktop app versions.
 
 ```tsx
-import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
+import {Row, Col} from '@gravity-ui/uikit';
 
 <Row space="5">
     <Col s="4">...</Col>
@@ -212,7 +189,7 @@ props:
 > To specify col value to all screen sizes use `s` (`small` - also you can think about this props as a `size`) prop
 
 ```tsx
-import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
+import {Row, Col} from '@gravity-ui/uikit';
 
 <Row
     /**
@@ -254,7 +231,7 @@ Css `Flexbox` model representation in `jsx` world. Has build in `spacing` to man
 -   space between children components in row direction
 
 ```jsx
-import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
+import {Row, Col} from '@gravity-ui/uikit';
 
 <Flex space="5">
     <TextInput />
@@ -265,7 +242,7 @@ import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
 -   nested `Flex` example
 
 ```jsx
-import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
+import {Row, Col} from '@gravity-ui/uikit';
 
 <Flex direction="column" space="5">
     <Flex space="5">
@@ -279,7 +256,7 @@ import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
 -   responsible example
 
 ```jsx
-import {Row, Col} from '@gravity-ui/uikit/unstable_layout';
+import {Row, Col} from '@gravity-ui/uikit';
 
 <Flex
     // direction: column will be applied to l, xl, xxl, xxxl screen sizes here
@@ -304,7 +281,7 @@ returns the following methods and objects:
     > Note: `s` breakpoint starts from `0px` and and's with `m (768px) - 1px`
 
 ```tsx
-import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+import {useLayoutContext} from '@gravity-ui/uikit';
 
 const Component = () => {
     const {activeMediaQuery} = useLayoutContext();
@@ -322,7 +299,7 @@ const Component = () => {
 -   `isMediaActive` - returns a boolean value if the passed value is equal to or greater than the currently active media expression. It is necessary to describe the logic of adaptive behavior of elements taking into account the mobile-first approach
 
 ```tsx
-import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+import {useLayoutContext} from '@gravity-ui/uikit';
 
 // this example of code will be shown on l, xl, xxl and xxxl screen sizes
 const Component = () => {
@@ -337,7 +314,7 @@ const Component = () => {
 -   `getClosestMediaProps` - it works in a similar way to is Media Active, only it takes map as an argument in the keys of screen resolutions. Returns the nearest available key value taking into account the mobile first approach.
 
 ```tsx
-import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+import {useLayoutContext} from '@gravity-ui/uikit';
 
 const mapOfPropsByScreen = {
     s: "i'm will be shown on 's' and 'n' screen size",

--- a/src/components/layout/LayoutProvider/__stories__/Layout.stories.tsx
+++ b/src/components/layout/LayoutProvider/__stories__/Layout.stories.tsx
@@ -3,8 +3,8 @@ import {Meta, Story} from '@storybook/react';
 import Docs from './Layout.docs.mdx';
 
 export default {
-    title: 'Layout (unstable)',
-    id: 'Layout (unstable)',
+    title: 'Layout',
+    id: 'Layout',
     parameters: {
         order: -100,
         docs: {

--- a/src/components/layout/Row/Row.tsx
+++ b/src/components/layout/Row/Row.tsx
@@ -36,6 +36,8 @@ export interface RowProps {
  *  <Col>col</Col>
  * </Row>
  * ```
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#row
  */
 export const Row = ({children, style, className, space, spaceRow}: RowProps) => {
     const {getClosestMediaProps} = useLayoutContext();

--- a/src/components/layout/Row/__stories__/Row.stories.tsx
+++ b/src/components/layout/Row/__stories__/Row.stories.tsx
@@ -5,7 +5,7 @@ import {Col} from '../../Col/Col';
 import {Box, LayoutPresenter} from '../../demo';
 
 export default {
-    title: 'Layout (unstable)/Row',
+    title: 'Layout/Row',
     component: Row,
 } as Meta;
 

--- a/src/components/layout/constants.ts
+++ b/src/components/layout/constants.ts
@@ -15,14 +15,6 @@ export const DEFAULT_LAYOUT_THEME: LayoutTheme = {
         xxxl: 1920,
     },
     spaceBaseSize: 4,
-    common: {
-        space: '3',
-        media: {
-            l: {
-                space: '5',
-            },
-        },
-    },
     components: {
         container: {
             gutters: '3',

--- a/src/components/layout/hooks/useLayoutContext.ts
+++ b/src/components/layout/hooks/useLayoutContext.ts
@@ -11,7 +11,7 @@ interface ComputedMediaContext {
      *  > Note: `s` breakpoint starts from `0px` and and's with `m` - 1px
      *
      * ```tsx
-     * import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+     * import {useLayoutContext} from '@gravity-ui/uikit';
      *
      * const Component = () => {
      *  const {activeMediaQuery} = useLayoutContext();
@@ -31,7 +31,7 @@ interface ComputedMediaContext {
      * Returns a boolean value if the passed value is equal to or greater than the currently active media expression.
      * It is necessary to describe the logic of adaptive behavior of elements taking into account the mobile-first approach
      * ```tsx
-     * import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+     * import {useLayoutContext} from '@gravity-ui/uikit';
      *
      * // this example of code will be shown on l, xl, xxl and xxxl screen sizes
      * const Component = () => {
@@ -49,7 +49,7 @@ interface ComputedMediaContext {
      * Returns the nearest available key value taking into account the mobile first approach.
      *
      * ```tsx
-     * import {useLayoutContext} from '@gravity-ui/uikit/unstable_layout';
+     * import {useLayoutContext} from '@gravity-ui/uikit';
      *
      * const mapOfPropsByScreen = {
      *  s: "i'm will be shown on 's' and 'n' screen size",
@@ -69,6 +69,8 @@ interface ComputedMediaContext {
 
 /**
  * Quick access to theme and helpers to work with media queries
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#uselayoutcontext
  */
 export const useLayoutContext = (): ComputedMediaContext => {
     const {activeMediaQuery, theme} = React.useContext(LayoutContext);

--- a/src/components/layout/spacing/spacing.tsx
+++ b/src/components/layout/spacing/spacing.tsx
@@ -72,6 +72,8 @@ export interface SpacingProps {
 
 /**
  * Utility to generate predefined css classes to describe position between components
+ * ---
+ * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#spacing-utility
  */
 export const spacing = (props: SpacingProps, className?: string) => {
     const classes: string[] = [];

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -91,10 +91,6 @@ export interface LayoutTheme {
      */
     spaceBaseSize: number;
     /**
-     * Common props, that can you all layout components
-     */
-    common: WithMedia<CommonProps>;
-    /**
      * Components props build in into the theme. You can describe the props depending on the current media expression
      */
     components: ComponentProps;


### PR DESCRIPTION
- remove `./unstable_layout` bundle
- remove unused section with common props in LayoutTheme. Now you need pass directly props in corresponding component (only `Container` now);
- added links to storybook docs from `jsdoc` on hover in each component

Note: may be in this pr should not remove `./unstable_layout` bundle and remove it on next major realease