### PR TITLE
fix(Popup): position render

### DIFF
--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -82,6 +82,7 @@ export function Popup({
     autoFocus = false,
 }: PopupProps) {
     const containerRef = React.useRef<HTMLDivElement>(null);
+    const [inTransition, setInTransition] = React.useState(true);
 
     useLayer({
         open,
@@ -132,37 +133,46 @@ export function Popup({
             >
                 <div
                     ref={handleRef}
-                    style={styles.popper}
+                    style={{
+                        ...styles.popper,
+                        transitionProperty: 'transform',
+                        transitionDuration: '1ms',
+                    }}
                     {...attributes.popper}
                     {...containerProps}
                     className={b({open}, className)}
                     data-qa={qa}
                     id={id}
                     role={role}
+                    onTransitionEnd={() => {
+                        setInTransition(false);
+                    }}
                 >
-                    <FocusTrap enabled={focusTrap && open} disableAutoFocus={!autoFocus}>
-                        {/* The onClick event handler is deprecated and should be removed */}
-                        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-                        <div
-                            onClick={onClick}
-                            onMouseEnter={onMouseEnter}
-                            onMouseLeave={onMouseLeave}
-                            onFocus={onFocus}
-                            onBlur={onBlur}
-                            className={b('content', contentClassName)}
-                            style={style}
-                            tabIndex={-1}
-                        >
-                            {hasArrow && (
-                                <PopupArrow
-                                    styles={styles.arrow}
-                                    attributes={attributes.arrow}
-                                    setArrowRef={setArrowRef}
-                                />
-                            )}
-                            {children}
-                        </div>
-                    </FocusTrap>
+                    {inTransition ? undefined : (
+                        <FocusTrap enabled={focusTrap && open} disableAutoFocus={!autoFocus}>
+                            {/* The onClick event handler is deprecated and should be removed */}
+                            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+                            <div
+                                onClick={onClick}
+                                onMouseEnter={onMouseEnter}
+                                onMouseLeave={onMouseLeave}
+                                onFocus={onFocus}
+                                onBlur={onBlur}
+                                className={b('content', contentClassName)}
+                                style={style}
+                                tabIndex={-1}
+                            >
+                                {hasArrow && (
+                                    <PopupArrow
+                                        styles={styles.arrow}
+                                        attributes={attributes.arrow}
+                                        setArrowRef={setArrowRef}
+                                    />
+                                )}
+                                {children}
+                            </div>
+                        </FocusTrap>
+                    )}
                 </div>
             </CSSTransition>
         </Portal>

--- a/src/components/Popup/__stories__/Popup.stories.tsx
+++ b/src/components/Popup/__stories__/Popup.stories.tsx
@@ -127,3 +127,66 @@ export const Position: StoryFn<PopupProps> = (args) => {
         </div>
     );
 };
+
+export const PopupInPopup: StoryFn<PopupProps> = (props: PopupProps) => {
+    const anchorRef = React.useRef<HTMLButtonElement>(null);
+    const anotherAnchorRef = React.useRef<HTMLDivElement>(null);
+
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <React.Fragment>
+            <Popup {...props} open={open} anchorRef={anchorRef} onClose={() => setOpen(false)}>
+                <div style={{padding: 10}} ref={anotherAnchorRef}>
+                    Popup content
+                </div>
+                <Popup {...props} open={open} anchorRef={anotherAnchorRef}>
+                    <div style={{padding: 10}}>Popup content</div>
+                </Popup>
+            </Popup>
+            <div
+                style={{
+                    width: '100%',
+                    height: 200,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                <Button ref={anchorRef} onClick={() => setOpen(!open)}>
+                    {open ? 'Hide' : 'Show'}
+                </Button>
+            </div>
+        </React.Fragment>
+    );
+};
+
+export const TextinputInPopup: StoryFn<PopupProps> = (props: PopupProps) => {
+    const anchorRef = React.useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <React.Fragment>
+            <Popup {...props} open={open} anchorRef={anchorRef} onClose={() => setOpen(false)}>
+                <TextInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                    id="suggest-1"
+                />
+            </Popup>
+            <div
+                style={{
+                    width: '100%',
+                    height: 200,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                <Button ref={anchorRef} onClick={() => setOpen(!open)}>
+                    {open ? 'Hide' : 'Show'}
+                </Button>
+            </div>
+        </React.Fragment>
+    );
+};


### PR DESCRIPTION
When rendering popup to popup, the internal popup loses its position. 
The position of the browser autocomplete is also lost when placing forms in the popup.
Trying to solve this problem using the `onTransitionEnd` event.