### PR TITLE
refactor(styles): set CSS vars in `pin` mixin

### DIFF
--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -92,20 +92,20 @@ $-pin-mixin-variables-ns: --_--g-pin-mixin-border-radius;
 
     @each $selector in $selectors {
         &#{get-pin-selector(#{$block}_pin_round-round, $selector, $append)} {
-            @include -pin-mixin-variables-from-list($radius $radius $radius $radius);
+            @include -pin-mixin-variables-from-list($radius);
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-brick, $selector, $append)} {
-            @include -pin-mixin-variables-from-list(0 0 0 0);
+            @include -pin-mixin-variables-from-list(0);
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-clear, $selector, $append)} {
-            @include -pin-mixin-variables-from-list(0 0 0 0);
+            @include -pin-mixin-variables-from-list(0);
             border-inline: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_circle-circle, $selector, $append)} {
-            @include -pin-mixin-variables-from-list(100px 100px 100px 100px);
+            @include -pin-mixin-variables-from-list(100px);
         }
 
         &#{get-pin-selector(#{$block}_pin_round-brick, $selector, $append)} {
@@ -127,12 +127,12 @@ $-pin-mixin-variables-ns: --_--g-pin-mixin-border-radius;
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-clear, $selector, $append)} {
-            @include -pin-mixin-variables-from-list(0 0 0 0);
+            @include -pin-mixin-variables-from-list(0);
             border-inline-end: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-brick, $selector, $append)} {
-            @include -pin-mixin-variables-from-list(0 0 0 0);
+            @include -pin-mixin-variables-from-list(0);
             border-inline-start: 0;
         }
 

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -66,92 +66,91 @@
     }
 }
 
+$-pin-mixin-variables-ns: --_--g-pin-mixin-border-radius;
+
+@mixin -pin-mixin-variables-from-list($list) {
+    $props: top-left, top-right, bottom-right, bottom-left;
+    $indexes: 1, 2, 3, 4;
+
+    @if list.length($list) == 1 {
+        $indexes: 1, 1, 1, 1;
+    }
+
+    @each $prop, $index in list.zip($props, $indexes) {
+        #{#{$-pin-mixin-variables-ns}-#{$prop}}: list.nth($list, $index);
+    }
+}
+
 @mixin pin($block, $selectors, $radius, $append: true) {
+    &#{get-pin-selector($block, $selectors, $append)} {
+        border-radius: (
+            var(#{$-pin-mixin-variables-ns}-top-left) var(#{$-pin-mixin-variables-ns}-top-right)
+                var(#{$-pin-mixin-variables-ns}-bottom-right)
+                var(#{$-pin-mixin-variables-ns}-bottom-left)
+        );
+    }
+
     @each $selector in $selectors {
         &#{get-pin-selector(#{$block}_pin_round-round, $selector, $append)} {
-            border-radius: $radius;
+            @include -pin-mixin-variables-from-list($radius $radius $radius $radius);
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-brick, $selector, $append)} {
-            border-radius: 0;
+            @include -pin-mixin-variables-from-list(0 0 0 0);
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-clear, $selector, $append)} {
-            border-radius: 0;
+            @include -pin-mixin-variables-from-list(0 0 0 0);
             border-inline: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_circle-circle, $selector, $append)} {
-            border-radius: 100px;
+            @include -pin-mixin-variables-from-list(100px 100px 100px 100px);
         }
 
         &#{get-pin-selector(#{$block}_pin_round-brick, $selector, $append)} {
-            border-start-start-radius: $radius;
-            border-start-end-radius: 0;
-            border-end-start-radius: $radius;
-            border-end-end-radius: 0;
+            @include -pin-mixin-variables-from-list($radius 0 0 $radius);
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-round, $selector, $append)} {
-            border-start-start-radius: 0;
-            border-start-end-radius: $radius;
-            border-end-start-radius: 0;
-            border-end-end-radius: $radius;
+            @include -pin-mixin-variables-from-list(0 $radius $radius 0);
         }
 
         &#{get-pin-selector(#{$block}_pin_round-clear, $selector, $append)} {
-            border-start-start-radius: $radius;
-            border-start-end-radius: 0;
-            border-end-start-radius: $radius;
-            border-end-end-radius: 0;
+            @include -pin-mixin-variables-from-list($radius 0 0 $radius);
             border-inline-end: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-round, $selector, $append)} {
-            border-start-start-radius: 0;
-            border-start-end-radius: $radius;
-            border-end-start-radius: 0;
-            border-end-end-radius: $radius;
+            @include -pin-mixin-variables-from-list(0 $radius $radius 0);
             border-inline-start: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-clear, $selector, $append)} {
-            border-radius: 0;
+            @include -pin-mixin-variables-from-list(0 0 0 0);
             border-inline-end: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-brick, $selector, $append)} {
-            border-radius: 0;
+            @include -pin-mixin-variables-from-list(0 0 0 0);
             border-inline-start: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_circle-brick, $selector, $append)} {
-            border-start-start-radius: 100px;
-            border-start-end-radius: 0;
-            border-end-start-radius: 100px;
-            border-end-end-radius: 0;
+            @include -pin-mixin-variables-from-list(100px 0 0 100px);
         }
 
         &#{get-pin-selector(#{$block}_pin_brick-circle, $selector, $append)} {
-            border-start-start-radius: 0;
-            border-start-end-radius: 100px;
-            border-end-start-radius: 0;
-            border-end-end-radius: 100px;
+            @include -pin-mixin-variables-from-list(0 100px 100px 0);
         }
 
         &#{get-pin-selector(#{$block}_pin_circle-clear, $selector, $append)} {
-            border-start-start-radius: 100px;
-            border-start-end-radius: 0;
-            border-end-start-radius: 100px;
-            border-end-end-radius: 0;
+            @include -pin-mixin-variables-from-list(100px 0 0 100px);
             border-inline-end: 0;
         }
 
         &#{get-pin-selector(#{$block}_pin_clear-circle, $selector, $append)} {
-            border-start-start-radius: 0;
-            border-start-end-radius: 100px;
-            border-end-start-radius: 0;
-            border-end-end-radius: 100px;
+            @include -pin-mixin-variables-from-list(0 100px 100px 0);
             border-inline-start: 0;
         }
     }

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -82,12 +82,15 @@ $-pin-mixin-variables-ns: --_--g-pin-mixin-border-radius;
 }
 
 @mixin pin($block, $selectors, $radius, $append: true) {
-    &#{get-pin-selector($block, $selectors, $append)} {
-        border-radius: (
-            var(#{$-pin-mixin-variables-ns}-top-left) var(#{$-pin-mixin-variables-ns}-top-right)
-                var(#{$-pin-mixin-variables-ns}-bottom-right)
-                var(#{$-pin-mixin-variables-ns}-bottom-left)
-        );
+    @each $selector in $selectors {
+        &#{get-pin-selector($block, $selector, $append)} {
+            border-radius: (
+                var(#{$-pin-mixin-variables-ns}-top-left)
+                    var(#{$-pin-mixin-variables-ns}-top-right)
+                    var(#{$-pin-mixin-variables-ns}-bottom-right)
+                    var(#{$-pin-mixin-variables-ns}-bottom-left)
+            );
+        }
     }
 
     @each $selector in $selectors {


### PR DESCRIPTION
This will set CSS-vars in private namespace, that will allow to developer reuse `border-radius` in children elements, for example to match nested element `border-radius` by reducing it via `calc()`.