### PR TITLE
feat!: rename theme prop `positive` -> `success`

### DIFF
--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -72,7 +72,7 @@ describe('Alert', () => {
         expect(container).toMatchSnapshot();
     });
 
-    test.each<AlertTheme>(['danger', 'info', 'positive', 'success', 'warning'])(
+    test.each<AlertTheme>(['danger', 'info', 'success', 'warning'])(
         'render correct icon if not normal theme',
         async (theme) => {
             const {container} = render(

--- a/src/components/Alert/AlertIcon.tsx
+++ b/src/components/Alert/AlertIcon.tsx
@@ -29,10 +29,6 @@ const typeToIcon: Record<
         filled: CircleInfoFill,
         outlined: CircleInfo,
     },
-    positive: {
-        filled: CircleCheckFill,
-        outlined: CircleCheck,
-    },
     success: {
         filled: CircleCheckFill,
         outlined: CircleCheck,

--- a/src/components/Alert/__stories__/Alert.stories.tsx
+++ b/src/components/Alert/__stories__/Alert.stories.tsx
@@ -54,7 +54,7 @@ const stories: AlertProps[] = [
     {
         title,
         message,
-        theme: 'positive',
+        theme: 'success',
         view: 'outlined',
         actions: (
             <Alert.Actions>
@@ -67,7 +67,7 @@ const stories: AlertProps[] = [
     {
         title,
         message,
-        theme: 'positive',
+        theme: 'success',
         view: 'filled',
 
         actions: [{text: right, handler: console.log}],

--- a/src/components/Alert/types.ts
+++ b/src/components/Alert/types.ts
@@ -1,12 +1,6 @@
 import type React from 'react';
 
-export type AlertTheme =
-    | 'normal'
-    | 'info'
-    | 'success'
-    | /** @deprecated */ 'positive'
-    | 'warning'
-    | 'danger';
+export type AlertTheme = 'normal' | 'info' | 'success' | 'warning' | 'danger';
 export type AlertView = 'filled' | 'outlined';
 export type AlertCorners = 'rounded' | 'square';
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -128,7 +128,6 @@ $block: '.#{variables.$ns}card';
             }
         }
 
-        &#{$block}_theme_positive,
         &#{$block}_theme_success {
             &#{$block}_view_outlined {
                 border: 1px solid var(--g-color-line-positive);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -12,13 +12,7 @@ type SelectionCardView = 'outlined' | 'clear';
 type ContainerCardView = 'outlined' | 'filled' | 'raised';
 
 export type CardType = 'selection' | 'action' | 'container';
-export type CardTheme =
-    | 'normal'
-    | 'info'
-    | 'success'
-    | /** @deprecated */ 'positive'
-    | 'warning'
-    | 'danger';
+export type CardTheme = 'normal' | 'info' | 'success' | 'warning' | 'danger';
 export type CardView = SelectionCardView | ContainerCardView;
 export type CardSize = 'm' | 'l';
 

--- a/src/components/Card/__tests__/Card.test.tsx
+++ b/src/components/Card/__tests__/Card.test.tsx
@@ -12,7 +12,7 @@ const cardText = 'Some text';
 
 const cardSizes: CardSize[] = ['l', 'm'];
 
-const cardThemes: CardTheme[] = ['danger', 'info', 'normal', 'success', 'positive', 'warning'];
+const cardThemes: CardTheme[] = ['danger', 'info', 'normal', 'success', 'warning'];
 
 const cardTypes: CardType[] = ['action', 'container', 'selection'];
 


### PR DESCRIPTION
Closes #987 