### PR TITLE
fix(TextInput): fix inside error display

### DIFF
--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -92,6 +92,7 @@ $block: '.#{variables.$ns}text-input';
     }
 
     &__error-icon {
+        box-sizing: content-box;
         color: var(--g-color-text-danger);
         padding: var(--_--text-input-error-icon-padding);
     }


### PR DESCRIPTION
If `* {box-sizing: border-box}` style is applied then we got this:

![image](https://github.com/gravity-ui/uikit/assets/3368839/db4c5535-8410-4230-ad1b-58e75c705d99)