### PR TITLE
fix(Button): do not shrink button when there is only one icon

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -34,6 +34,7 @@ $block: '.#{variables.$ns}button';
         color 0.15s linear;
     transform: scale(1);
     display: inline-flex;
+    flex-shrink: 0;
     justify-content: center;
     padding: 0 var(--g-button-padding, var(--_--padding));
     gap: var(--g-button-icon-offset, var(--_--icon-offset));

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -34,7 +34,6 @@ $block: '.#{variables.$ns}button';
         color 0.15s linear;
     transform: scale(1);
     display: inline-flex;
-    flex-shrink: 0;
     justify-content: center;
     padding: 0 var(--g-button-padding, var(--_--padding));
     gap: var(--g-button-icon-offset, var(--_--icon-offset));
@@ -294,6 +293,10 @@ $block: '.#{variables.$ns}button';
 
         &_side_end {
             order: 1;
+        }
+
+        &:only-child {
+            margin: 0;
         }
     }
 


### PR DESCRIPTION
Resetting plugin makes button with only icon shrink (https://github.com/gravity-ui/uikit/issues/1529). Started to happen after flex refactoring (https://github.com/gravity-ui/uikit/pull/1452)

Related issue https://github.com/gravity-ui/uikit/issues/1529