### PR TITLE
fix(TextInput): add overflow hidden to text-input__content wrapper

### DIFF
--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -44,6 +44,10 @@ $block: '.#{variables.$ns}text-input';
 
     &__content {
         box-sizing: border-box;
+        // It's fixing input overflowed behaviour
+        // Input itself doesn't have a border radius, but content has.
+        // And it could cause a render problem,
+        // when input accidentally goes beyond the wrapper
         overflow: hidden;
         display: flex;
         width: 100%;

--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -44,6 +44,7 @@ $block: '.#{variables.$ns}text-input';
 
     &__content {
         box-sizing: border-box;
+        overflow: hidden;
         display: flex;
         width: 100%;
     }


### PR DESCRIPTION
Hi

In some browsers (MIcrosoft Edge and others) we have encountered an issue where the input is autocompleted and displays the background outside of the input edges.

PS: Solving this problem by adding a border radius to the input doesn't work as expected, at least because it doesn't match the content radius.

| AS IS | TO BE | With radius |
|--------|--------|--------|
| <img width="664" alt="image" src="https://github.com/gravity-ui/uikit/assets/2071148/e37426e0-0454-4f82-acfa-ea3a1f5adfe8"> | <img width="664" alt="image" src="https://github.com/gravity-ui/uikit/assets/2071148/9c18fa44-482f-49b6-952c-89da8c0d4cda"> | <img width="664" alt="image" src="https://github.com/gravity-ui/uikit/assets/2071148/5d765c3e-42f0-4777-aa82-85253582b1c3"> | 