### PR TITLE
fix(Select): do not trigger `onOpenChange` in case of controlled `open`

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -178,6 +178,15 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
     const isErrorIconVisible =
         isErrorStateVisible && Boolean(errorMessage) && errorPlacement === 'inside';
 
+    const toggleOpenIfNeeded = React.useCallback(
+        (nextOpen?: boolean) => {
+            if (typeof propsOpen === 'undefined') {
+                toggleOpen(nextOpen);
+            }
+        },
+        [propsOpen, toggleOpen],
+    );
+
     const handleOptionClick = React.useCallback(
         (option?: FlattenOption) => {
             if (!option || option?.disabled || 'label' in option) {
@@ -215,12 +224,12 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
             }
             if ([KeyCode.ARROW_DOWN, KeyCode.ARROW_UP].includes(e.key) && !open) {
                 e.preventDefault();
-                toggleOpen();
+                toggleOpenIfNeeded();
             }
 
             listRef?.current?.onKeyDown(e);
         },
-        [handleOptionClick, open, toggleOpen],
+        [open, handleOptionClick, toggleOpenIfNeeded],
     );
 
     const handleFilterKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLElement>) => {
@@ -262,7 +271,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
         inlineStyles.width = width;
     }
 
-    const handleClose = React.useCallback(() => toggleOpen(false), [toggleOpen]);
+    const handleClose = React.useCallback(() => toggleOpenIfNeeded(false), [toggleOpenIfNeeded]);
     const {onFocus, onBlur} = props;
     const {focusWithinProps} = useFocusWithin({
         onFocusWithin: onFocus,
@@ -332,7 +341,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
             style={inlineStyles}
         >
             <SelectControl
-                toggleOpen={toggleOpen}
+                toggleOpen={toggleOpenIfNeeded}
                 hasClear={hasClear}
                 clearValue={handleClearValue}
                 ref={handleControlRef}

--- a/src/components/Select/__tests__/Select.base-actions.test.tsx
+++ b/src/components/Select/__tests__/Select.base-actions.test.tsx
@@ -139,14 +139,13 @@ describe('Select base actions', () => {
             expect(onOpenChange).toHaveBeenCalledWith(false);
             expect(onOpenChange).toHaveBeenCalledTimes(2);
         });
-        test('should call onOpenChange whith controlled open', async () => {
+        test('should not call onOpenChange with controlled open', async () => {
             const onOpenChange = jest.fn();
             setup({open: true, onOpenChange});
 
             await toggleSelectPopup();
 
-            expect(onOpenChange).toHaveBeenCalledWith(false);
-            expect(onOpenChange).toHaveBeenCalledTimes(1);
+            expect(onOpenChange).toHaveBeenCalledTimes(0);
         });
     });
 

--- a/src/hooks/useSelect/useSelect.ts
+++ b/src/hooks/useSelect/useSelect.ts
@@ -30,10 +30,11 @@ export const useSelect = <T extends unknown>({
                 const nextValue = [option.value];
                 setValue(nextValue);
             }
-
-            toggleOpen(false);
+            if (typeof open === 'undefined') {
+                toggleOpen(false);
+            }
         },
-        [value, setValue, toggleOpen],
+        [value, open, setValue, toggleOpen],
     );
 
     const handleMultipleSelection = React.useCallback(


### PR DESCRIPTION
Closes #1664 