### PR TITLE
fix(TextInput): share font styles between error and note blocks in OuterAdditionalContent

### DIFF
--- a/src/components/controls/common/OuterAdditionalContent/OuterAdditionalContent.scss
+++ b/src/components/controls/common/OuterAdditionalContent/OuterAdditionalContent.scss
@@ -10,12 +10,11 @@ $block: '.#{variables.$ns}outer-additional-content';
 
     &__note,
     &__error {
+        @include mixins.text-body-1();
         margin-block-start: 2px;
     }
 
     &__error {
-        @include mixins.text-body-1();
-
         color: var(--g-color-text-danger);
 
         &:not(:last-child) {


### PR DESCRIPTION
This change fix bug with overlapping note when for `TextInput` (or parent block) set `line-height:0`
 https://github.com/gravity-ui/uikit/issues/1886