### PR TITLE
feat(ListItemView): ability to pass custom react node as a content prop

### DIFF
--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -164,7 +164,7 @@ const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
                         <TreeSelect
                             items={items}
                             size="s"
-                            mapItemDataToProps={(title) => ({title})}
+                            mapItemDataToContentProps={(title) => ({title})}
                             title="Actions select example"
                         />
                     );

--- a/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
+++ b/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
@@ -25,7 +25,7 @@ import type {
 } from '../../../../TreeSelect/types';
 import {TextInput} from '../../../../controls/TextInput';
 import {Flex} from '../../../../layout/Flex/Flex';
-import type {ListItemCommonProps, ListItemViewProps} from '../../../../useList';
+import type {ListItemViewContentType, ListItemViewProps} from '../../../../useList';
 import {ListContainerView, ListItemView, useListFilter} from '../../../../useList';
 import {block} from '../../../../utils/cn';
 import type {TableColumnConfig} from '../../../Table';
@@ -190,16 +190,18 @@ const useDndRenderItem = (sortable: boolean | undefined) => {
     }) => {
         const isDragDisabled = sortable === false || renderContainerProps?.isDragDisabled === true;
         const endSlot = isDragDisabled ? undefined : <Icon data={Grip} size={16} />;
-        const hasSelectionIcon = !item.isRequired;
         const startSlot = item.isRequired ? <Icon data={Lock} /> : undefined;
         const selected = item.isRequired ? false : props.selected;
 
         const commonProps: ListItemViewProps = {
             ...props,
             selected,
-            startSlot,
-            hasSelectionIcon,
-            endSlot,
+            selectionViewType: item.isRequired ? 'single' : 'multiple',
+            content: {
+                ...props.content,
+                startSlot,
+                endSlot,
+            },
         };
 
         if (isDragDisabled) {
@@ -241,7 +243,7 @@ export type TableColumnSetupItem = TableSetting & {
     sticky?: TableColumnConfig<unknown>['sticky'];
 };
 
-const mapItemDataToProps = (item: TableColumnSetupItem): ListItemCommonProps => {
+const mapItemDataToContentProps = (item: TableColumnSetupItem): ListItemViewContentType => {
     return {
         title: item.title,
     };
@@ -435,7 +437,7 @@ export const TableColumnSetup = (props: TableColumnSetupProps) => {
     return (
         <TreeSelect
             className={b(null, className)}
-            mapItemDataToProps={mapItemDataToProps}
+            mapItemDataToContentProps={mapItemDataToContentProps}
             multiple
             size="l"
             open={open}

--- a/src/components/TreeList/TreeList.tsx
+++ b/src/components/TreeList/TreeList.tsx
@@ -28,7 +28,7 @@ export const TreeList = <T,>({
     renderItem: propsRenderItem,
     renderContainer = ListContainer,
     onItemClick: propsOnItemClick,
-    mapItemDataToProps,
+    mapItemDataToContentProps,
 }: TreeListProps<T>) => {
     const uniqId = useUniqId();
     const treeListId = id ?? uniqId;
@@ -71,7 +71,7 @@ export const TreeList = <T,>({
             id: itemId,
             size,
             multiple,
-            mapItemDataToProps,
+            mapItemDataToContentProps,
             onItemClick,
             list,
         });

--- a/src/components/TreeList/__stories__/TreeListDocs.md
+++ b/src/components/TreeList/__stories__/TreeListDocs.md
@@ -25,7 +25,7 @@ const items: ListItemType<string>[] = ['one', 'two', 'free', 'four', 'five'];
 
 const list = useList({items});
 
-<TreeList list={list} mapItemDataToProps={(item) => ({title: item})} />;
+<TreeList list={list} mapItemDataToContentProps={(item) => ({title: item})} />;
 ```
 
 ### Example with state:
@@ -56,7 +56,7 @@ const Component = () => {
     <TreeList
       list={list}
       onItemClick={handleItemClick}
-      mapItemDataToProps={({title}) => ({title})}
+      mapItemDataToContentProps={({title}) => ({title})}
     />
   );
 };
@@ -64,18 +64,18 @@ const Component = () => {
 
 ## Props:
 
-| Name               | Description                                                                                                                                                                                                                    |                                             Type                                             | Default |
-| :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------: | :-----: |
-| list               | result of [list](/docs/lab-uselist--docs#uselist) hook.                                                                                                                                                                        |                                       `UseListResult`                                        |         |
-| containerRef       | a reference to the DOM element of the List container inside which to search for its elements;                                                                                                                                  |                      `React.RefObject<HTMLDivElement \| HTMLUlElement>`                      |         |
-| qa                 | Selector for tests                                                                                                                                                                                                             |                                           `string`                                           |         |
-| size               | The size of the element. This also affects the rounding radius of the list element                                                                                                                                             |                                     `s \| m \| l \| xl`                                      |   `m`   |
-| mapItemDataToProps | Map list item data (`T`) to `ListItemView` props                                                                                                                                                                               |                              `(data: T) => ListItemCommonProps`                              |         |
-| multiple           | One or multiple elements selected list                                                                                                                                                                                         |                                          `boolean`                                           | `false` |
-| id                 | id attribute                                                                                                                                                                                                                   |                                           `string`                                           |         |
-| renderItem         | Redefine the rendering of a list item. For example, add dividers between list items or wrap an item in a link component. As a view component to display a list item, use [ListItemView](/docs/lab-uselist--docs#listitemview); |                   `(props: TreeListRenderItem<T, P>) => React.JSX.Element`                   |         |
-| renderContainer    | Render custom list container.                                                                                                                                                                                                  |                  `(props: TreeListRenderContainer<T>) => React.JSX.Element`                  |         |
-| onItemClick        | Override default on click behavior. Pass `null` to disable on click handler                                                                                                                                                    | `(props: {id: ListItemId; list: UseListResult<T>}, e: React.SyntheticEvent) => void \| null` |         |
+| Name                      | Description                                                                                                                                                                                                                    |                                             Type                                             | Default |
+| :------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------: | :-----: |
+| list                      | result of [list](/docs/lab-uselist--docs#uselist) hook.                                                                                                                                                                        |                                       `UseListResult`                                        |         |
+| containerRef              | a reference to the DOM element of the List container inside which to search for its elements;                                                                                                                                  |                      `React.RefObject<HTMLDivElement \| HTMLUlElement>`                      |         |
+| qa                        | Selector for tests                                                                                                                                                                                                             |                                           `string`                                           |         |
+| size                      | The size of the element. This also affects the rounding radius of the list element                                                                                                                                             |                                     `s \| m \| l \| xl`                                      |   `m`   |
+| mapItemDataToContentProps | Map list item data (`T`) to `ListItemView` `content` prop                                                                                                                                                                      |                           `(data: T) => ListItemViewContentProps`                            |         |
+| multiple                  | One or multiple elements selected list                                                                                                                                                                                         |                                          `boolean`                                           | `false` |
+| id                        | id attribute                                                                                                                                                                                                                   |                                           `string`                                           |         |
+| renderItem                | Redefine the rendering of a list item. For example, add dividers between list items or wrap an item in a link component. As a view component to display a list item, use [ListItemView](/docs/lab-uselist--docs#listitemview); |                   `(props: TreeListRenderItem<T, P>) => React.JSX.Element`                   |         |
+| renderContainer           | Render custom list container.                                                                                                                                                                                                  |                  `(props: TreeListRenderContainer<T>) => React.JSX.Element`                  |         |
+| onItemClick               | Override default on click behavior. Pass `null` to disable on click handler                                                                                                                                                    | `(props: {id: ListItemId; list: UseListResult<T>}, e: React.SyntheticEvent) => void \| null` |         |
 
 ### TreeListRenderItem props:
 

--- a/src/components/TreeList/__stories__/stories/DefaultStory.tsx
+++ b/src/components/TreeList/__stories__/stories/DefaultStory.tsx
@@ -12,7 +12,7 @@ function identity<T>(value: T): T {
 }
 
 export interface DefaultStoryProps
-    extends Omit<TreeListProps<{title: string}>, 'items' | 'mapItemDataToProps'> {
+    extends Omit<TreeListProps<{title: string}>, 'items' | 'mapItemDataToContentProps'> {
     itemsCount?: number;
 }
 
@@ -34,7 +34,7 @@ export const DefaultStory = ({itemsCount = 5, ...props}: DefaultStoryProps) => {
                     {...props}
                     list={listWithGroups}
                     onItemClick={null}
-                    mapItemDataToProps={identity}
+                    mapItemDataToContentProps={identity}
                 />
             </Flex>
             <Flex direction={'column'} gap="3">
@@ -46,7 +46,7 @@ export const DefaultStory = ({itemsCount = 5, ...props}: DefaultStoryProps) => {
                     {...props}
                     list={listWithNoGroups}
                     onItemClick={null}
-                    mapItemDataToProps={identity}
+                    mapItemDataToContentProps={identity}
                 />
             </Flex>
         </Flex>

--- a/src/components/TreeList/__stories__/stories/InfinityScrollStory.tsx
+++ b/src/components/TreeList/__stories__/stories/InfinityScrollStory.tsx
@@ -21,7 +21,7 @@ function identity<T>(value: T): T {
 export interface InfinityScrollStoryProps
     extends Omit<
         TreeListProps<Entity>,
-        'value' | 'onUpdate' | 'items' | 'multiple' | 'size' | 'mapItemDataToProps'
+        'value' | 'onUpdate' | 'items' | 'multiple' | 'size' | 'mapItemDataToContentProps'
     > {
     itemsCount?: number;
 }
@@ -44,13 +44,18 @@ export const InfinityScrollStory = ({itemsCount = 3, ...storyProps}: InfinityScr
                 {...storyProps}
                 size="l"
                 list={list}
-                mapItemDataToProps={identity}
+                mapItemDataToContentProps={identity}
                 multiple={multiple}
                 renderItem={({props, context: {isLastItem, childrenIds}}) => {
                     const node = (
                         <ListItemView
                             {...props}
-                            endSlot={childrenIds ? <Label>{childrenIds.length}</Label> : undefined}
+                            content={{
+                                ...props.content,
+                                endSlot: childrenIds ? (
+                                    <Label>{childrenIds.length}</Label>
+                                ) : undefined,
+                            }}
                         />
                     );
 

--- a/src/components/TreeList/__stories__/stories/WithDisabledElementsStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithDisabledElementsStory.tsx
@@ -8,7 +8,7 @@ import {TreeList} from '../../TreeList';
 import type {TreeListProps} from '../../types';
 
 export interface WithDisabledElementsStoryProps
-    extends Omit<TreeListProps<{text: string}>, 'items' | 'mapItemDataToProps'> {}
+    extends Omit<TreeListProps<{text: string}>, 'items' | 'mapItemDataToContentProps'> {}
 
 const items: ListItemType<{text: string}>[] = [
     {
@@ -50,7 +50,7 @@ export const WithDisabledElementsStory = ({...storyProps}: WithDisabledElementsS
                 {...storyProps}
                 list={list}
                 containerRef={containerRef}
-                mapItemDataToProps={({text}) => ({title: text})}
+                mapItemDataToContentProps={({text}) => ({title: text})}
                 onItemClick={({id}) => {
                     getListItemClickHandler({list})({id});
                     alert(

--- a/src/components/TreeList/__stories__/stories/WithDndListStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithDndListStory.tsx
@@ -42,7 +42,7 @@ const randomItems: CustomDataType[] = createRandomizedData({
 }).map(({data}, idx) => ({someRandomKey: data, id: String(idx)}));
 
 export interface WithDndListStoryProps
-    extends Omit<TreeListProps<CustomDataType>, 'items' | 'mapItemDataToProps'> {}
+    extends Omit<TreeListProps<CustomDataType>, 'items' | 'mapItemDataToContentProps'> {}
 
 export const WithDndListStory = (storyProps: WithDndListStoryProps) => {
     const [items, setItems] = React.useState(randomItems);
@@ -117,10 +117,13 @@ export const WithDndListStory = (storyProps: WithDndListStoryProps) => {
         index,
         renderContainerProps,
     }) => {
-        const commonProps = {
+        const commonProps: ListItemViewProps = {
             ...props,
-            title: data.someRandomKey,
-            endSlot: <Icon data={Grip} size={16} />,
+            content: {
+                ...props.content,
+                title: data.someRandomKey,
+                endSlot: <Icon data={Grip} size={16} />,
+            },
         };
 
         // here passed props from `renderContainer` method.
@@ -151,7 +154,7 @@ export const WithDndListStory = (storyProps: WithDndListStoryProps) => {
             {...storyProps}
             list={list}
             containerRef={containerRef}
-            mapItemDataToProps={({someRandomKey}) => ({title: someRandomKey})}
+            mapItemDataToContentProps={({someRandomKey}) => ({title: someRandomKey})}
             renderContainer={renderContainer}
             renderItem={renderItem}
         />

--- a/src/components/TreeList/__stories__/stories/WithFiltrationAndControlsStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithFiltrationAndControlsStory.tsx
@@ -15,7 +15,10 @@ interface Entity {
 }
 
 export interface WithFiltrationAndControlsStoryProps
-    extends Omit<TreeListProps<Entity>, 'value' | 'onUpdate' | 'items' | 'mapItemDataToProps'> {
+    extends Omit<
+        TreeListProps<Entity>,
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps'
+    > {
     itemsCount?: number;
 }
 
@@ -59,7 +62,7 @@ export const WithFiltrationAndControlsStory = ({
             <TreeList
                 {...treeSelectProps}
                 list={list}
-                mapItemDataToProps={(x) => x}
+                mapItemDataToContentProps={(x) => x}
                 renderContainer={renderContainer}
             />
             <Flex gap="2" className={spacing({px: 2, py: 1})}>

--- a/src/components/TreeList/__stories__/stories/WithGroupSelectionAndCustomIconStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithGroupSelectionAndCustomIconStory.tsx
@@ -6,7 +6,7 @@ import {Button} from '../../../Button';
 import {Icon} from '../../../Icon';
 import {Flex, spacing} from '../../../layout';
 import {ListItemView, useList} from '../../../useList';
-import type {ListItemCommonProps, ListItemId} from '../../../useList';
+import type {ListItemId, ListItemViewContentType} from '../../../useList';
 import {createRandomizedData} from '../../../useList/__stories__/utils/makeData';
 import {TreeList} from '../../TreeList';
 import type {TreeListProps} from '../../types';
@@ -24,12 +24,14 @@ interface CustomDataStructure {
 export interface WithGroupSelectionAndCustomIconStoryProps
     extends Omit<
         TreeListProps<CustomDataStructure>,
-        'value' | 'onUpdate' | 'items' | 'cantainerRef' | 'size' | 'mapItemDataToProps'
+        'value' | 'onUpdate' | 'items' | 'cantainerRef' | 'size' | 'mapItemDataToContentProps'
     > {
     itemsCount?: number;
 }
 
-const mapCustomDataStructureToKnownProps = (props: CustomDataStructure): ListItemCommonProps => ({
+const mapCustomDataStructureToKnownProps = (
+    props: CustomDataStructure,
+): ListItemViewContentType => ({
     title: props.a,
 });
 
@@ -61,28 +63,26 @@ export const WithGroupSelectionAndCustomIconStory = ({
                 {...props}
                 list={list}
                 size="l"
-                mapItemDataToProps={mapCustomDataStructureToKnownProps}
+                mapItemDataToContentProps={mapCustomDataStructureToKnownProps}
                 onItemClick={onItemClick}
-                renderItem={({
-                    data,
-                    props: {
-                        expanded, // don't use default ListItemView expand icon
-                        ...preparedProps
-                    },
-                    context: {childrenIds},
-                }) => {
+                renderItem={({id, props: itemProps, context: {childrenIds}}) => {
                     // has no group
-                    preparedProps.hasSelectionIcon = Boolean(props.multiple);
+                    itemProps.selectionViewType = props.multiple ? 'multiple' : 'single';
 
                     return (
                         <ListItemView
-                            {...preparedProps}
-                            {...mapCustomDataStructureToKnownProps(data)}
-                            startSlot={
-                                <Icon size={16} data={childrenIds ? Database : PlugConnection} />
-                            }
-                            endSlot={
-                                childrenIds ? (
+                            {...itemProps}
+                            content={{
+                                ...itemProps.content,
+                                isGroup: false,
+                                startSlot: (
+                                    <Icon
+                                        size={16}
+                                        data={childrenIds ? Database : PlugConnection}
+                                    />
+                                ),
+
+                                endSlot: childrenIds ? (
                                     <Button
                                         size="m"
                                         className={spacing({mr: 1})}
@@ -90,20 +90,24 @@ export const WithGroupSelectionAndCustomIconStory = ({
                                             e.stopPropagation();
                                             list.state.setExpanded?.((prevExpandedState) => ({
                                                 ...prevExpandedState,
-                                                [preparedProps.id]:
-                                                    !prevExpandedState[preparedProps.id],
+                                                [id]: !prevExpandedState[id],
                                             }));
                                         }}
                                         extraProps={{
-                                            'aria-label': expanded
+                                            'aria-label': itemProps.content.expanded
                                                 ? closeButtonLabel
                                                 : expandButtonLabel,
                                         }}
                                     >
-                                        <Icon data={expanded ? ChevronDown : ChevronUp} size={16} />
+                                        <Icon
+                                            data={
+                                                itemProps.content.expanded ? ChevronDown : ChevronUp
+                                            }
+                                            size={16}
+                                        />
                                     </Button>
-                                ) : undefined
-                            }
+                                ) : undefined,
+                            }}
                         />
                     );
                 }}

--- a/src/components/TreeList/__stories__/stories/WithItemLinksAndActionsStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithItemLinksAndActionsStory.tsx
@@ -21,7 +21,7 @@ function identity<T>(value: T): T {
 }
 
 export interface WithItemLinksAndActionsStoryProps
-    extends Omit<TreeListProps<{title: string}>, 'items' | 'size' | 'mapItemDataToProps'> {}
+    extends Omit<TreeListProps<{title: string}>, 'items' | 'size' | 'mapItemDataToContentProps'> {}
 
 export const WithItemLinksAndActionsStory = (props: WithItemLinksAndActionsStoryProps) => {
     const items = React.useMemo(() => createRandomizedData({num: 10, depth: 1}), []);
@@ -43,49 +43,41 @@ export const WithItemLinksAndActionsStory = (props: WithItemLinksAndActionsStory
         <TreeList
             {...props}
             list={list}
-            mapItemDataToProps={identity}
+            mapItemDataToContentProps={identity}
             onItemClick={onItemClick}
             size="l"
-            renderItem={({
-                data,
-                props: {
-                    expanded, // don't use build in expand icon ListItemView behavior
-                    ...state
-                },
-                context: {childrenIds},
-            }) => {
+            renderItem={({id, props: itemProps, context: {childrenIds}}) => {
                 return (
                     // eslint-disable-next-line jsx-a11y/anchor-is-valid
                     <a href="#" style={{textDecoration: 'none', color: 'inherit', width: '100%'}}>
                         <ListItemView
-                            {...data}
-                            {...state}
-                            endSlot={
-                                <DropdownMenu
-                                    onSwitcherClick={(e) => {
-                                        e.stopPropagation();
-                                        e.preventDefault();
-                                    }}
-                                    items={[
-                                        {
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                console.log(
-                                                    `Clicked by action with id: ${state.id}`,
-                                                );
+                            {...itemProps}
+                            content={{
+                                ...itemProps.content,
+                                isGroup: false,
+                                endSlot: (
+                                    <DropdownMenu
+                                        onSwitcherClick={(e) => {
+                                            e.stopPropagation();
+                                            e.preventDefault();
+                                        }}
+                                        items={[
+                                            {
+                                                action: (e) => {
+                                                    e.stopPropagation();
+                                                    console.log(`Clicked by action with id: ${id}`);
+                                                },
+                                                text: 'action 1',
                                             },
-                                            text: 'action 1',
-                                        },
-                                    ]}
-                                    defaultSwitcherProps={{
-                                        extraProps: {
-                                            'aria-label': moreOptionsButton,
-                                        },
-                                    }}
-                                />
-                            }
-                            startSlot={
-                                childrenIds ? (
+                                        ]}
+                                        defaultSwitcherProps={{
+                                            extraProps: {
+                                                'aria-label': moreOptionsButton,
+                                            },
+                                        }}
+                                    />
+                                ),
+                                startSlot: childrenIds ? (
                                     <Button
                                         size="m"
                                         view="flat"
@@ -95,27 +87,36 @@ export const WithItemLinksAndActionsStory = (props: WithItemLinksAndActionsStory
 
                                             list.state.setExpanded?.((prevExpandedState) => ({
                                                 ...prevExpandedState,
-                                                [state.id]: !prevExpandedState[state.id],
+                                                [id]: !prevExpandedState[id],
                                             }));
                                         }}
                                         extraProps={{
-                                            'aria-label': expanded
+                                            'aria-label': itemProps.content.expanded
                                                 ? closeButtonLabel
                                                 : expandButtonLabel,
                                         }}
                                     >
-                                        <Icon data={expanded ? ChevronDown : ChevronUp} size={16} />
+                                        <Icon
+                                            data={
+                                                itemProps.content.expanded ? ChevronDown : ChevronUp
+                                            }
+                                            size={16}
+                                        />
                                     </Button>
                                 ) : (
                                     <Flex
                                         width={28}
                                         justifyContent="center"
-                                        spacing={state.indentation > 0 ? {ml: 1} : undefined}
+                                        spacing={
+                                            (itemProps.content.indentation || 0) > 0
+                                                ? {ml: 1}
+                                                : undefined
+                                        }
                                     >
                                         <Icon data={FolderOpen} size={16} />
                                     </Flex>
-                                )
-                            }
+                                ),
+                            }}
                         />
                     </a>
                 );

--- a/src/components/TreeList/types.ts
+++ b/src/components/TreeList/types.ts
@@ -3,11 +3,11 @@ import type React from 'react';
 import type {QAProps} from '../types';
 import type {
     ListContainerProps,
-    ListItemCommonProps,
     ListItemId,
     ListItemListContextProps,
     ListItemSize,
-    RenderItemProps,
+    ListItemViewCommonProps,
+    ListItemViewContentType,
     UseListResult,
 } from '../useList';
 
@@ -15,7 +15,7 @@ export type TreeListRenderItem<T, P extends {} = {}> = (props: {
     id: ListItemId;
     data: T;
     // required item props to render
-    props: RenderItemProps;
+    props: ListItemViewCommonProps;
     // internal list context props
     context: ListItemListContextProps;
     list: UseListResult<T>;
@@ -29,7 +29,7 @@ export type TreeListContainerProps<T> = ListContainerProps<T> & {
 
 export type TreeListRenderContainer<T> = (props: TreeListContainerProps<T>) => React.JSX.Element;
 
-export type TreeListMapItemDataToProps<T> = (item: T) => ListItemCommonProps;
+export type TreeListMapItemDataToContentProps<T> = (item: T) => ListItemViewContentType;
 
 export type TreeListOnItemClickPayload<T> = {id: ListItemId; list: UseListResult<T>};
 
@@ -57,5 +57,8 @@ export interface TreeListProps<T, P extends {} = {}> extends QAProps {
      * `null` - disable default click handler
      */
     onItemClick?: null | TreeListOnItemClick<T>;
-    mapItemDataToProps: TreeListMapItemDataToProps<T>;
+    /**
+     * List item `data` to ListItemView `content` props
+     */
+    mapItemDataToContentProps: TreeListMapItemDataToContentProps<T>;
 }

--- a/src/components/TreeSelect/TreeSelect.tsx
+++ b/src/components/TreeSelect/TreeSelect.tsx
@@ -57,7 +57,7 @@ export const TreeSelect = React.forwardRef(function TreeSelect<T>(
         renderControl,
         renderItem = defaultItemRenderer as TreeListRenderItem<T>,
         renderContainer,
-        mapItemDataToProps,
+        mapItemDataToContentProps,
         onFocus,
         onBlur,
         getItemId,
@@ -173,7 +173,9 @@ export const TreeSelect = React.forwardRef(function TreeSelect<T>(
         <SelectControl
             {...controlProps}
             selectedOptionsContent={React.Children.toArray(
-                value.map((itemId) => mapItemDataToProps(list.structure.itemsById[itemId]).title),
+                value.map(
+                    (itemId) => mapItemDataToContentProps(list.structure.itemsById[itemId]).title,
+                ),
             ).join(', ')}
             view="normal"
             pin="round-round"
@@ -224,7 +226,7 @@ export const TreeSelect = React.forwardRef(function TreeSelect<T>(
                     containerRef={containerRef}
                     onItemClick={handleItemClick}
                     renderContainer={renderContainer}
-                    mapItemDataToProps={mapItemDataToProps}
+                    mapItemDataToContentProps={mapItemDataToContentProps}
                     renderItem={renderItem ?? defaultItemRenderer}
                 />
 

--- a/src/components/TreeSelect/__stories__/TreeSelect.stories.tsx
+++ b/src/components/TreeSelect/__stories__/TreeSelect.stories.tsx
@@ -42,7 +42,7 @@ export default {
 const DefaultTemplate: StoryFn<
     Omit<
         TreeSelectProps<{title: string}>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps'
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps'
     > & {
         itemsCount?: number;
     }
@@ -55,7 +55,7 @@ const DefaultTemplate: StoryFn<
                 {...props}
                 placeholder="-"
                 items={items}
-                mapItemDataToProps={(x) => x}
+                mapItemDataToContentProps={(x) => x}
                 onItemClick={({id, list}) => {
                     getListItemClickHandler({list})({id});
                     console.log('clicked on item with id: ', id);

--- a/src/components/TreeSelect/__stories__/components/InfinityScrollExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/InfinityScrollExample.tsx
@@ -23,7 +23,7 @@ function identity<T>(value: T): T {
 export interface InfinityScrollExampleProps
     extends Omit<
         TreeSelectProps<Entity>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps' | 'multiple' | 'defaultValue'
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps' | 'multiple' | 'defaultValue'
     > {
     itemsCount?: number;
 }
@@ -75,16 +75,20 @@ export const InfinityScrollExample = ({
             <TreeSelect
                 {...storyProps}
                 value={value}
-                mapItemDataToProps={identity}
+                mapItemDataToContentProps={identity}
                 items={items}
                 onItemClick={handleGroupItemClick}
-                renderItem={({data, props, context: {isLastItem, childrenIds}}) => {
+                renderItem={({props, context: {isLastItem, childrenIds}}) => {
                     const node = (
                         <ListItemView
                             {...props}
-                            {...data}
+                            content={{
+                                ...props.content,
+                                endSlot: childrenIds ? (
+                                    <Label>{childrenIds.length}</Label>
+                                ) : undefined,
+                            }}
                             className={sp({mx: 1})}
-                            endSlot={childrenIds ? <Label>{childrenIds.length}</Label> : undefined}
                         />
                     );
 

--- a/src/components/TreeSelect/__stories__/components/WithDisabledElementsExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithDisabledElementsExample.tsx
@@ -10,7 +10,7 @@ interface Entity {
 }
 
 export interface WithDisabledElementsExampleProps
-    extends Omit<TreeSelectProps<Entity>, 'items' | 'mapItemDataToProps'> {}
+    extends Omit<TreeSelectProps<Entity>, 'items' | 'mapItemDataToContentProps'> {}
 
 const items: ListItemType<Entity>[] = [
     {
@@ -42,7 +42,7 @@ export const WithDisabledElementsExample = ({...props}: WithDisabledElementsExam
             items={items}
             getItemId={({id}) => id}
             containerRef={containerRef}
-            mapItemDataToProps={({text}) => ({title: text})}
+            mapItemDataToContentProps={({text}) => ({title: text})}
         />
     );
 };

--- a/src/components/TreeSelect/__stories__/components/WithDndListExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithDndListExample.tsx
@@ -38,7 +38,7 @@ type CustomDataType = {someRandomKey: string; id: string};
 export interface WithDndListExampleProps
     extends Omit<
         TreeSelectProps<CustomDataType>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps'
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps'
     > {}
 
 const randomItems: CustomDataType[] = createRandomizedData({
@@ -108,10 +108,13 @@ export const WithDndListExample = (storyProps: WithDndListExampleProps) => {
         index,
         renderContainerProps,
     }) => {
-        const commonProps = {
+        const commonProps: ListItemViewProps = {
             ...props,
-            title: data.someRandomKey,
-            endSlot: <Icon data={Grip} size={16} />,
+            content: {
+                ...props.content,
+                title: data.someRandomKey,
+                endSlot: <Icon data={Grip} size={16} />,
+            },
         };
 
         // here passed props from `renderContainer` method.
@@ -144,7 +147,7 @@ export const WithDndListExample = (storyProps: WithDndListExampleProps) => {
                 items={items}
                 // you can omit this prop here. If prop `id` passed, TreeSelect would take it by default
                 getItemId={({id}) => id}
-                mapItemDataToProps={({someRandomKey}) => ({
+                mapItemDataToContentProps={({someRandomKey}) => ({
                     title: someRandomKey,
                 })}
                 renderContainer={renderContainer}

--- a/src/components/TreeSelect/__stories__/components/WithFiltrationAndControlsExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithFiltrationAndControlsExample.tsx
@@ -17,7 +17,7 @@ function identity<T>(value: T): T {
 export interface WithFiltrationAndControlsExampleProps
     extends Omit<
         TreeSelectProps<{title: string}>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps' | 'defaultValue' | 'multiple'
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps' | 'defaultValue' | 'multiple'
     > {
     itemsCount?: number;
 }
@@ -51,7 +51,7 @@ export const WithFiltrationAndControlsExample = ({
         <Flex>
             <TreeSelect
                 {...treeSelectProps}
-                mapItemDataToProps={identity}
+                mapItemDataToContentProps={identity}
                 multiple
                 open={open}
                 popupWidth={350}
@@ -68,9 +68,9 @@ export const WithFiltrationAndControlsExample = ({
                         ref={filterState.filterRef}
                     />
                 }
-                renderItem={({props, data}) => (
+                renderItem={({props}) => (
                     <div style={{paddingInline: 8}}>
-                        <ListItemView {...props} {...data} />
+                        <ListItemView {...props} />
                     </div>
                 )}
                 renderContainer={renderContainer}

--- a/src/components/TreeSelect/__stories__/components/WithGroupSelectionControlledStateAndCustomIcon.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithGroupSelectionControlledStateAndCustomIcon.tsx
@@ -6,7 +6,7 @@ import {Button} from '../../../Button';
 import {Icon} from '../../../Icon';
 import {Flex, spacing} from '../../../layout';
 import {ListItemView} from '../../../useList';
-import type {ListItemCommonProps, ListItemId, UseListResult} from '../../../useList';
+import type {ListItemId, ListItemViewContentType, UseListResult} from '../../../useList';
 import {createRandomizedData} from '../../../useList/__stories__/utils/makeData';
 import {TreeSelect} from '../../TreeSelect';
 import type {TreeSelectProps} from '../../types';
@@ -21,18 +21,20 @@ interface CustomDataStructure {
 export interface WithGroupSelectionControlledStateAndCustomIconExampleProps
     extends Omit<
         TreeSelectProps<CustomDataStructure>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps' | 'size'
+        'value' | 'onUpdate' | 'items' | 'mapItemDataToContentProps' | 'size'
     > {
     itemsCount?: number;
 }
 
-const mapCustomDataStructureToKnownProps = (props: CustomDataStructure): ListItemCommonProps => ({
+const mapCustomDataStructureToKnownProps = (
+    props: CustomDataStructure,
+): ListItemViewContentType => ({
     title: props.a,
 });
 
 export const WithGroupSelectionControlledStateAndCustomIconExample = ({
     itemsCount = 5,
-    ...props
+    ...storyProps
 }: WithGroupSelectionControlledStateAndCustomIconExampleProps) => {
     // const [value, setValue] = React.useState<string[]>([]);
     const [open, setOpen] = React.useState(true);
@@ -55,35 +57,30 @@ export const WithGroupSelectionControlledStateAndCustomIconExample = ({
     return (
         <Flex>
             <TreeSelect
-                {...props}
+                {...storyProps}
                 size="l"
                 open={open}
                 onOpenChange={setOpen}
-                // value={value}
                 items={items}
-                mapItemDataToProps={mapCustomDataStructureToKnownProps}
+                mapItemDataToContentProps={mapCustomDataStructureToKnownProps}
                 onItemClick={onItemClick}
-                renderItem={({
-                    data,
-                    props: {
-                        expanded, // don't use default ListItemView expand icon
-                        ...renderProps
-                    },
-                    context: {childrenIds},
-                    list,
-                }) => {
+                renderItem={({id, props, context: {childrenIds}, list}) => {
                     // groups items are selectable too
-                    renderProps.hasSelectionIcon = Boolean(props.multiple);
+                    props.selectionViewType = storyProps.multiple ? 'multiple' : 'single';
 
                     return (
                         <ListItemView
-                            {...renderProps}
-                            {...mapCustomDataStructureToKnownProps(data)}
-                            startSlot={
-                                <Icon size={16} data={childrenIds ? Database : PlugConnection} />
-                            }
-                            endSlot={
-                                childrenIds ? (
+                            {...props}
+                            content={{
+                                ...props.content,
+                                isGroup: false,
+                                startSlot: (
+                                    <Icon
+                                        size={16}
+                                        data={childrenIds ? Database : PlugConnection}
+                                    />
+                                ),
+                                endSlot: childrenIds ? (
                                     <Button
                                         size="m"
                                         className={spacing({mr: 1})}
@@ -91,15 +88,17 @@ export const WithGroupSelectionControlledStateAndCustomIconExample = ({
                                             e.stopPropagation();
                                             list.state.setExpanded?.((prevExpandedState) => ({
                                                 ...prevExpandedState,
-                                                [renderProps.id]:
-                                                    !prevExpandedState[renderProps.id],
+                                                [id]: !prevExpandedState[id],
                                             }));
                                         }}
                                     >
-                                        <Icon data={expanded ? ChevronDown : ChevronUp} size={16} />
+                                        <Icon
+                                            data={props.content.expanded ? ChevronDown : ChevronUp}
+                                            size={16}
+                                        />
                                     </Button>
-                                ) : undefined
-                            }
+                                ) : undefined,
+                            }}
                         />
                     );
                 }}

--- a/src/components/TreeSelect/__stories__/components/WithItemLinksAndActionsExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithItemLinksAndActionsExample.tsx
@@ -18,10 +18,16 @@ function identity<T>(value: T): T {
 export interface WithItemLinksAndActionsExampleProps
     extends Omit<
         TreeSelectProps<{title: string}>,
-        'value' | 'onUpdate' | 'items' | 'mapItemDataToProps' | 'size' | 'open' | 'onOpenChange'
+        | 'value'
+        | 'onUpdate'
+        | 'items'
+        | 'mapItemDataToContentProps'
+        | 'size'
+        | 'open'
+        | 'onOpenChange'
     > {}
 
-export const WithItemLinksAndActionsExample = (props: WithItemLinksAndActionsExampleProps) => {
+export const WithItemLinksAndActionsExample = (storyProps: WithItemLinksAndActionsExampleProps) => {
     const [value, setValue] = React.useState<string[]>([]);
     const [open, setOpen] = React.useState(true);
     const items = React.useMemo(() => createRandomizedData({num: 10, depth: 1}), []);
@@ -39,22 +45,14 @@ export const WithItemLinksAndActionsExample = (props: WithItemLinksAndActionsExa
     return (
         <Flex>
             <TreeSelect
-                {...props}
+                {...storyProps}
                 value={value}
                 items={items}
-                mapItemDataToProps={identity}
+                mapItemDataToContentProps={identity}
                 open={open}
                 onOpenChange={setOpen}
                 size="l"
-                renderItem={({
-                    data,
-                    props: {
-                        expanded, // don't use build in expand icon ListItemView behavior
-                        ...state
-                    },
-                    context: {childrenIds},
-                    list,
-                }) => {
+                renderItem={({id, props, context: {childrenIds}, list}) => {
                     return (
                         // eslint-disable-next-line jsx-a11y/anchor-is-valid
                         <a
@@ -62,30 +60,30 @@ export const WithItemLinksAndActionsExample = (props: WithItemLinksAndActionsExa
                             style={{textDecoration: 'none', color: 'inherit', width: '100%'}}
                         >
                             <ListItemView
-                                {...data}
-                                {...state}
-                                onClick={() => onItemClick(state.id, list)}
-                                endSlot={
-                                    <DropdownMenu
-                                        onSwitcherClick={(e) => {
-                                            e.stopPropagation();
-                                            e.preventDefault();
-                                        }}
-                                        items={[
-                                            {
-                                                action: (e) => {
-                                                    e.stopPropagation();
-                                                    console.log(
-                                                        `Clicked by action with id: ${state.id}`,
-                                                    );
+                                {...props}
+                                content={{
+                                    ...props.content,
+                                    isGroup: false,
+                                    endSlot: (
+                                        <DropdownMenu
+                                            onSwitcherClick={(e) => {
+                                                e.stopPropagation();
+                                                e.preventDefault();
+                                            }}
+                                            items={[
+                                                {
+                                                    action: (e) => {
+                                                        e.stopPropagation();
+                                                        console.log(
+                                                            `Clicked by action with id: ${id}`,
+                                                        );
+                                                    },
+                                                    text: 'action 1',
                                                 },
-                                                text: 'action 1',
-                                            },
-                                        ]}
-                                    />
-                                }
-                                startSlot={
-                                    childrenIds ? (
+                                            ]}
+                                        />
+                                    ),
+                                    startSlot: childrenIds ? (
                                         <Button
                                             size="m"
                                             view="flat"
@@ -95,12 +93,14 @@ export const WithItemLinksAndActionsExample = (props: WithItemLinksAndActionsExa
 
                                                 list.state.setExpanded?.((prevExpandedState) => ({
                                                     ...prevExpandedState,
-                                                    [state.id]: !prevExpandedState[state.id],
+                                                    [id]: !prevExpandedState[id],
                                                 }));
                                             }}
                                         >
                                             <Icon
-                                                data={expanded ? ChevronDown : ChevronUp}
+                                                data={
+                                                    props.content.expanded ? ChevronDown : ChevronUp
+                                                }
                                                 size={16}
                                             />
                                         </Button>
@@ -108,12 +108,17 @@ export const WithItemLinksAndActionsExample = (props: WithItemLinksAndActionsExa
                                         <Flex
                                             width={28}
                                             justifyContent="center"
-                                            spacing={state.indentation > 0 ? {ml: 1} : undefined}
+                                            spacing={
+                                                (props.content.indentation ?? 0) > 0
+                                                    ? {ml: 1}
+                                                    : undefined
+                                            }
                                         >
                                             <Icon data={FolderOpen} size={16} />
                                         </Flex>
-                                    )
-                                }
+                                    ),
+                                }}
+                                onClick={() => onItemClick(id, list)}
                             />
                         </a>
                     );

--- a/src/components/useList/__stories__/Docs.mdx
+++ b/src/components/useList/__stories__/Docs.mdx
@@ -74,7 +74,7 @@ function List() {
             {list.structure.items.map((_, i) => {
                 const {props} = getItemRenderState({
                     id: String(i),
-                    mapItemDataToProps: (title) => ({title}),
+                    mapItemDataToContentProps: (title) => ({title}),
                     onItemClick,
                     list,
                 });
@@ -114,7 +114,7 @@ function List() {
                     {(id) => {
                         const {props} = getItemRenderState({
                             id: String(i),
-                            mapItemDataToProps: (title) => ({title}),
+                            mapItemDataToContentProps: (title) => ({title}),
                             onItemClick,
                             list,
                         });

--- a/src/components/useList/__stories__/components/FlattenList.tsx
+++ b/src/components/useList/__stories__/components/FlattenList.tsx
@@ -72,10 +72,10 @@ export const FlattenList = ({itemsCount, size}: FlattenListProps) => {
                             id,
                             size,
                             onItemClick,
-                            mapItemDataToProps: (x) => x,
+                            mapItemDataToContentProps: (x) => x,
                             list,
                         });
-                        return <ListItemView {...props} hasSelectionIcon={false} />;
+                        return <ListItemView {...props} selectionViewType="single" />;
                     }}
                 </VirtualizedListContainer>
             </ListContainerView>

--- a/src/components/useList/__stories__/components/InfinityScrollList.tsx
+++ b/src/components/useList/__stories__/components/InfinityScrollList.tsx
@@ -72,7 +72,7 @@ export const InfinityScrollList = ({size}: InfinityScrollListProps) => {
                                     size,
                                     onItemClick,
                                     multiple: true,
-                                    mapItemDataToProps: (x) => x,
+                                    mapItemDataToContentProps: (x) => x,
                                     list,
                                 });
                                 const node = <ListItemView {...props} />;

--- a/src/components/useList/__stories__/components/ListWithDnd.tsx
+++ b/src/components/useList/__stories__/components/ListWithDnd.tsx
@@ -77,9 +77,14 @@ export const ListWithDnd = ({size, itemsCount, 'aria-label': ariaLabel}: ListWit
                                         id,
                                         size,
                                         onItemClick,
-                                        mapItemDataToProps: (x) => x,
+                                        mapItemDataToContentProps: (x) => x,
                                         list,
                                     });
+
+                                    console.log(
+                                        '🚀 ~ {list.structure.visibleFlattenIds.map ~ props:',
+                                        props,
+                                    );
 
                                     return (
                                         <Draggable
@@ -93,11 +98,14 @@ export const ListWithDnd = ({size, itemsCount, 'aria-label': ariaLabel}: ListWit
                                             ) => (
                                                 <ListItemView
                                                     {...props}
+                                                    content={{
+                                                        ...props.content,
+                                                        endSlot: <Icon data={Grip} size={16} />,
+                                                    }}
                                                     {...provided.draggableProps}
                                                     {...provided.dragHandleProps}
                                                     dragging={snapshot.isDragging}
                                                     ref={provided.innerRef}
-                                                    endSlot={<Icon data={Grip} size={16} />}
                                                     role="option"
                                                 />
                                             )}

--- a/src/components/useList/__stories__/components/PopupWithTogglerList.tsx
+++ b/src/components/useList/__stories__/components/PopupWithTogglerList.tsx
@@ -83,11 +83,16 @@ export const PopupWithTogglerList = ({size, itemsCount}: PopupWithTogglerListPro
                             id,
                             size,
                             onItemClick,
-                            mapItemDataToProps: (x) => x,
+                            mapItemDataToContentProps: (x) => x,
                             list,
                         });
 
-                        return <ListItemView {...props} hasSelectionIcon={!context.childrenIds} />;
+                        return (
+                            <ListItemView
+                                {...props}
+                                selectionViewType={context.childrenIds ? 'single' : 'multiple'}
+                            />
+                        );
                     }}
                 />
             </Popup>

--- a/src/components/useList/__stories__/components/RecursiveList.tsx
+++ b/src/components/useList/__stories__/components/RecursiveList.tsx
@@ -58,11 +58,16 @@ export const RecursiveList = ({size, itemsCount, 'aria-label': ariaLabel}: Recur
                         size,
                         onItemClick,
                         multiple: true,
-                        mapItemDataToProps: (x) => x,
+                        mapItemDataToContentProps: (x) => x,
                         list,
                     });
 
-                    return <ListItemView {...props} hasSelectionIcon={!context.childrenIds} />;
+                    return (
+                        <ListItemView
+                            {...props}
+                            selectionViewType={context.childrenIds ? 'single' : 'multiple'}
+                        />
+                    );
                 }}
             />
         </Flex>

--- a/src/components/useList/__stories__/docs/get-item-render-state.md
+++ b/src/components/useList/__stories__/docs/get-item-render-state.md
@@ -19,7 +19,7 @@ const {data, props, context} = getItemRenderState({
     multiple: true,
     size, // list size
     onItemClick,
-    mapItemDataToProps: (item) => ({title: item.title}),
+    mapItemDataToContentProps: (item) => ({title: item.title}),
     list,
 });
 
@@ -28,16 +28,16 @@ return <ListItemView {...props} />;
 
 #### Props:
 
-| Name               | Description                                                                        |                              Type                              | Default |
-| :----------------- | :--------------------------------------------------------------------------------- | :------------------------------------------------------------: | :-----: |
-| id                 | `id` of list item                                                                  |                          `ListItemId`                          |         |
-| list               | result of `useList` hook                                                           |                        `UseListResult`                         |         |
-| multiple           | One or multiple elements selected list                                             |                           `boolean`                            |         |
-| onItemClick        | Optional on click handler                                                          | `(payload :{id: ListItemId}, e: React.SyntheticEvent) => void` |         |
-| size               | The size of the element. This also affects the rounding radius of the list element |                      `s \| m \| l \| xl`                       |   `m`   |
-| mapItemDataToProps | Map list item data (`T`) to `ListItemView` props                                   |               `(data: T) => ListItemCommonProps`               |         |
+| Name                      | Description                                                                        |                              Type                              | Default |
+| :------------------------ | :--------------------------------------------------------------------------------- | :------------------------------------------------------------: | :-----: |
+| id                        | `id` of list item                                                                  |                          `ListItemId`                          |         |
+| list                      | result of `useList` hook                                                           |                        `UseListResult`                         |         |
+| multiple                  | One or multiple elements selected list                                             |                           `boolean`                            |         |
+| onItemClick               | Optional on click handler                                                          | `(payload :{id: ListItemId}, e: React.SyntheticEvent) => void` |         |
+| size                      | The size of the element. This also affects the rounding radius of the list element |                      `s \| m \| l \| xl`                       |   `m`   |
+| mapItemDataToContentProps | Map list item data (`T`) to `ListItemView` `content` prop                          |            `(data: T) => ListItemViewContentProps`             |         |
 
-##### ListItemCommonProps
+##### ListItemViewContentProps
 
 | Name      |       Type        |   Note   |
 | :-------- | :---------------: | :------: |
@@ -83,7 +83,7 @@ const onItemClick = () => {};
       multiple: false,
       size, // list size
       onItemClick,
-      mapItemDataToProps,
+      mapItemDataToContentProps,
       list,
     });
 

--- a/src/components/useList/__stories__/docs/list-container-view.md
+++ b/src/components/useList/__stories__/docs/list-container-view.md
@@ -17,7 +17,7 @@ The default container for all custom lists. Contains all html attributes and sty
 const containerRef = React.useRef<HTMLDivElement>(null);
 
 <ListContainerView ref={containerRef} fixedHeight>
-  <ListItemView title="123" id="1" />
-  <ListItemView title="456" id="2" />
+  <ListItemView content={{title: '123'}} id="1" />
+  <ListItemView content={{title: '456'}} id="2" />
 </ListContainerView>;
 ```

--- a/src/components/useList/__stories__/docs/list-item-view.md
+++ b/src/components/useList/__stories__/docs/list-item-view.md
@@ -30,9 +30,12 @@ const List = () => {
                    <ListItemView
                        key={i}
                        id={String(i)}
-                       title={item.title}
-                       subtitle={item.subtitle}
-                       endSlot={item.icon}
+                       content={{
+                            title: item.title,
+                            subtitle: item.subtitle,
+                            endSlot: item.icon,
+                       }}
+                       // content={<YouCustomComponent />}
                    />
                )
            }}
@@ -43,24 +46,30 @@ const List = () => {
 
 #### Props:
 
+| Name          | Description                                                                                                                                                                                                                                                                           |               Type                | Default |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------: | :-----: |
+| id            | Required prop. Set `[data-list-item="${id}"]` data attribute. By this it core list engine finds elements to scroll to.                                                                                                                                                                |             `string`              |         |
+| as            | If needed, override `html` tag. By default - `li`                                                                                                                                                                                                                                     |           `HTMLElement`           |  `li`   |
+| size          | The size of the element. This also affects the rounding radius of the list element                                                                                                                                                                                                    |        `s \| m \| l \| xl`        |   `m`   |
+| height        | The height of the element in pixels. By default, it is calculated depending on the `size` parameter and the presence of the `subtitle` parameter.<br>Also you can define item height by two variants:<br>- component props `height`;<br>- css custom property `--g-list-item-height`; |             `number `             |         |
+| selected      | The selected state of the component                                                                                                                                                                                                                                                   |            `boolean `             |         |
+| active        | The state when the element is in the user's focus, but not selected. It can also be used when you drag an element                                                                                                                                                                     |            `boolean `             |         |
+| disabled      | The disabled state. It also prevents clicking on an element                                                                                                                                                                                                                           |            `boolean `             |         |
+| activeOnHover | directly control hover behavior                                                                                                                                                                                                                                                       |            `boolean `             |         |
+| onClick       | On item click callback. If `disabled` option is `true` click don't appears                                                                                                                                                                                                            |           `() => void`            |         |
+| content       | Typed props or ReactNode in difficult cases                                                                                                                                                                                                                                           | `ContentProps \| React.ReactNode` |         |
+
+#### ContentProps
+
 | Name             | Description                                                                                                                                                |         Type          | Default |
 | :--------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------: | :-----: |
-| id               | Required prop. Set `[data-list-item="${id}"]` data attribute. By this it core list engine finds elements to scroll to.                                     |       `string`        |         |
 | title            | Base required prop to use. If passed string, applies default component styles according design system. Pass you own component if you wont custom behavior; |   `React.ReactNode`   |         |
 | subtitle         | Slot under `title`. If passed string apply predefined styles. Or you can pass custom `React.ReactNode` to use you own behavior                             |   `React.ReactNode`   |         |
-| as               | If needed, override `html` tag. By default - `li`                                                                                                          |     `HTMLElement`     |  `li`   |
-| size             | The size of the element. This also affects the rounding radius of the list element                                                                         |  `s \| m \| l \| xl`  |   `m`   |
-| height           | The height of the element in pixels. By default, it is calculated depending on the `size` parameter and the presence of the `subtitle` parameter           |       `number `       |         |
-| selected         | The selected state of the component                                                                                                                        |      `boolean `       |         |
-| active           | The state when the element is in the user's focus, but not selected. It can also be used when you drag an element                                          |      `boolean `       |         |
-| disabled         | The disabled state. It also prevents clicking on an element                                                                                                |      `boolean `       |         |
-| activeOnHover    | directly control hover behavior                                                                                                                            |      `boolean `       |         |
-| indentation      | Affects the visual indentation of the element content                                                                                                      |       `number `       |         |
-| hasSelectionIcon | Show selected icon if selected and reserve space for this icon                                                                                             |      `boolean `       |         |
-| onClick          | On item click callback. If `disabled` option is `true` click don't appears                                                                                 |     `() => void`      |         |
-| startSlot        | Custom slot before `title`                                                                                                                                 |   `React.ReactNode`   |         |
-| endSlot          | Custom slot before `title`                                                                                                                                 |   `React.ReactNode`   |         |
 | style            | Inline styles if needed                                                                                                                                    | `React.CSSProperties` |         |
 | className        | Custom class name to mix with                                                                                                                              |       `string`        |         |
-| expanded         | Adds a visual representation of a group element if the value is different from `undefined`                                                                 | `string \| undefined` |         |
 | dragging         | manage view of dragging element. Required for draggable list implementation                                                                                |       `boolean`       |         |
+| indentation      | Affects the visual indentation of the element content                                                                                                      |       `number `       |         |
+| hasSelectionIcon | Show selected icon if selected and reserve space for this icon                                                                                             |      `boolean `       |         |
+| endSlot          | Custom slot before `title`                                                                                                                                 |   `React.ReactNode`   |         |
+| expanded         | Adds a visual representation of a group element if the value is different from `undefined`                                                                 | `string \| undefined` |         |
+| startSlot        | Custom slot before `title`                                                                                                                                 |   `React.ReactNode`   |         |

--- a/src/components/useList/__stories__/docs/list-recursive-renderer.md
+++ b/src/components/useList/__stories__/docs/list-recursive-renderer.md
@@ -49,7 +49,7 @@ function List() {
           {(id) => {
             const {props} = getItemRenderState({
               id: String(i),
-              mapItemDataToProps: (title) => ({title}),
+              mapItemDataToContentProps: (title) => ({title}),
               onItemClick,
               list,
             });

--- a/src/components/useList/components/ListItemView/ListItemView.scss
+++ b/src/components/useList/components/ListItemView/ListItemView.scss
@@ -4,6 +4,14 @@ $block: '.#{variables.$ns}list-item-view';
 
 #{$block} {
     flex-shrink: 0;
+    display: flex;
+    flex-grow: 1;
+    align-items: center;
+
+    &__content {
+        width: 100%;
+        height: 100%;
+    }
 
     &__main-content {
         width: 100%;

--- a/src/components/useList/components/ListItemView/ListItemView.tsx
+++ b/src/components/useList/components/ListItemView/ListItemView.tsx
@@ -1,96 +1,59 @@
 import React from 'react';
 
-import {Check, ChevronDown, ChevronUp} from '@gravity-ui/icons';
-
-import {Icon} from '../../../Icon';
-import {Text, colorText} from '../../../Text';
-import {Flex, spacing} from '../../../layout';
-import type {FlexProps} from '../../../layout';
+import {spacing} from '../../../layout';
 import type {QAProps} from '../../../types';
-import {block} from '../../../utils/cn';
 import {LIST_ITEM_DATA_ATR, modToHeight} from '../../constants';
-import type {ListItemCommonProps, ListItemId, ListItemSize} from '../../types';
+import type {ListItemId, ListItemSize, ListItemViewContentType} from '../../types';
 
-import './ListItemView.scss';
+import {ListItemViewContent, isListItemContentPropsGuard} from './ListItemViewContent';
+import {b} from './styles';
 
-const b = block('list-item-view');
-
-export interface ListItemViewProps<T extends React.ElementType = 'li'>
-    extends QAProps,
-        ListItemCommonProps {
-    /**
-     * Ability to override default html tag
-     */
-    as?: T;
+export interface ListItemViewCommonProps<T extends React.ElementType = 'li'> extends QAProps {
     /**
      * @default `m`
      */
     size?: ListItemSize;
-    height?: number;
-    selected?: boolean;
-    active?: boolean;
-    disabled?: boolean;
-    /**
-     * By default hovered elements has active styles. You can disable this behavior
-     */
-    activeOnHover?: boolean;
-    /**
-     * Build in indentation component to render nested views structure
-     */
-    indentation?: number;
-    /**
-     * Show selected icon if selected and reserve space for this icon
-     */
-    hasSelectionIcon?: boolean;
-    /**
-     * Note: if passed and `disabled` option is `true` click will not be appear
-     */
-    onClick?: React.ComponentPropsWithoutRef<T>['onClick'];
-    style?: React.CSSProperties;
-    className?: string;
-    role?: React.AriaRole;
-    expanded?: boolean;
-    /**
-     * Add active styles and change selection behavior during dnd is performing
-     */
-    dragging?: boolean;
     /**
      * `[${LIST_ITEM_DATA_ATR}="${id}"]` data attribute to find element.
      * For example for scroll to
      */
     id: ListItemId;
+    /**
+     * Note: if passed and `disabled` option is `true` click will not be appear
+     */
+    onClick?: React.ComponentPropsWithoutRef<T>['onClick'];
+    selected?: boolean;
+    disabled?: boolean;
+    active?: boolean;
+    selectionViewType?: 'single' | 'multiple';
+    content: ListItemViewContentType;
+}
+
+export interface ListItemViewProps<T extends React.ElementType = 'li'>
+    extends Omit<ListItemViewCommonProps, 'content'> {
+    /**
+     * Ability to override default html tag
+     */
+    as?: T;
+    height?: number;
+    /**
+     * By default hovered elements has active styles. You can disable this behavior
+     */
+    activeOnHover?: boolean;
+    style?: React.CSSProperties;
+    className?: string;
+    role?: React.AriaRole;
+    /**
+     * Add active styles and change selection behavior during dnd is performing
+     */
+    dragging?: boolean;
+    content: ListItemViewContentType | React.ReactNode;
 }
 
 type ListItemViewRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['ref'];
 
 type ListItemViewPropsWithTypedAttrs<T extends React.ElementType> = ListItemViewProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof ListItemViewProps<T>>;
-
-interface SlotProps extends FlexProps {
-    indentation?: number;
-}
-
-export const ListItemViewSlot = ({
-    children,
-    indentation: indent = 1,
-    className,
-    ...props
-}: SlotProps) => {
-    return (
-        <Flex width={indent * 16} className={b('slot', className)} {...props}>
-            {children}
-        </Flex>
-    );
-};
-
-const renderSafeIndentation = (indentation?: number) => {
-    if (indentation && indentation >= 1) {
-        return (
-            <ListItemViewSlot indentation={Math.floor(indentation) as SlotProps['indentation']} />
-        );
-    }
-    return null;
-};
 
 export const ListItemView = React.forwardRef(function ListItemView<
     T extends React.ElementType = 'li',
@@ -102,32 +65,35 @@ export const ListItemView = React.forwardRef(function ListItemView<
         active,
         selected,
         disabled,
+        selectionViewType = 'multiple',
         activeOnHover: propsActiveOnHover,
         className,
-        hasSelectionIcon = true,
-        indentation,
-        startSlot,
-        subtitle,
-        endSlot,
-        title,
         height,
-        expanded,
         dragging,
-        style,
+        style: propsStyle,
+        content,
         role = 'option',
         onClick: _onClick,
         ...rest
-    }: ListItemViewPropsWithTypedAttrs<T>,
+    }: ListItemViewProps<T>,
     ref?: ListItemViewRef<T>,
 ) {
-    const as: React.ElementType = asProps || 'li';
-    const isGroup = typeof expanded === 'boolean';
+    const Tag: React.ElementType = asProps || 'li';
     const onClick = disabled ? undefined : _onClick;
     const activeOnHover =
         typeof propsActiveOnHover === 'boolean' ? propsActiveOnHover : Boolean(onClick);
+    const style = {
+        minHeight: `var(--g-list-item-height, ${
+            height ??
+            modToHeight[size][
+                Number(Boolean(isListItemContentPropsGuard(content) ? content?.subtitle : false))
+            ]
+        }px)`,
+        ...propsStyle,
+    };
 
     return (
-        <Flex
+        <Tag
             {...{[LIST_ITEM_DATA_ATR]: id}}
             role={role}
             aria-selected={selected}
@@ -135,71 +101,30 @@ export const ListItemView = React.forwardRef(function ListItemView<
             className={b(
                 {
                     active: dragging || active,
-                    selected: selected && !hasSelectionIcon,
+                    selected: selected && selectionViewType === 'single',
                     activeOnHover,
                     radius: size,
+                    size,
                     dragging,
                     clickable: Boolean(onClick),
                 },
                 spacing({px: 2}, className),
             )}
-            style={{
-                minHeight: height ?? modToHeight[size][Number(Boolean(subtitle))],
-                ...style,
-            }}
-            as={as}
+            style={style}
             ref={ref}
-            alignItems="center"
-            gap="4"
-            justifyContent="space-between"
             {...rest}
         >
-            <Flex gap="2" alignItems="center" grow>
-                {hasSelectionIcon && (
-                    <ListItemViewSlot // reserve space
-                    >
-                        {selected ? (
-                            <Icon data={Check} size={16} className={colorText({color: 'info'})} />
-                        ) : null}
-                    </ListItemViewSlot>
-                )}
-
-                {renderSafeIndentation(indentation)}
-
-                {isGroup ? (
-                    <Icon
-                        className={b('icon', colorText({color: disabled ? 'hint' : undefined}))}
-                        data={expanded ? ChevronDown : ChevronUp}
-                        size={16}
-                    />
-                ) : null}
-
-                {startSlot}
-
-                <div className={b('main-content')}>
-                    {typeof title === 'string' ? (
-                        <Text
-                            ellipsis
-                            color={disabled ? 'hint' : undefined}
-                            variant={isGroup ? 'subheader-1' : undefined}
-                        >
-                            {title}
-                        </Text>
-                    ) : (
-                        title
-                    )}
-                    {typeof subtitle === 'string' ? (
-                        <Text ellipsis color={disabled ? 'hint' : 'secondary'}>
-                            {subtitle}
-                        </Text>
-                    ) : (
-                        subtitle
-                    )}
-                </div>
-            </Flex>
-
-            {endSlot}
-        </Flex>
+            {isListItemContentPropsGuard(content) ? (
+                <ListItemViewContent
+                    {...content}
+                    hasSelectionIcon={selectionViewType === 'multiple'}
+                    selected={selected}
+                    disabled={disabled}
+                />
+            ) : (
+                content
+            )}
+        </Tag>
     );
 }) as <C extends React.ElementType = 'li'>({
     ref,

--- a/src/components/useList/components/ListItemView/ListItemViewContent.tsx
+++ b/src/components/useList/components/ListItemView/ListItemViewContent.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import {Check, ChevronDown, ChevronUp} from '@gravity-ui/icons';
+
+import {Icon} from '../../../Icon';
+import {Text, colorText} from '../../../Text';
+import {Flex} from '../../../layout';
+import type {FlexProps} from '../../../layout';
+import type {ListItemViewContentType} from '../../types';
+
+import {b} from './styles';
+
+export const isListItemContentPropsGuard = (
+    props: ListItemViewContentType | React.ReactNode,
+): props is ListItemViewContentType => {
+    return typeof props === 'object' && props !== null && 'title' in props;
+};
+
+interface SlotProps extends FlexProps {
+    indentation?: number;
+}
+
+const ListItemViewSlot = ({children, indentation = 1, className, ...props}: SlotProps) => {
+    return (
+        <Flex width={indentation * 16} className={b('slot', className)} {...props}>
+            {children}
+        </Flex>
+    );
+};
+
+const renderSafeIndentation = (indentation?: number) => {
+    if (indentation && indentation >= 1) {
+        return (
+            <ListItemViewSlot indentation={Math.floor(indentation) as SlotProps['indentation']} />
+        );
+    }
+    return null;
+};
+
+interface ListItemViewContentProps extends ListItemViewContentType {
+    selected?: boolean;
+    disabled?: boolean;
+    /**
+     * Show selected icon if selected and reserve space for this icon
+     */
+    hasSelectionIcon: boolean;
+}
+
+export const ListItemViewContent = ({
+    startSlot,
+    subtitle,
+    endSlot,
+    disabled,
+    hasSelectionIcon,
+    isGroup,
+    indentation,
+    expanded,
+    selected,
+    title,
+}: ListItemViewContentProps) => {
+    return (
+        <Flex alignItems="center" justifyContent="space-between" gap="4" className={b('content')}>
+            <Flex gap="2" alignItems="center" grow>
+                {hasSelectionIcon && (
+                    <ListItemViewSlot // reserve space
+                    >
+                        {selected ? (
+                            <Icon data={Check} size={16} className={colorText({color: 'info'})} />
+                        ) : null}
+                    </ListItemViewSlot>
+                )}
+
+                {renderSafeIndentation(indentation)}
+
+                {isGroup ? (
+                    <Icon
+                        className={b('icon', colorText({color: disabled ? 'hint' : undefined}))}
+                        data={expanded ? ChevronDown : ChevronUp}
+                        size={16}
+                    />
+                ) : null}
+
+                {startSlot}
+
+                <div className={b('main-content')}>
+                    {typeof title === 'string' ? (
+                        <Text
+                            ellipsis
+                            color={disabled ? 'hint' : undefined}
+                            variant={isGroup ? 'subheader-1' : undefined}
+                        >
+                            {title}
+                        </Text>
+                    ) : (
+                        title
+                    )}
+                    {typeof subtitle === 'string' ? (
+                        <Text ellipsis color={disabled ? 'hint' : 'secondary'}>
+                            {subtitle}
+                        </Text>
+                    ) : (
+                        subtitle
+                    )}
+                </div>
+            </Flex>
+
+            {endSlot}
+        </Flex>
+    );
+};

--- a/src/components/useList/components/ListItemView/__stories__/ListItemView.stories.tsx
+++ b/src/components/useList/components/ListItemView/__stories__/ListItemView.stories.tsx
@@ -9,6 +9,7 @@ import {Flex, sp} from '../../../../layout';
 import type {ListItemId} from '../../../../useList/types';
 import {ListItemView as ListItemViewComponent} from '../ListItemView';
 import type {ListItemViewProps} from '../ListItemView';
+import {isListItemContentPropsGuard} from '../ListItemViewContent';
 
 export default {
     title: 'Lab/useList/ListItemView',
@@ -72,128 +73,164 @@ const EndSlot = ({selfStart}: {selfStart?: boolean}) => (
 const stories: ListItemViewProps[] = [
     {
         id: '1',
-        title,
-        activeOnHover: false,
-        subtitle,
+        content: {
+            title,
+            subtitle,
+            startSlot: <StartSlot />,
+        },
         disabled: true,
-        startSlot: <StartSlot />,
+        activeOnHover: false,
     },
     {
         id: '2',
-        title,
-        subtitle: 'activeOnHover - false',
+        content: {
+            title,
+            subtitle: 'activeOnHover - false',
+            endSlot: <EndSlot />,
+        },
+        selected: true,
         activeOnHover: false,
-        endSlot: <EndSlot />,
     },
     {
         id: '3',
-        title,
+        selectionViewType: 'single',
+        content: {
+            title,
+            subtitle,
+            startSlot: <StartSlot />,
+        },
+        selected: true,
         size: 'l',
-        subtitle,
-        hasSelectionIcon: false,
-        startSlot: <StartSlot />,
     },
     {
         id: '4',
-        title,
+        content: {
+            title,
+            startSlot: <StartSlot />,
+        },
         disabled: true,
         size: 'xl',
         height: 60,
-        startSlot: <StartSlot />,
     },
     {
         id: '5',
         size: 'l',
-        startSlot: <StartSlot />,
-        title,
+        content: {
+            startSlot: <StartSlot />,
+            title,
+        },
     },
     {
         id: '6',
-        title: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis, voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia qui deserunt autem quas necessitatibus nam possimus aperiam.',
-        size: 'l',
-        subtitle: 'indentation 1',
-        startSlot: <StartSlot />,
-        indentation: 1,
+        content: {
+            title: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis, voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia qui deserunt autem quas necessitatibus nam possimus aperiam.',
+            subtitle: 'indentation 1',
+            startSlot: <StartSlot />,
+            indentation: 1,
+            endSlot: <EndSlot />,
+        },
         selected: true,
-        endSlot: <EndSlot />,
+        size: 'l',
     },
     {
         id: '7',
-        expanded: true,
         size: 'xl',
-        title: 'Group 1',
-        endSlot: <EndSlot />,
+        content: {
+            isGroup: true,
+            expanded: true,
+            title: 'Group 1',
+            endSlot: <EndSlot />,
+        },
     },
     {
         id: '8',
-        hasSelectionIcon: false,
-        expanded: true,
+        selectionViewType: 'single',
+        content: {
+            title: 'Group 1',
+            expanded: true,
+            isGroup: true,
+        },
         disabled: true,
         size: 'xl',
-        title: 'Group 1',
     },
     {
         id: '9',
-        hasSelectionIcon: false,
-        title: (
-            <Text>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
-                voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia
-                qui deserunt autem quas necessitatibus nam possimus aperiam.
-            </Text>
-        ),
+        selectionViewType: 'single',
+        content: {
+            subtitle: (
+                <Text color="secondary">
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
+                    voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi
+                    officia qui deserunt autem quas necessitatibus nam possimus aperiam.
+                </Text>
+            ),
+            startSlot: <StartSlot selfStart />,
+            title: (
+                <Text>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
+                    voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi
+                    officia qui deserunt autem quas necessitatibus nam possimus aperiam.
+                </Text>
+            ),
+            endSlot: <EndSlot selfStart />,
+        },
         size: 'l',
-        subtitle: (
-            <Text color="secondary">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
-                voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia
-                qui deserunt autem quas necessitatibus nam possimus aperiam.
-            </Text>
-        ),
-        startSlot: <StartSlot selfStart />,
         selected: true,
         className: sp({p: 2}),
-        endSlot: <EndSlot selfStart />,
     },
     {
         id: '10',
-        title: (
-            <Text ellipsisLines={2}>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
-                voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia
-                qui deserunt autem quas necessitatibus nam possimus aperiam.
-            </Text>
-        ),
-        size: 'l',
-        subtitle: (
-            <Text color="danger" ellipsis>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
-                voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia
-                qui deserunt autem quas necessitatibus nam possimus aperiam.
-            </Text>
-        ),
-        startSlot: <StartSlot selfStart />,
+        content: {
+            title: (
+                <Text ellipsisLines={2}>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
+                    voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi
+                    officia qui deserunt autem quas necessitatibus nam possimus aperiam.
+                </Text>
+            ),
+            subtitle: (
+                <Text color="danger" ellipsis>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
+                    voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi
+                    officia qui deserunt autem quas necessitatibus nam possimus aperiam.
+                </Text>
+            ),
+            startSlot: <StartSlot selfStart />,
+            indentation: 1,
+            endSlot: <EndSlot selfStart />,
+        },
         selected: true,
-        indentation: 1,
+        size: 'l',
         className: sp({p: 2}),
-        endSlot: <EndSlot selfStart />,
     },
     {
         id: '11',
-        title: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis, voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia qui deserunt autem quas necessitatibus nam possimus aperiam.',
         size: 'l',
-        subtitle: (
-            <Text ellipsisLines={2} color="secondary">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
-                voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia
-                qui deserunt autem quas necessitatibus nam possimus aperiam.
-            </Text>
+        content: {
+            title: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis, voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi officia qui deserunt autem quas necessitatibus nam possimus aperiam.',
+            subtitle: (
+                <Text ellipsisLines={2} color="secondary">
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex quos officiis,
+                    voluptates nobis doloribus veritatis quo odit sequi eligendi aliquam quasi
+                    officia qui deserunt autem quas necessitatibus nam possimus aperiam.
+                </Text>
+            ),
+            expanded: true,
+            isGroup: true,
+            startSlot: <StartSlot />,
+            indentation: 1,
+            endSlot: <EndSlot />,
+        },
+    },
+    {
+        id: '12',
+        size: 'l',
+        content: (
+            <Flex gap="2" alignItems="center">
+                <StartSlot />
+                <Text>Override list item context with react node</Text>
+            </Flex>
         ),
-        expanded: true,
-        startSlot: <StartSlot />,
-        indentation: 1,
-        selected: true,
-        endSlot: <EndSlot />,
     },
 ];
 
@@ -202,35 +239,55 @@ const ListItemViewTemplate: StoryFn<ListItemViewProps> = () => {
     const [selectedById, setSelectedById] = React.useState<Record<ListItemId, boolean>>({});
 
     return (
-        <Flex direction="column" role="listbox" aria-label="Sample list">
-            {stories.map((props, i) => (
-                <ListItemViewComponent
-                    key={i}
-                    {...props}
-                    expanded={expandedById[props.id] ?? props.expanded}
-                    selected={selectedById[props.id]}
-                    onClick={handleClick(props)}
-                />
-            ))}
+        <Flex direction="column" role="listbox" aria-label="Sample list" width={400}>
+            {stories.map((props, i) => {
+                let expanded: boolean | undefined;
+
+                if (isListItemContentPropsGuard(props.content) && props.content.isGroup) {
+                    expanded =
+                        props.id in expandedById ? expandedById[props.id] : props.content.expanded;
+                }
+
+                return (
+                    <ListItemViewComponent
+                        key={i}
+                        {...props}
+                        content={
+                            isListItemContentPropsGuard(props.content)
+                                ? {
+                                      ...props.content,
+                                      expanded,
+                                  }
+                                : props.content
+                        }
+                        selected={selectedById[props.id]}
+                        onClick={handleClick(props)}
+                    />
+                );
+            })}
         </Flex>
     );
 
-    function handleClick({id, expanded}: ListItemViewProps) {
-        const isGroup = typeof expanded === 'boolean';
+    function handleClick({id, content}: ListItemViewProps) {
+        if (isListItemContentPropsGuard(content)) {
+            const isGroup = content.isGroup;
 
-        return () => {
-            if (isGroup) {
-                setExpandedById((prevState) => ({
-                    ...prevState,
-                    [id]: typeof prevState[id] === 'undefined' ? !expanded : !prevState[id],
-                }));
-            } else {
-                setSelectedById((prevState) => ({
-                    ...prevState,
-                    [id]: !prevState[id],
-                }));
-            }
-        };
+            return () => {
+                if (isGroup) {
+                    setExpandedById((prevState) => ({
+                        ...prevState,
+                        [id]: id in prevState ? !prevState[id] : !content.expanded,
+                    }));
+                } else {
+                    setSelectedById((prevState) => ({
+                        ...prevState,
+                        [id]: !prevState[id],
+                    }));
+                }
+            };
+        }
+
+        return undefined;
     }
 };
 export const ListItemView = ListItemViewTemplate.bind({});

--- a/src/components/useList/components/ListItemView/index.ts
+++ b/src/components/useList/components/ListItemView/index.ts
@@ -1,2 +1,3 @@
 export {ListItemView} from './ListItemView';
-export type {ListItemViewProps} from './ListItemView';
+export {isListItemContentPropsGuard} from './ListItemViewContent';
+export type {ListItemViewProps, ListItemViewCommonProps} from './ListItemView';

--- a/src/components/useList/components/ListItemView/styles.ts
+++ b/src/components/useList/components/ListItemView/styles.ts
@@ -1,0 +1,5 @@
+import {block} from '../../../utils/cn';
+
+import './ListItemView.scss';
+
+export const b = block('list-item-view');

--- a/src/components/useList/types.ts
+++ b/src/components/useList/types.ts
@@ -1,5 +1,3 @@
-import type {QAProps} from '../types';
-
 export type ListItemId = string;
 
 export type ListItemSize = 's' | 'm' | 'l' | 'xl';
@@ -41,30 +39,23 @@ export type ItemState = {
     indentation: number;
 };
 
-export type ListItemCommonProps = {
+export type ListItemViewContentType = {
     title: React.ReactNode;
     subtitle?: React.ReactNode;
     startSlot?: React.ReactNode;
     endSlot?: React.ReactNode;
+    /**
+     * Build in indentation component to render nested views structure
+     */
+    indentation?: number;
+    isGroup?: boolean;
+    expanded?: boolean;
 };
 
 export type ListItemListContextProps = ItemState &
     Partial<GroupParsedState> & {
         isLastItem: boolean;
     };
-
-export type RenderItemProps = {
-    size: ListItemSize;
-    id: ListItemId;
-    onClick: ((e: React.SyntheticEvent) => void) | undefined;
-    selected: boolean | undefined;
-    disabled: boolean;
-    expanded: boolean | undefined;
-    active: boolean;
-    indentation: number;
-    hasSelectionIcon?: boolean;
-} & ListItemCommonProps &
-    QAProps;
 
 export type ParsedState<T> = {
     /**

--- a/src/components/useList/utils/getItemRenderState.tsx
+++ b/src/components/useList/utils/getItemRenderState.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable valid-jsdoc */
 import type {QAProps} from '../../types';
+import type {ListItemViewCommonProps} from '../components/ListItemView';
 import type {
-    ListItemCommonProps,
     ListItemId,
     ListItemListContextProps,
     ListItemSize,
+    ListItemViewContentType,
     ListOnItemClick,
-    RenderItemProps,
     UseListResult,
 } from '../types';
 
@@ -19,7 +19,7 @@ type ItemRendererProps<T> = QAProps & {
      */
     multiple?: boolean;
     id: ListItemId;
-    mapItemDataToProps(data: T): ListItemCommonProps;
+    mapItemDataToContentProps(data: T): ListItemViewContentType;
     onItemClick?: ListOnItemClick;
     list: UseListResult<T>;
 };
@@ -31,7 +31,7 @@ export const getItemRenderState = <T,>({
     qa,
     list,
     onItemClick,
-    mapItemDataToProps,
+    mapItemDataToContentProps,
     size = 'm',
     multiple = false,
     id,
@@ -43,24 +43,20 @@ export const getItemRenderState = <T,>({
             id === list.structure.visibleFlattenIds[list.structure.visibleFlattenIds.length - 1],
     };
 
-    let expanded; // `undefined` value means than tree list will look as nested list without groups
-
-    // isGroup
-    if (list.state.expandedById && id in list.state.expandedById) {
-        expanded = list.state.expandedById[id];
-    }
-
-    const props: RenderItemProps = {
+    const props: ListItemViewCommonProps = {
         id,
         size,
-        expanded,
-        active: id === list.state.activeItemId,
-        indentation: context.indentation,
-        disabled: Boolean(list.state.disabledById?.[id]),
         selected: Boolean(list.state.selectedById[id]),
-        hasSelectionIcon: Boolean(multiple) && !context.childrenIds, // hide multiple selection view at group nodes
+        disabled: Boolean(list.state.disabledById?.[id]),
+        active: id === list.state.activeItemId,
         onClick: onItemClick ? (e: React.SyntheticEvent) => onItemClick({id}, e) : undefined,
-        ...mapItemDataToProps(list.structure.itemsById[id]),
+        selectionViewType: Boolean(multiple) && !context.childrenIds ? 'multiple' : 'single', // no multiple selection at group nodes
+        content: {
+            expanded: list.state.expandedById?.[id],
+            indentation: context.indentation,
+            isGroup: list.state.expandedById && id in list.state.expandedById,
+            ...mapItemDataToContentProps(list.structure.itemsById[id]),
+        },
     };
 
     if (qa) {


### PR DESCRIPTION
…ent prop

What has been done:

- Added the ability to transfer a custom react component as a `content` prop in `ListItemView`;
- Removed `Flex` component from root of `ListItemView` component. Flex uses inline styles what prevent class override approach of `ListItemView`;

Now ListItemView look very close to previous approach of current `List` component