### PR TITLE
fix(PinInput): remove height glitch in Safari

### DIFF
--- a/src/components/PinInput/PinInput.scss
+++ b/src/components/PinInput/PinInput.scss
@@ -13,6 +13,7 @@ $block: '.#{variables.$ns}pin-input';
     &__item {
         flex: 0 0 auto;
         width: var(--g-pin-input-item-width, var(--_--item-width));
+        line-height: 0;
     }
 
     &__control {


### PR DESCRIPTION
In Safari PinInput "jumps" during browser rerender while inside flex context. Setting zero line-height prevents inner TextInput which is `display: inline-block` from changing the height