### PR TITLE
feat(Button): allow to pass any valid `<button>` or `<a>` HTML attributes

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -68,9 +68,7 @@ export const Alert = (props: AlertProps) => {
                             view="flat"
                             className={bAlert('close-btn')}
                             onClick={onClose}
-                            extraProps={{
-                                'aria-label': i18n('label_close'),
-                            }}
+                            aria-label={i18n('label_close')}
                         >
                             <Icon
                                 data={Xmark}

--- a/src/components/Alert/types.ts
+++ b/src/components/Alert/types.ts
@@ -89,7 +89,7 @@ export interface AlertActionsProps {
     items?: AlertAction[];
     children?: React.ReactNode | React.ReactNode[];
 }
-export interface AlertActionProps extends ButtonProps {}
+export type AlertActionProps = ButtonProps;
 export interface AlertTitleProps {
     className?: string;
     text: string;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -154,13 +154,13 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
             component,
             {
                 ...commonProps,
-                ...restProps,
-                ...extraProps,
                 ref,
                 tabIndex: disabled ? undefined : 0,
                 role: 'button',
                 'aria-disabled': disabled,
                 'aria-pressed': selected,
+                ...restProps,
+                ...extraProps,
             },
             content,
         );
@@ -170,8 +170,6 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         return (
             <a
                 {...commonProps}
-                {...linkProps}
-                {...(extraProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
                 ref={ref as React.Ref<HTMLAnchorElement>}
                 rel={
                     linkProps.target === '_blank' && !linkProps.rel
@@ -179,6 +177,8 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
                         : linkProps.rel
                 }
                 aria-disabled={disabled}
+                {...linkProps}
+                {...(extraProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
             >
                 {content}
             </a>
@@ -189,12 +189,12 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         return (
             <button
                 {...commonProps}
-                {...buttonProps}
-                {...(extraProps as React.ButtonHTMLAttributes<HTMLButtonElement>)}
                 ref={ref as React.Ref<HTMLButtonElement>}
                 type={buttonProps.type ?? 'button'}
                 disabled={disabled}
                 aria-pressed={selected}
+                {...buttonProps}
+                {...(extraProps as React.ButtonHTMLAttributes<HTMLButtonElement>)}
             >
                 {content}
             </button>

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -449,33 +449,21 @@ LANDING_BLOCK-->
 
 ## Properties
 
-| Name         | Description                                               |              Type               |     Default     |
-| :----------- | :-------------------------------------------------------- | :-----------------------------: | :-------------: |
-| children     | Button content. You can mix text with `<Icon/>` component |           `ReactNode`           |                 |
-| className    | HTML `class` attribute                                    |            `string`             |                 |
-| component    | Overrides the root component                              |       `ElementType<any>`        |   `"button"`    |
-| disabled     | Toggles `disabled` state                                  |             `false`             |     `false`     |
-| extraProps   | Any additional props                                      |            `Record`             |                 |
-| href         | HTML `href` attribute                                     |            `string`             |                 |
-| id           | HTML `id` attribute                                       |            `string`             |                 |
-| loading      | Toggles `loading` state                                   |             `false`             |     `false`     |
-| onBlur       | `blur` event handler                                      |           `Function`            |                 |
-| onClick      | `click` event handler                                     |           `Function`            |                 |
-| onFocus      | `focus` event handler                                     |           `Function`            |                 |
-| onMouseEnter | `mouseenter` event handler                                |           `Function`            |                 |
-| onMouseLeave | `mouseleave` event handler                                |           `Function`            |                 |
-| pin          | Sets button edges style                                   |            `string`             | `"round-round"` |
-| qa           | HTML `data-qa` attribute, used in tests                   |            `string`             |                 |
-| rel          | HTML `rel` attribute                                      |            `string`             |                 |
-| selected     | Toggles `selected` state                                  |                                 |                 |
-| size         | Sets button size                                          |            `string`             |      `"m"`      |
-| style        | HTML `style` attribute                                    |      `React.CSSProperties`      |                 |
-| tabIndex     | HTML `tabIndex` attribute                                 |            `number`             |                 |
-| target       | HTML `target` attribute                                   |            `string`             |                 |
-| title        | HTML `title` attribute                                    |            `string`             |                 |
-| type         | HTML `type` attribute                                     | `"button"` `"submit"` `"reset"` |   `"button"`    |
-| view         | Sets button appearance                                    |            `string`             |   `"normal"`    |
-| width        | `"auto"` `"max"`                                          |        `"auto"` `"max"`         |                 |
+`ButtonProps` extends `React.ButtonHTMLAttributes` or `React.AnchorHTMLAttributes` based on passed `href` prop.
+
+| Name      | Description                                               |        Type        |     Default     |
+| :-------- | :-------------------------------------------------------- | :----------------: | :-------------: |
+| children  | Button content. You can mix text with `<Icon/>` component |    `ReactNode`     |                 |
+| component | Overrides the root component                              | `ElementType<any>` |   `"button"`    |
+| disabled  | Toggles `disabled` state                                  |      `false`       |     `false`     |
+| href      | HTML `href` attribute, forces to render an `<a>` element  |      `string`      |                 |
+| loading   | Toggles `loading` state                                   |      `false`       |     `false`     |
+| pin       | Sets button edges style                                   |      `string`      | `"round-round"` |
+| qa        | HTML `data-qa` attribute, used in tests                   |      `string`      |                 |
+| selected  | Toggles `selected` state                                  |                    |                 |
+| size      | Sets button size                                          |      `string`      |      `"m"`      |
+| view      | Sets button appearance                                    |      `string`      |   `"normal"`    |
+| width     | `"auto"` `"max"`                                          |  `"auto"` `"max"`  |                 |
 
 ## CSS API
 

--- a/src/components/Button/__stories__/Button.stories.tsx
+++ b/src/components/Button/__stories__/Button.stories.tsx
@@ -12,6 +12,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 
 import {Showcase} from '../../../demo/Showcase';
 import {Icon as IconComponent} from '../../Icon/Icon';
+import type {ButtonLinkProps} from '../Button';
 import {Button} from '../Button';
 
 import {ButtonViewShowcase} from './ButtonViewShowcase';
@@ -37,7 +38,7 @@ export default {
             },
         },
     },
-} as Meta;
+} as Meta<typeof Button>;
 
 type Story = StoryObj<typeof Button>;
 
@@ -158,7 +159,7 @@ export const Pin: Story = {
     },
 };
 
-export const Link: Story = {
+export const Link: StoryObj<ButtonLinkProps> = {
     args: {
         ...Default.args,
         children: ['Link Button', <IconComponent key="icon" data={ArrowUpRightFromSquare} />],
@@ -180,7 +181,7 @@ export const InsideText: Story = {
                 <Button {...args} /> dolor
                 <br />
                 sit{' '}
-                <Button {...args} extraProps={{'aria-label': 'Icon button inside text'}}>
+                <Button {...args} aria-label="Icon button inside text">
                     <IconComponent data={Globe} />
                 </Button>{' '}
                 amet

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import {render, screen} from '../../../../test-utils/utils';
 import {Button} from '../Button';
-import type {ButtonPin, ButtonProps, ButtonSize, ButtonView} from '../Button';
+import type {ButtonPin, ButtonSize, ButtonView} from '../Button';
 
 const qaId = 'button-component';
 
@@ -105,11 +105,11 @@ describe('Button', () => {
     test('should render custom component', () => {
         const text = 'Button with custom component';
 
-        const ButtonComponent = (props: ButtonProps) => {
+        const ButtonComponent = (props: React.HTMLAttributes<HTMLElement>) => {
             return (
-                <button {...props} style={{boxShadow: '2px 2px 2px 2px deepskyblue'}}>
+                <div {...props} style={{boxShadow: '2px 2px 2px 2px deepskyblue'}}>
                     {text}
-                </button>
+                </div>
             );
         };
 

--- a/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/src/components/ClipboardButton/ClipboardButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {ActionTooltip} from '../ActionTooltip';
 import {Button} from '../Button';
-import type {ButtonProps, ButtonSize} from '../Button';
+import type {ButtonButtonProps, ButtonSize} from '../Button';
 import {ClipboardIcon} from '../ClipboardIcon';
 import {CopyToClipboard} from '../CopyToClipboard';
 import type {CopyToClipboardProps, CopyToClipboardStatus} from '../CopyToClipboard/types';
@@ -14,7 +14,7 @@ export interface ClipboardButtonProps
         Omit<ClipboardButtonComponentProps, 'status' | 'onClick'> {}
 
 interface ClipboardButtonComponentProps
-    extends Omit<ButtonProps, 'href' | 'component' | 'target' | 'rel' | 'loading' | 'children'> {
+    extends Omit<ButtonButtonProps, 'component' | 'loading' | 'children' | 'onCopy'> {
     status: CopyToClipboardStatus;
     /** Disable tooltip. Tooltip won't be shown */
     hasTooltip?: boolean;
@@ -42,7 +42,6 @@ const ClipboardButtonComponent = (props: ClipboardButtonComponentProps) => {
         tooltipSuccessText = i18n('endCopy'),
         status,
         view = 'flat',
-        extraProps = {},
         ...rest
     } = props;
 
@@ -51,15 +50,7 @@ const ClipboardButtonComponent = (props: ClipboardButtonComponentProps) => {
             disabled={!hasTooltip}
             title={status === 'success' ? tooltipSuccessText : tooltipInitialText}
         >
-            <Button
-                view={view}
-                size={size}
-                extraProps={{
-                    'aria-label': tooltipInitialText,
-                    ...extraProps,
-                }}
-                {...rest}
-            >
+            <Button view={view} size={size} aria-label={tooltipInitialText} {...rest}>
                 <Button.Icon>
                     <ClipboardIcon size={ButtonSizeToIconSize[size]} status={status} />
                 </Button.Icon>

--- a/src/components/Dialog/ButtonClose/ButtonClose.tsx
+++ b/src/components/Dialog/ButtonClose/ButtonClose.tsx
@@ -26,9 +26,7 @@ export function ButtonClose({onClose}: ButtonCloseProps) {
                 size="l"
                 className={b('btn')}
                 onClick={(event) => onClose(event, {isOutsideClick: false})}
-                extraProps={{
-                    'aria-label': i18n('close'),
-                }}
+                aria-label={i18n('close')}
             >
                 <Icon data={Xmark} size={20} />
             </Button>

--- a/src/components/Dialog/DialogFooter/DialogFooter.tsx
+++ b/src/components/Dialog/DialogFooter/DialogFooter.tsx
@@ -16,8 +16,8 @@ interface DialogFooterOwnProps {
     onClickButtonCancel?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     textButtonCancel?: string;
     textButtonApply?: string;
-    propsButtonCancel?: Partial<ButtonProps>;
-    propsButtonApply?: Partial<ButtonProps>;
+    propsButtonCancel?: ButtonProps;
+    propsButtonApply?: ButtonProps;
     loading?: boolean;
     children?: React.ReactNode;
     errorText?: string;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -118,9 +118,9 @@ export const Label = React.forwardRef(function Label(
             actionButton = (
                 <Button
                     size={buttonSize}
-                    extraProps={{'aria-label': copyButtonLabel || undefined}}
                     onClick={hasOnClick ? onClick : undefined}
                     disabled={disabled}
+                    aria-label={copyButtonLabel}
                     {...commonActionButtonProps}
                 >
                     <Button.Icon>
@@ -133,8 +133,8 @@ export const Label = React.forwardRef(function Label(
                 <Button
                     onClick={onCloseClick}
                     size={buttonSize}
-                    extraProps={{'aria-label': closeButtonLabel || undefined}}
                     disabled={disabled}
+                    aria-label={closeButtonLabel}
                     {...commonActionButtonProps}
                 >
                     <Icon size={closeIconSize} data={Xmark} />

--- a/src/components/Palette/Palette.tsx
+++ b/src/components/Palette/Palette.tsx
@@ -192,7 +192,7 @@ export const Palette = React.forwardRef<HTMLDivElement, PaletteProps>(function P
                                     title={option.title}
                                     view={isSelected ? 'normal' : 'flat'}
                                     selected={isSelected}
-                                    extraProps={{value: option.value}}
+                                    value={option.value}
                                     size={size}
                                     onClick={() => handleSelection(option)}
                                 >

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -163,9 +163,7 @@ export const Popover = React.forwardRef<PopoverInstanceProps, PopoverProps & QAP
                             size="s"
                             view="flat-secondary"
                             onClick={handleCloseClick}
-                            extraProps={{
-                                'aria-label': 'Close',
-                            }}
+                            aria-label="Close"
                         >
                             <Icon data={Xmark} size={16} />
                         </Button>

--- a/src/components/Popover/__stories__/Popover.stories.tsx
+++ b/src/components/Popover/__stories__/Popover.stories.tsx
@@ -213,11 +213,9 @@ const AccessibleTemplate: StoryFn<PopoverProps> = () => {
             <Base content="Accessible tooltip" tooltipId={tooltipId}>
                 {({onClick, open}) => (
                     <Button
-                        extraProps={{
-                            'aria-controls': open ? tooltipId : undefined,
-                            'aria-describedby': tooltipId,
-                        }}
                         onClick={onClick}
+                        aria-controls={open ? tooltipId : undefined}
+                        aria-describedby={tooltipId}
                     >
                         Tooltip
                     </Button>
@@ -244,12 +242,10 @@ const AccessibleTemplate: StoryFn<PopoverProps> = () => {
                 {({onClick}) => (
                     <Button
                         ref={ref}
-                        extraProps={{
-                            'aria-controls': popoverId,
-                            'aria-describedby': popoverId,
-                            'aria-expanded': openPopover,
-                        }}
                         onClick={onClick}
+                        aria-controls={popoverId}
+                        aria-describedby={popoverId}
+                        aria-expanded={openPopover}
                     >
                         Popover
                     </Button>

--- a/src/components/Select/__stories__/SelectShowcase.tsx
+++ b/src/components/Select/__stories__/SelectShowcase.tsx
@@ -272,9 +272,7 @@ export const SelectShowcase = (props: SelectProps) => {
                                 ref={ref}
                                 view="action"
                                 onClick={onClick}
-                                extraProps={{
-                                    onKeyDown,
-                                }}
+                                onKeyDown={onKeyDown}
                                 className={b({'has-clear': props.hasClear})}
                             >
                                 <span className={b('text')}>User control</span>
@@ -306,10 +304,8 @@ export const SelectShowcase = (props: SelectProps) => {
                                 ref={ref}
                                 view="action"
                                 onClick={onClick}
-                                extraProps={{
-                                    onKeyDown,
-                                    'aria-label': 'Add',
-                                }}
+                                onKeyDown={onKeyDown}
+                                aria-label="Add"
                             >
                                 <Icon data={Plus} />
                             </Button>

--- a/src/components/Table/__stories__/WithTableSettingsCustomActions/WithTableSettingsCustomActions.tsx
+++ b/src/components/Table/__stories__/WithTableSettingsCustomActions/WithTableSettingsCustomActions.tsx
@@ -4,7 +4,6 @@ import {ArrowRotateLeft} from '@gravity-ui/icons';
 import _isEqual from 'lodash/isEqual';
 
 import {Button} from '../../../Button';
-import type {ButtonProps} from '../../../Button';
 import {Icon} from '../../../Icon';
 import {Flex} from '../../../layout';
 import type {TableProps} from '../../Table';
@@ -72,11 +71,11 @@ export const WithTableSettingsCustomActionsShowcase = ({
     );
 };
 
-function SelectAllButton<T extends ButtonProps>({onClick}: T) {
+function SelectAllButton({onClick}: {onClick: React.MouseEventHandler}) {
     return <Button onClick={onClick}>Select All</Button>;
 }
 
-function ResetButton<T extends ButtonProps>({onClick}: T) {
+function ResetButton({onClick}: {onClick: React.MouseEventHandler}) {
     return (
         <Button view="outlined-warning" onClick={onClick}>
             <Flex alignItems="center" gap="1">

--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -178,11 +178,9 @@ const DefaultRowActions = <I extends TableDataItem>({
                 size={rowActionsSize}
                 ref={anchorRef}
                 disabled={disabled}
-                extraProps={{
-                    'aria-label': i18n('label-actions'),
-                    'aria-expanded': isPopupOpen,
-                    'aria-controls': rowId,
-                }}
+                aria-label={i18n('label-actions')}
+                aria-expanded={isPopupOpen}
+                aria-controls={rowId}
             >
                 <Icon data={Ellipsis} />
             </Button>

--- a/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
+++ b/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
@@ -349,7 +349,7 @@ export const TableColumnSetup = (props: TableColumnSetupProps) => {
 
         return (
             renderSwitcher?.({onClick: toggleOpen, onKeyDown}) || (
-                <Button onClick={toggleOpen} extraProps={{onKeyDown}}>
+                <Button onClick={toggleOpen} onKeyDown={onKeyDown}>
                     <Icon data={Gear} />
                     {i18n('button_switcher')}
                 </Button>

--- a/src/components/Table/hoc/withTableSettings/withTableSettings.tsx
+++ b/src/components/Table/hoc/withTableSettings/withTableSettings.tsx
@@ -205,8 +205,8 @@ export function withTableSettings<I extends TableDataItem, E extends {} = {}>(
                                     <Button
                                         view="flat"
                                         className={b('settings-button')}
-                                        extraProps={{'aria-label': i18n('label_settings')}}
                                         onClick={onClick}
+                                        aria-label={i18n('label_settings')}
                                     >
                                         <Icon data={Gear} />
                                     </Button>

--- a/src/components/Toaster/Toast/Toast.tsx
+++ b/src/components/Toaster/Toast/Toast.tsx
@@ -119,7 +119,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastUnitedProps>(function
                         view="flat"
                         className={b('btn-close')}
                         onClick={onClose}
-                        extraProps={{'aria-label': i18n('label_close-button')}}
+                        aria-label={i18n('label_close-button')}
                     >
                         <Icon data={Xmark} />
                     </Button>

--- a/src/components/Tooltip/__stories__/Tooltip.stories.tsx
+++ b/src/components/Tooltip/__stories__/Tooltip.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
     render: (args) => {
         return (
             <Tooltip {...args}>
-                <Button extraProps={{'aria-describedby': args.id}}>Hover to see tooltip</Button>
+                <Button aria-describedby={args.id}>Hover to see tooltip</Button>
             </Tooltip>
         );
     },

--- a/src/components/TreeList/__stories__/stories/WithGroupSelectionAndCustomIconStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithGroupSelectionAndCustomIconStory.tsx
@@ -93,11 +93,7 @@ export const WithGroupSelectionAndCustomIconStory = ({
                                                         : false,
                                             }));
                                         }}
-                                        extraProps={{
-                                            'aria-label': expanded
-                                                ? closeButtonLabel
-                                                : expandButtonLabel,
-                                        }}
+                                        aria-label={expanded ? closeButtonLabel : expandButtonLabel}
                                     >
                                         <Icon data={expanded ? ChevronDown : ChevronUp} size={16} />
                                     </Button>

--- a/src/components/TreeList/__stories__/stories/WithItemLinksAndActionsStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithItemLinksAndActionsStory.tsx
@@ -98,11 +98,7 @@ export const WithItemLinksAndActionsStory = (props: WithItemLinksAndActionsStory
                                                         : false,
                                             }));
                                         }}
-                                        extraProps={{
-                                            'aria-label': expanded
-                                                ? closeButtonLabel
-                                                : expandButtonLabel,
-                                        }}
+                                        aria-label={expanded ? closeButtonLabel : expandButtonLabel}
                                     >
                                         <Icon data={expanded ? ChevronDown : ChevronUp} size={16} />
                                     </Button>

--- a/src/components/controls/TextInput/__stories__/TextInputShowcase.tsx
+++ b/src/components/controls/TextInput/__stories__/TextInputShowcase.tsx
@@ -34,7 +34,7 @@ const EyeButton = (props: {
             view="flat"
             disabled={disabled}
             onClick={onClick}
-            extraProps={{'aria-label': opened ? showLabel : hideLabel}}
+            aria-label={opened ? showLabel : hideLabel}
         >
             <Icon data={opened ? Eye : EyeSlash} />
         </Button>

--- a/src/components/controls/common/ClearButton/ClearButton.tsx
+++ b/src/components/controls/common/ClearButton/ClearButton.tsx
@@ -56,10 +56,8 @@ export const ClearButton = (props: Props) => {
             size={size}
             className={b(null, className)}
             onClick={onClick}
-            extraProps={{
-                onMouseDown: preventDefaultHandler,
-                'aria-label': i18n('label_clear-button'),
-            }}
+            onMouseDown={preventDefaultHandler}
+            aria-label={i18n('label_clear-button')}
         >
             <Icon data={Xmark} size={ICON_SIZE} />
         </Button>

--- a/src/demo/colors/ColorPanel.tsx
+++ b/src/demo/colors/ColorPanel.tsx
@@ -70,9 +70,7 @@ export function ColorPanel(props: ColorPanelProps) {
                     }
                     className="color-panel__bg-switcher"
                     onClick={() => rotateBackground()}
-                    extraProps={{
-                        'aria-labelledby': tooltipId,
-                    }}
+                    aria-labelledby={tooltipId}
                 >
                     <Icon data={Bulb} />
                 </Button>

--- a/src/stories/Branding/BrandingConfugurator/BrandingConfigurator.tsx
+++ b/src/stories/Branding/BrandingConfugurator/BrandingConfigurator.tsx
@@ -113,9 +113,7 @@ export function BrandingConfigurator({theme}: BrandingConfiguratorProps) {
                         view="outlined"
                         size="xl"
                         onClick={handleRandomClick}
-                        extraProps={{
-                            'aria-label': 'Regenerate colors',
-                        }}
+                        aria-label="Regenerate colors"
                     >
                         <Icon data={ArrowsRotateRight} size={20} />
                     </Button>

--- a/src/stories/Branding/PaletteGenerator/PaletteGenerator.tsx
+++ b/src/stories/Branding/PaletteGenerator/PaletteGenerator.tsx
@@ -167,9 +167,7 @@ export function PaletteGenerator({theme}: BrandingConfiguratorProps) {
                         view="outlined"
                         size="l"
                         onClick={handleSwapContrastClick}
-                        extraProps={{
-                            'aria-label': 'Switch colors',
-                        }}
+                        aria-label="Switch colors"
                     >
                         <Icon data={ArrowUpArrowDown} size={18} />
                     </Button>


### PR DESCRIPTION
This PR introduces an easier way to pass any extra properties to the component and deprecates `extraProps` prop:
```jsx
// Before
<Button extraProps={{onKeyDown: () => {}}} />

// After
<Button onKeyDown={() => {}} />
```

By default, extra properties extend `React.ButtonHTMLAttributes` and when `href` property is passed they extend `React.AnchorHTMLAttributes`.

PR potentially will break types because `ButtonProps` can no longer be extended in interface declaration:

```ts
// Can't extend in interface
interface MyButton extends ButtonProps {
    myProp: string;
}

// This works fine
type MyButton = ButtonProps & {
    myProp: string;
}
```