### PR TITLE
fix(Select): activate first clickable item

### DIFF
--- a/src/components/Select/__stories__/SelectShowcase.tsx
+++ b/src/components/Select/__stories__/SelectShowcase.tsx
@@ -190,8 +190,8 @@ export const SelectShowcase = (props: SelectProps) => {
                 code={[EXAMPLE_DISABLED_OPTIONS]}
                 selectProps={props}
             >
-                <Select.Option value="val1" content="Value1" />
-                <Select.Option value="val2" content="Value2" disabled />
+                <Select.Option value="val1" content="Value1" disabled />
+                <Select.Option value="val2" content="Value2" />
                 <Select.Option value="val3" content="Value3" disabled />
                 <Select.Option value="val4" content="Value4" />
             </ExampleItem>

--- a/src/components/Select/utils.tsx
+++ b/src/components/Select/utils.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {KeyCode} from '../../constants';
-import type {List, ListItemData} from '../List';
+import {List, type ListItemData} from '../List';
 
 import {GROUP_ITEM_MARGIN_TOP, MOBILE_ITEM_HEIGHT, SIZE_TO_ITEM_HEIGHT} from './constants';
 import type {Option, OptionGroup} from './tech-components';
@@ -210,8 +210,7 @@ export const getActiveItem = (listRef: React.RefObject<List<FlattenOption>>) => 
 
 export const activateFirstClickableItem = (listRef: React.RefObject<List<FlattenOption>>) => {
     const items = getListItems(listRef);
-    const isGroupTitleFirstItem = items[0] && 'label' in items[0];
-    listRef?.current?.activateItem(isGroupTitleFirstItem ? 1 : 0, false);
+    listRef?.current?.activateItem(List.findNextIndex(items, 0, 1), false);
 };
 
 const isOptionMatchedByFilter = (option: SelectOption, filter: string) => {

--- a/src/components/Select/utils.tsx
+++ b/src/components/Select/utils.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import {KeyCode} from '../../constants';
-import {List, type ListItemData} from '../List';
+import {List} from '../List';
+import type {ListItemData} from '../List';
 
 import {GROUP_ITEM_MARGIN_TOP, MOBILE_ITEM_HEIGHT, SIZE_TO_ITEM_HEIGHT} from './constants';
 import type {Option, OptionGroup} from './tech-components';


### PR DESCRIPTION
Issue: the `activateFirstClickableItem` is not working properly. It activates the item if it is in the first place and in the disabled state.