### PR TITLE
fix(Dialog): correct width's vars order

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -9,7 +9,7 @@ $block: '.#{variables.$ns}dialog';
     position: relative;
     display: flex;
     flex-direction: column;
-    width: var(var(--g-dialog-width), --_--width);
+    width: var(--g-dialog-width, var(--_--width));
 
     &_has-scroll {
         overflow-y: auto;

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -9,7 +9,7 @@ $block: '.#{variables.$ns}dialog';
     position: relative;
     display: flex;
     flex-direction: column;
-    width: var(--_--width, var(--g-dialog-width));
+    width: var(var(--g-dialog-width), --_--width);
 
     &_has-scroll {
         overflow-y: auto;


### PR DESCRIPTION
it is necessary to reverse the order of variables to give opportunity to change dialog width