### PR TITLE
feat(Text): add `id` prop

### DIFF
--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -167,6 +167,7 @@ LANDING_BLOCK-->
 | :--------- | :------------------------------------------------------ | :--------------------------------------: | :--------: |
 | children   | Text content                                            |            `React.ReactNode`             |            |
 | className  | HTML `class` attribute                                  |                 `string`                 |            |
+| id         | HTML `id` attribute                                     |                 `string`                 |            |
 | as         | Ability to override default html tag                    |         `React.ElementType<any>`         |            |
 | style      | HTML `style` attribute                                  |          `React.CSSProperties`           |            |
 | variant    | Font of the text                                        |                 `string`                 | `"body-1"` |

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -14,6 +14,7 @@ export interface TextProps extends TextBaseProps, ColorTextBaseProps, QAProps {
     as?: keyof JSX.IntrinsicElements;
     style?: React.CSSProperties;
     className?: string;
+    id?: string;
     children?: React.ReactNode;
     title?: string;
 }


### PR DESCRIPTION
`id` often required to use with `aria-labelledby` attribute