### PR TITLE
feat: pass event to handler callback in useOutsideClick

### DIFF
--- a/src/hooks/useOutsideClick/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick/useOutsideClick.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export interface UseOutsideClickProps<T> {
     ref: React.RefObject<T>;
-    handler?: () => void;
+    handler?: (e: MouseEvent | TouchEvent) => void;
 }
 
 type UseOutsideClickType = <K extends HTMLElement>(props: UseOutsideClickProps<K>) => void;
@@ -21,7 +21,7 @@ export const useOutsideClick: UseOutsideClickType = ({ref, handler}) => {
             const elem = ref?.current;
 
             if (elem && !elem.contains(e.target as Node) && handler) {
-                handler();
+                handler(e);
             }
         };
 


### PR DESCRIPTION
We're using `useOutsideClick` to close a modal.

The modal renders a menu popup with a tethering mechanism (Popper.js or similar). The popup is rendered not inline, but on the root level at the very end of the `<body>` content. As a result, when a menu item is clicked, the `useOutsideClick` callback is triggered and the modal is closed.

Conceptually, the menu popup is part of the modal, so selecting an item in the menu should not close the modal.

This can be easily resolved by checking that the click has been made on the actual page and not a popup which is not part of the page:

```ts
const handler (e: MouseEvent | TouchEvent) => {
  if (
      e.target instanceof HTMLElement // Type narrowing to allow using `e.target.closest()`
      && e.target.closest('#my-app') // Ignore clicks on popups. Only respond to clicks on the actual page.
  ) {
    closeModal();
  }
}

useOutsideClick({ref: foo, handler});
```

But unfortunately, the `useOutsideClick` hook does not pass the event.

This PR enables passing of the event.

PS Me on Staff: https://nda.ya.ru/t/BGTaa7T67AUVGa