### PR TITLE
fix(Tabs): tab outline focus is stripped

### DIFF
--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -84,6 +84,7 @@ $block: '.#{variables.$ns}tabs';
         &:focus {
             #{$block}__item-content {
                 outline: 2px solid var(--g-color-line-focus);
+                outline-offset: -2px;
             }
         }
 


### PR DESCRIPTION
Fixes #1048 
Before: 
![image](https://github.com/gravity-ui/uikit/assets/3332159/18fd1f57-c909-4898-abd2-7ed09f551d08)
After PR:
![image](https://github.com/gravity-ui/uikit/assets/3332159/e776ec2f-9366-44ad-adfd-773fd1cd6d24)
