### PR TITLE
fix(Table): not propagate click in table actions menu

### DIFF
--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -275,6 +275,13 @@ export function withTableActions<I extends TableDataItem, E extends {} = {}>(
                 return (item: I, index: number, event: React.MouseEvent<HTMLTableRowElement>) => {
                     if (
                         // @ts-expect-error
+                        event.nativeEvent.target.closest(`.${menuCn}`)
+                    ) {
+                        return undefined;
+                    }
+
+                    if (
+                        // @ts-expect-error
                         event.nativeEvent.target.matches(
                             `.${actionsButtonCn}, .${actionsButtonCn} *`,
                         )


### PR DESCRIPTION
#1753 


It's stopped here if an action is active
https://github.com/gravity-ui/uikit/blob/ba98496b4006de772e01df2d836bde69530926ca/src/components/Table/hoc/withTableActions/withTableActions.tsx#L141

but if an action is disabled then the handler with `stopPropagation` is not called. 
Maybe this is an appropriate way to fix this.