### PR TITLE
fix(Select): fixed behaviour of isOptionMatchedByFilter

### DIFF
--- a/src/components/Select/utils.tsx
+++ b/src/components/Select/utils.tsx
@@ -215,7 +215,7 @@ const isOptionMatchedByFilter = (option: SelectOption, filter: string) => {
     const lowerOptionText = getOptionText(option).toLocaleLowerCase();
     const lowerFilter = filter.toLocaleLowerCase();
 
-    return Boolean(lowerOptionText.match(lowerFilter));
+    return lowerOptionText.indexOf(lowerFilter) !== -1;
 };
 
 const isGroupTitle = (option?: FlattenOption): option is GroupTitleItem => {


### PR DESCRIPTION
We had an issue with behaviour of filter in Select component. Problem is: it used String::match, which converted string argument into new RegEx without screening of functional characters, hence it crashed web page in case you type `[` or `(` into filter prompt.