### PR TITLE
docs(Skeleton): default story is not visible

### DIFF
--- a/src/components/Skeleton/__stories__/Skeleton.stories.tsx
+++ b/src/components/Skeleton/__stories__/Skeleton.stories.tsx
@@ -15,5 +15,9 @@ export default {
 const DefaultTemplate: StoryFn<SkeletonProps> = (args) => <Skeleton {...args} />;
 export const Default = DefaultTemplate.bind({});
 
+Default.args = {
+    style: {height: 30},
+};
+
 const ShowcaseTemplate: StoryFn = () => <SkeletonShowcase />;
 export const Showcase = ShowcaseTemplate.bind({});


### PR DESCRIPTION
issue: https://github.com/gravity-ui/uikit/issues/969

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.