### PR TITLE
fix(Table): remove background for action cells

### DIFF
--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -82,8 +82,6 @@
         #{variables.$block} &_sticky_end {
             position: sticky;
             z-index: 2;
-
-            background: var(--g-color-base-background);
         }
 
         &_border_right {


### PR DESCRIPTION
### Problem
Table action columns have background color, whereas other columns are transparent.

### Way to reproduce

Set custom background color under the Table component.
<img width="1408" alt="image" src="https://github.com/gravity-ui/uikit/assets/64990498/466bcfbd-6360-4405-bd35-06213983e95a">

### Way to fix

Remove background prop.
<img width="1406" alt="image" src="https://github.com/gravity-ui/uikit/assets/64990498/d12bf665-32fa-4997-ad7a-1ab288232201">
 