### PR TITLE
fix: adding new classes in rootClassName before removing

### DIFF
--- a/src/components/theme/dom-helpers.ts
+++ b/src/components/theme/dom-helpers.ts
@@ -23,20 +23,20 @@ export function updateBodyClassName({
         bodyEl.classList.add(rootClassName);
     }
 
-    if (className) {
-        const parsedCustomRootClassNames = className.split(' ');
-        parsedCustomRootClassNames.forEach((cls) => {
-            if (cls && !bodyEl.classList.contains(cls)) {
-                bodyEl.classList.add(cls);
-            }
-        });
-    }
-
     if (prevClassName) {
         const parsedPrevCustomRootClassNames = prevClassName.split(' ');
         parsedPrevCustomRootClassNames.forEach((cls) => {
             if (cls) {
                 bodyEl.classList.remove(cls);
+            }
+        });
+    }
+
+    if (className) {
+        const parsedCustomRootClassNames = className.split(' ');
+        parsedCustomRootClassNames.forEach((cls) => {
+            if (cls && !bodyEl.classList.contains(cls)) {
+                bodyEl.classList.add(cls);
             }
         });
     }


### PR DESCRIPTION
In case we want to add a new class to the rootClassName and keep the previous ones, in the current implementation we can't do that, because we will remove all those classes that were in the previous rootClassName and remain in the new rootClassName