### PR TITLE
fix(Select): fix tick icon color

### DIFF
--- a/src/components/Select/components/SelectList/SelectList.scss
+++ b/src/components/Select/components/SelectList/SelectList.scss
@@ -191,7 +191,7 @@ $xl-right-padding: '12px';
         box-sizing: content-box;
         flex: 0 0 16px;
         visibility: hidden;
-        color: var(--g-color-text-info);
+        color: var(--g-color-text-brand);
         padding-inline-end: var(--_--select-tick-icon-padding-right);
 
         &_shown {


### PR DESCRIPTION
On figma layouts the icon color is specified as --g-color-text-brand in overview List, but in the code it is --g-color-text-info