### PR TITLE
feat(link_underline): add link underline

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -42,4 +42,8 @@ $block: '.#{variables.$ns}link';
             color: var(--g-color-text-link-visited-hover);
         }
     }
+
+    &_underline {
+        text-decoration: underline;
+    }
 }

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -13,6 +13,7 @@ export type LinkView = 'normal' | 'primary' | 'secondary';
 export interface LinkProps extends DOMProps, QAProps {
     view?: LinkView;
     visitable?: boolean;
+    underline?: boolean;
     title?: string;
     href: string;
     target?: string;
@@ -31,6 +32,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
     {
         view = 'normal',
         visitable,
+        underline,
         href,
         target,
         rel,
@@ -63,7 +65,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
         onBlur,
         id,
         style,
-        className: b({view, visitable}, className),
+        className: b({view, visitable, underline}, className),
         'data-qa': qa,
     };
 

--- a/src/components/Link/__stories__/Link.new.stories.tsx
+++ b/src/components/Link/__stories__/Link.new.stories.tsx
@@ -40,6 +40,9 @@ export default {
         id: {
             control: {type: 'text'},
         },
+        underline: {
+            control: {type: 'boolean'},
+        },
     },
     parameters: {
         order: -100,


### PR DESCRIPTION
Add underline property for link

underline - true
<img width="99" alt="Screenshot 2024-06-15 at 22 18 35" src="https://github.com/gravity-ui/uikit/assets/105169805/a5927073-ccdd-4569-8eab-9318ab1ea16b">

<img width="493" alt="Screenshot 2024-06-15 at 22 18 47" src="https://github.com/gravity-ui/uikit/assets/105169805/6c02d4da-4fbb-4e02-af63-b497dd8d7b7c">

underline - false
<img width="83" alt="Screenshot 2024-06-15 at 22 58 06" src="https://github.com/gravity-ui/uikit/assets/105169805/8ae9eda1-f8d1-410a-8c44-de82fe63d796">

<img width="486" alt="Screenshot 2024-06-15 at 22 58 36" src="https://github.com/gravity-ui/uikit/assets/105169805/f7670886-b130-4748-a798-ce5e719c771c">



<img width="558" alt="Screenshot 2024-06-15 at 22 15 03" src="https://github.com/gravity-ui/uikit/assets/105169805/fdcc9f05-6d9b-4368-b8e7-90ca2140163a">

Linked [issue](https://github.com/gravity-ui/uikit/issues/1642)