### PR TITLE
feat(Card): use common constants for card's radiuses

### DIFF
--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -157,11 +157,11 @@ $block: '.#{variables.$ns}card';
 
     &_size {
         &_m {
-            --_--border-radius: var(--g-border-radius-l);
+            --_--border-radius: var(--g-border-radius-card-m);
         }
 
         &_l {
-            --_--border-radius: var(--g-border-radius-xxl);
+            --_--border-radius: var(--g-border-radius-card-l);
         }
     }
 }

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -157,11 +157,11 @@ $block: '.#{variables.$ns}card';
 
     &_size {
         &_m {
-            --_--border-radius: 8px;
+            --_--border-radius: var(--g-border-radius-l);
         }
 
         &_l {
-            --_--border-radius: 16px;
+            --_--border-radius: var(--g-border-radius-xxl);
         }
     }
 }

--- a/styles/themes/common/_index.scss
+++ b/styles/themes/common/_index.scss
@@ -12,7 +12,9 @@
     --g-border-radius-m: 6px;
     --g-border-radius-l: 8px;
     --g-border-radius-xl: 10px;
-    --g-border-radius-xxl: 16px;
+
+    --g-border-radius-card-m: 8px;
+    --g-border-radius-card-l: 16px;
 
     --g-focus-border-radius: 2px;
 

--- a/styles/themes/common/_index.scss
+++ b/styles/themes/common/_index.scss
@@ -12,6 +12,7 @@
     --g-border-radius-m: 6px;
     --g-border-radius-l: 8px;
     --g-border-radius-xl: 10px;
+    --g-border-radius-xxl: 16px;
 
     --g-focus-border-radius: 2px;
 


### PR DESCRIPTION
- add new radius constant --g-border-radius-xxl
- replace string values to common radius constants in styles
source:
https://github.com/gravity-ui/landing/pull/220#discussion_r1657214751