### PR TITLE
feat(LayerManager): export getLayersCount

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -65,3 +65,4 @@ export {useOnFocusOutside} from './utils/useOnFocusOutside';
 export * from './utils/interactions';
 export * from './utils/xpath';
 export * from './utils/useFileInput/useFileInput';
+export {getLayersCount} from './utils/LayerManager';

--- a/src/components/utils/LayerManager.ts
+++ b/src/components/utils/LayerManager.ts
@@ -158,3 +158,7 @@ class LayerManager {
 }
 
 export const layerManager = new LayerManager();
+
+export const getLayersCount = () => {
+    return layerManager.getLayersCount();
+};


### PR DESCRIPTION
In order to create idle Popups in common, I need a way to determine in render-time whether current layer stack is empty (so that idle popup can start rendering). Even though I can subscribe to `layerschange` with event broker, there is no way to know if stack is initially empty. 