### PR TITLE
docs(Button): fix readme noText example

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -199,7 +199,6 @@ To add an icon to the `Button`, you should use the [`Icon`](../Icon) component, 
     <Icon data={Gear} size={18} />
 </Button>
 <Button view="outlined" size="l">
-    No text:
     <Icon data={Gear} size={18} />
 </Button>
 `}


### PR DESCRIPTION
Now if you copy the example without text, it turns out that it is not completely without text.