### PR TITLE
fix(breadcrumbs): fix adaptive more view and define ResizeObserver in ssr apps

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -53,6 +53,7 @@ interface BreadcrumbsState<T extends BreadcrumbsItem> {
 const RESIZE_THROTTLE = 200;
 const MORE_ITEM_WIDTH = 34;
 const DEFAULT_POPUP_PLACEMENT = ['bottom', 'top'];
+const GAP_WIDTH = 4 * 2;
 
 const b = block('breadcrumbs');
 
@@ -98,7 +99,7 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
     }
 
     private container: React.RefObject<HTMLDivElement>;
-    private resizeObserver: ResizeObserver;
+    private resizeObserver?: ResizeObserver;
 
     constructor(props: BreadcrumbsProps<T>) {
         super(props);
@@ -111,7 +112,7 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
 
     componentDidMount() {
         this.recalculate();
-        this.resizeObserver.observe(this.container.current as Element);
+        this.resizeObserver?.observe(this.container.current as Element);
     }
 
     componentDidUpdate(prevProps: BreadcrumbsProps<T>) {
@@ -121,7 +122,7 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
     }
 
     componentWillUnmount() {
-        this.resizeObserver.disconnect();
+        this.resizeObserver?.disconnect();
     }
 
     render() {
@@ -221,12 +222,17 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
             const dividers: HTMLElement[] = Array.from(
                 this.container.current.querySelectorAll(`.${b('divider')}`),
             );
-            const items: HTMLElement[] = Array.from(
-                this.container.current.querySelectorAll(`.${b('item')}`),
-            );
+            const items: HTMLElement[] = [
+                ...(Array.from(
+                    this.container.current.querySelectorAll(`.${b('switcher')}`),
+                ) as HTMLElement[]),
+                ...(Array.from(
+                    this.container.current.querySelectorAll(`.${b('item')}`),
+                ) as HTMLElement[]),
+            ];
 
             const availableWidth = this.container.current.offsetWidth;
-            const itemsWidths = items.map((elem) => elem.scrollWidth);
+            const itemsWidths = items.map((elem) => elem.scrollWidth + GAP_WIDTH);
             const dividersWidths = dividers.map((elem) => elem.offsetWidth);
             const buttonsWidth = itemsWidths.reduce((total, width, index, widths) => {
                 const isLastItem = widths.length - 1 === index;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -219,8 +219,9 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
 
     private recalculate() {
         const {items: allItems, lastDisplayedItemsCount, firstDisplayedItemsCount} = this.props;
+        const availableWidth = this.container.current?.offsetWidth || 0;
 
-        if (this.container.current) {
+        if (this.container.current && availableWidth > 0) {
             const dividers: HTMLElement[] = Array.from(
                 this.container.current.querySelectorAll(`.${b('divider')}`),
             );
@@ -233,7 +234,6 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
                 ) as HTMLElement[]),
             ];
 
-            const availableWidth = this.container.current.offsetWidth;
             const itemsWidths = items.map(
                 (elem, i) =>
                     elem.scrollWidth + (i === items.length - 1 ? GAP_WIDTH : GAP_WIDTH * 2),

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -53,7 +53,7 @@ interface BreadcrumbsState<T extends BreadcrumbsItem> {
 const RESIZE_THROTTLE = 200;
 const MORE_ITEM_WIDTH = 34;
 const DEFAULT_POPUP_PLACEMENT = ['bottom', 'top'];
-const GAP_WIDTH = 4 * 2;
+const GAP_WIDTH = 4;
 
 const b = block('breadcrumbs');
 
@@ -105,7 +105,9 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
         super(props);
 
         this.handleResize = _throttle(this.handleResize, RESIZE_THROTTLE);
-        this.resizeObserver = new ResizeObserver(this.handleResize);
+        if (typeof window !== 'undefined') {
+            this.resizeObserver = new ResizeObserver(this.handleResize);
+        }
         this.container = React.createRef();
         this.state = Breadcrumbs.prepareInitialState(props);
     }
@@ -232,7 +234,10 @@ export class Breadcrumbs<T extends BreadcrumbsItem = BreadcrumbsItem> extends Re
             ];
 
             const availableWidth = this.container.current.offsetWidth;
-            const itemsWidths = items.map((elem) => elem.scrollWidth + GAP_WIDTH);
+            const itemsWidths = items.map(
+                (elem, i) =>
+                    elem.scrollWidth + (i === items.length - 1 ? GAP_WIDTH : GAP_WIDTH * 2),
+            );
             const dividersWidths = dividers.map((elem) => elem.offsetWidth);
             const buttonsWidth = itemsWidths.reduce((total, width, index, widths) => {
                 const isLastItem = widths.length - 1 === index;


### PR DESCRIPTION
Fix responsive bug: when migrating to uikit 6, there was a bug with incorrect display when the parent container overflowed 
Fix ResizeObserver: : ResizeObserver is not defined at new Breadcrumbs

Closes #1349 