### PR TITLE
feat(withTableSorting): add control the use of data sorting

### DIFF
--- a/src/components/Table/hoc/withTableSorting/withTableSorting.tsx
+++ b/src/components/Table/hoc/withTableSorting/withTableSorting.tsx
@@ -28,6 +28,7 @@ export interface WithTableSortingProps {
     defaultSortState?: SortState;
     sortState?: SortState;
     onSortStateChange?: (sortState: SortState) => void;
+    disableDataSorting?: boolean;
 }
 
 interface WithTableSortingState {
@@ -73,10 +74,10 @@ export function withTableSorting<I extends TableDataItem, E extends {} = {}>(
         }
 
         private getSortedData() {
-            const {data, columns} = this.props;
+            const {data, columns, disableDataSorting = this.isControlledState()} = this.props;
             const sortState = this.getSortState();
 
-            if (this.isControlledState() || sortState.length === 0) {
+            if (disableDataSorting || sortState.length === 0) {
                 return data;
             }
 
@@ -195,10 +196,12 @@ export function withTableSorting<I extends TableDataItem, E extends {} = {}>(
         private handleSortStateChange(newSortState: SortState) {
             const {onSortStateChange} = this.props;
 
-            if (this.isControlledState()) {
-                onSortStateChange!(newSortState);
-            } else {
+            if (!this.isControlledState()) {
                 this.setState({sort: newSortState});
+            }
+
+            if (onSortStateChange) {
+                onSortStateChange(newSortState);
             }
         }
 


### PR DESCRIPTION
The method `isControlledState()` in this HOC is for determining whether the `sortState` is provided externally or not. It shouldn't turn off the whole sorting as it does in this case making the whole HOC useless.