### PR TITLE
fix(useFocusWithin): ignore blur event when window loses focus

### DIFF
--- a/src/hooks/useFocusWithin/useFocusWithin.ts
+++ b/src/hooks/useFocusWithin/useFocusWithin.ts
@@ -185,9 +185,10 @@ function useFocusEvents({
     const onBlurHandler = React.useCallback(
         (event: React.FocusEvent) => {
             if (
-                event.relatedTarget === null ||
-                event.relatedTarget === document.body ||
-                event.relatedTarget === (document as EventTarget)
+                document.activeElement !== event.target &&
+                (event.relatedTarget === null ||
+                    event.relatedTarget === document.body ||
+                    event.relatedTarget === (document as EventTarget))
             ) {
                 onBlur(event);
                 targetRef.current = null;


### PR DESCRIPTION
Issue #1737

Apparently when Firefox's window loses focus a blur event is fired. 

It can be reproduced on Linux GNOME with `super` + `space` to switch language. I do not know whether or not it works on KDE.
It can be emulated on Mac with `control` + `space` to open search bar.

On Windows with switching language by `win` + `space` it works fine.

Maybe this solution can help.