### PR TITLE
fix(Icon):  correctly parse function with default props

### DIFF
--- a/src/components/Icon/utils.ts
+++ b/src/components/Icon/utils.ts
@@ -15,7 +15,7 @@ export function isSvgrData(data: SVGIconData): data is SVGIconSvgrData {
 }
 
 export function isComponentSvgData(data: SVGIconData): data is SVGIconComponentData {
-    return typeof data === 'object' && 'defaultProps' in data;
+    return (typeof data === 'object' || typeof data === 'function') && 'defaultProps' in data;
 }
 
 export function isStringSvgData(data: SVGIconData): data is SVGIconStringData {


### PR DESCRIPTION
Now, we can catch a bag when the size or width and height are not specified directly and transform the input data for the icon by svgr.

**Example of transformed by svgr data svg from  [gravity-ui/icons/ ](https://github.com/gravity-ui/icons/blob/main/svgs/arrow-up-right-from-square.svg ) **
```
var ArrowUpRightFromSquareIcon = function ArrowUpRightFromSquareIcon(props) {
  return /*#__PURE__*/_jsx("svg", _objectSpread(_objectSpread({}, props), {}, {
    children: /*#__PURE__*/_jsx("path", {
      fill: "currentColor",
      fillRule: "evenodd",
      d: "M10 1.5A.75.75 0 0 0 10 3h1.94L6.97 7.97a.75.75 0 0 0 1.06 1.06L13 4.06V6a.75.75 0 0 0 1.5 0V2.25a.75.75 0 0 0-.75-.75H10ZM7.5 3.25a.75.75 0 0 0-.75-.75H4.5a3 3 0 0 0-3 3v6a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V9.25a.75.75 0 0 0-1.5 0v2.25a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 3 11.5v-6A1.5 1.5 0 0 1 4.5 4h2.25a.75.75 0 0 0 .75-.75Z",
      clipRule: "evenodd"
    })
  }));
};
ArrowUpRightFromSquareIcon.defaultProps = {
  xmlns: "http://www.w3.org/2000/svg",
  width: "16",
  height: "16",
  fill: "none",
  viewBox: "0 0 16 16"
};
```
Creating a component as a usual function skips the default props of the component.
Let's change the method of creating the SVGR component to getting props.

----
I hereby agree to the terms of the CLA available at: [CLA](https://yandex.ru/legal/cla/?lang=ru).