### PR TITLE
Add hook sync with local storage

### DIFF
--- a/src/hooks/useSyncWithLS/README.md
+++ b/src/hooks/useSyncWithLS/README.md
@@ -1,0 +1,19 @@
+<!--GITHUB_BLOCK-->
+
+# useSyncWithLS
+
+<!--/GITHUB_BLOCK-->
+
+```tsx
+import {useSyncWithLS} from '@gravity-ui/uikit';
+```
+
+The `useSyncWithLS` hook executes callback when value changed in Local Storage
+
+## Properties
+
+| Name           | Description                                                  |      Type      |   Default   |
+| :------------- | :----------------------------------------------------------- | :------------: | :---------: |
+| callback       | Callback function called when key in local storage triggered | `VoidFunction` |             |
+| dataSourceName | Name for data source of keys                                 |    `string`    | 'sync-tabs' |
+| uniqueKey      | Key in local storage for handle                              |    `string`    |             |

--- a/src/hooks/useSyncWithLS/index.ts
+++ b/src/hooks/useSyncWithLS/index.ts
@@ -1,0 +1,2 @@
+export {useSyncWithLS} from './useSyncWithLS';
+export type {UseSyncWithLSInputProps, UseSyncWithLSOutputProps} from './useSyncWithLS';

--- a/src/hooks/useSyncWithLS/useSyncWithLS.ts
+++ b/src/hooks/useSyncWithLS/useSyncWithLS.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export type UseSyncWithLSInputProps<T> = {
+    callback: T;
+    uniqueKey: string;
+    dataSourceName?: string;
+};
+export type UseSyncWithLSOutputProps = {callback: (...args: unknown[]) => void};
+
+export const useSyncWithLS = <T extends Function>({
+    dataSourceName = 'sync-tabs',
+    callback,
+    uniqueKey,
+}: UseSyncWithLSInputProps<T>): UseSyncWithLSOutputProps => {
+    const key = `${dataSourceName}.${uniqueKey}`;
+
+    const handler = (event: StorageEvent) => {
+        if (event.key === key) {
+            return callback();
+        }
+        return undefined;
+    };
+
+    React.useEffect(() => {
+        // Action in non-active tab
+        window.addEventListener('storage', handler);
+
+        return () => {
+            window.removeEventListener('storage', handler);
+            localStorage.removeItem(key);
+        };
+    });
+
+    return {
+        callback: React.useCallback(() => {
+            localStorage.setItem(key, String(Number(localStorage.getItem(key) || '0') + 1));
+            return callback();
+        }, [key, callback]),
+    };
+};

--- a/src/hooks/useSyncWithLS/useSyncWithLS.ts
+++ b/src/hooks/useSyncWithLS/useSyncWithLS.ts
@@ -15,7 +15,7 @@ export const useSyncWithLS = <T extends Function>({
     const key = `${dataSourceName}.${uniqueKey}`;
 
     const handler = (event: StorageEvent) => {
-        if (event.key === key) {
+        if (event.key === key && event.newValue) {
             return callback();
         }
         return undefined;


### PR DESCRIPTION
Perform action in multiple tabs simultaneously using Local Storage key and 'storage' event listener.

How to use:
```
export const App = () => {
  const [open, setOpen] = useState(false);

  const close = useCallback(() => setOpen(true), []);
  const handleClose = useCallback(() => {
    close();
    closeWithLS();
  }, []);
  const { callback: closeWithLS } = useSyncWithLS({
    callback: close,
    uniqueKey: 'close-key',
  });
  return (
    <div>
      <button onClick={handleClose}>Close</button>
      <div>{open ? 'Open' : 'Close'}</div>
    </div>
  );
};
```