### PR TITLE
fix(Table): fix copying the array from getRowClassNames

### DIFF
--- a/src/components/Table/hoc/withTableSelection/withTableSelection.tsx
+++ b/src/components/Table/hoc/withTableSelection/withTableSelection.tsx
@@ -203,7 +203,9 @@ export function withTableSelection<I extends TableDataItem, E extends {} = {}>(
             (getRowClassNames?: (item: I, index: number) => string[]) => {
                 return (item: I, index: number) => {
                     const {selectedIds} = this.props;
-                    const classNames = getRowClassNames ? getRowClassNames(item, index) : [];
+                    const classNames = getRowClassNames
+                        ? getRowClassNames(item, index).slice()
+                        : [];
                     const id = Table.getRowId(this.props, item, index);
                     const selected = selectedIds.includes(id);
 


### PR DESCRIPTION
Mutating `classNames` array with `push` can cause problems in cases where the `getRowClassNames` function isn't pure and gets it's return value from the outer scope.
e.g.
```ts
const classNames = ["foo-row"];
const getRowClassNames = () => classNames;

const TableWithSelection = withTableSelection(Table);

const Component = () => {
  // ...
  return <TableWithSelection {...props} getRowClassNames={getRowClassNames} />;
}
```
The example above results in rows having `row_selected` class even after being removed from `selectedIds` 