### PR TITLE
fix(Table): fixed checkbox max width

### DIFF
--- a/src/components/Table/hoc/withTableSelection/withTableSelection.scss
+++ b/src/components/Table/hoc/withTableSelection/withTableSelection.scss
@@ -1,9 +1,12 @@
 @use '../../variables';
 
+$checkboxWidth: 17px;
+
 #{variables.$block} {
     &__checkbox_cell {
         position: relative;
-        min-width: 17px;
+        min-width: $checkboxWidth;
+        width: $checkboxWidth;
     }
 
     &__selection-checkbox {


### PR DESCRIPTION
Fixed a issue where when the table was stretched, the checkbox also started to stretch