### PR TITLE
fix(Text): return missing props to TextProps type

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -16,6 +16,8 @@ export interface TextProps<C extends React.ElementType = 'span'>
      */
     as?: C;
     ellipsisLines?: number;
+    className?: string;
+    styles?: React.CSSProperties;
 }
 
 type TextRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['ref'];


### PR DESCRIPTION
For extending components if Text used inside wrapper component