### PR TITLE
fix(useListNavigation): remove navigation with right and left arrows

### DIFF
--- a/src/components/utils/useListNavigation/README.md
+++ b/src/components/utils/useListNavigation/README.md
@@ -2,8 +2,8 @@
 
 React hook used to navigate through the items in a list
 
-`ArrowDown`, `ArrowRight` will increase currently active item index
-`ArrowUp`, `ArrowLeft` will reduce currently active item index
+`ArrowDown` will increase currently active item index
+`ArrowUp` will reduce currently active item index
 `PageDown` will increase currently active item index by pageSize (works if `pageSize` passed)
 `PageUp` will reduce currently active item index by pageSize (works if `pageSize` passed)
 `Home` will navigate to the start of the list if `processHomeKey` (disable if you want to move the cursor to the start of active input on `Home` key, for example)

--- a/src/components/utils/useListNavigation/useListNavigation.ts
+++ b/src/components/utils/useListNavigation/useListNavigation.ts
@@ -60,8 +60,7 @@ export function useListNavigation<ItemType, AnchorType extends HTMLElement>({
             }
 
             switch (event.key) {
-                case 'ArrowDown':
-                case 'ArrowRight': {
+                case 'ArrowDown': {
                     event.preventDefault();
 
                     // Go 1 step forward
@@ -71,8 +70,7 @@ export function useListNavigation<ItemType, AnchorType extends HTMLElement>({
 
                     break;
                 }
-                case 'ArrowUp':
-                case 'ArrowLeft': {
+                case 'ArrowUp': {
                     event.preventDefault();
 
                     // Go 1 step back


### PR DESCRIPTION
Navigation with right/left arrows breaks the behaviour of cursor navigation,  so better to disable it for all the lists