### PR TITLE
Add support NextLink and other custom link components

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,6 +50,7 @@ export interface ButtonProps extends DOMProps, QAProps {
     type?: 'button' | 'submit' | 'reset';
     component?: React.ElementType;
     href?: string;
+    hrefComponent?: React.ElementType;
     target?: string;
     rel?: string;
     extraProps?:
@@ -80,6 +81,7 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         type = 'button',
         component,
         href,
+        hrefComponent,
         target,
         rel,
         extraProps,
@@ -137,14 +139,17 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         'data-qa': qa,
     };
 
-    if (typeof href === 'string' || component) {
+    if (href || component) {
         const linkProps = {
             href,
             target,
             rel: target === '_blank' && !rel ? 'noopener noreferrer' : rel,
         };
+
+        const LinkComponent = hrefComponent || 'a';
+
         return React.createElement(
-            component || 'a',
+            component || LinkComponent,
             {
                 ...extraProps,
                 ...commonProps,

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -446,35 +446,67 @@ LANDING_BLOCK-->
 
 <!--/GITHUB_BLOCK-->
 
+## Next.js  
+By default, the `<Button />` component renders an `<a>` tag for links.
+
+To use the Next.js `<Link />` component, pass it to the `hrefComponent` prop when rendering the `<Button />`. 
+<!--LANDING_BLOCK
+
+<ExampleBlock
+    background='rgb(68, 38, 204)'
+    code={`
+import NextLink from 'next/link';
+
+<Button href="#" hrefComponent={NextLink}>NextJS Link</Button>
+`}
+>
+    <UIKit.Button view="normal-contrast" size="l">Normal Contrast</UIKit.Button>
+    <UIKit.Button view="outlined-contrast" size="l">Outlined Contrast</UIKit.Button>
+    <UIKit.Button view="flat-contrast" size="l">Flat Contrast</UIKit.Button>
+</ExampleBlock>
+
+LANDING_BLOCK-->
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+import NextLink from 'next/link';
+
+<Button href="#" hrefComponent={NextLink}>NextJS Link</Button>
+```
+
+<!--/GITHUB_BLOCK--> 
+
 ## Properties
 
-| Name         | Description                                                        |              Type               |     Default     |
-| :----------- | :----------------------------------------------------------------- | :-----------------------------: | :-------------: |
-| children     | Button content. You can use both text and the `<Icon/>` component. |           `ReactNode`           |                 |
-| className    | `class` HTML attribute                                             |            `string`             |                 |
-| component    | Overrides the root component                                       |       `ElementType<any>`        |   `"button"`    |
-| disabled     | Toggles the `disabled` state                                       |             `false`             |     `false`     |
-| extraProps   | Additional properties                                              |            `Record`             |                 |
-| href         | `href` HTML attribute                                              |            `string`             |                 |
-| id           | `id` HTML attribute                                                |            `string`             |                 |
-| loading      | Toggles the `loading` state                                        |             `false`             |     `false`     |
-| onBlur       | `blur` event handler                                               |           `Function`            |                 |
-| onClick      | `click` event handler                                              |           `Function`            |                 |
-| onFocus      | `focus` event handler                                              |           `Function`            |                 |
-| onMouseEnter | `mouseenter` event handler                                         |           `Function`            |                 |
-| onMouseLeave | `mouseleave` event handler                                         |           `Function`            |                 |
-| pin          | Sets the button edge style                                         |            `string`             | `"round-round"` |
-| qa           | `data-qa` HTML attribute, used for testing                         |            `string`             |                 |
-| rel          | `rel` HTML attribute                                               |            `string`             |                 |
-| selected     | Toggles the `selected` state                                       |                                 |                 |
-| size         | Sets the button size                                               |            `string`             |      `"m"`      |
-| style        | `style` HTML attribute                                             |      `React.CSSProperties`      |                 |
-| tabIndex     | `tabIndex` HTML attribute                                          |            `number`             |                 |
-| target       | `target` HTML attribute                                            |            `string`             |                 |
-| title        | `title` HTML attribute                                             |            `string`             |                 |
-| type         | `type` HTML attribute                                              | `"button"` `"submit"` `"reset"` |   `"button"`    |
-| view         | Sets the button appearance                                         |            `string`             |   `"normal"`    |
-| width        | `"auto"` `"max"`                                                   |        `"auto"` `"max"`         |                 |
+| Name          | Description                                                        |              Type               |     Default     |
+| :------------ | :----------------------------------------------------------------- | :-----------------------------: | :-------------: |
+| children      | Button content. You can use both text and the `<Icon/>` component. |           `ReactNode`           |                 |
+| className     | `class` HTML attribute                                             |            `string`             |                 |
+| component     | Overrides the root component                                       |       `ElementType<any>`        |   `"button"`    |
+| disabled      | Toggles the `disabled` state                                       |             `false`             |     `false`     |
+| extraProps    | Additional properties                                              |            `Record`             |                 |
+| href          | `href` HTML attribute                                              |            `string`             |                 |
+| hrefComponent | Sets the custom link component for the button                      |       `React.ElementType`       |     `"<a>"`     |
+| id            | `id` HTML attribute                                                |            `string`             |                 |
+| loading       | Toggles the `loading` state                                        |             `false`             |     `false`     |
+| onBlur        | `blur` event handler                                               |           `Function`            |                 |
+| onClick       | `click` event handler                                              |           `Function`            |                 |
+| onFocus       | `focus` event handler                                              |           `Function`            |                 |
+| onMouseEnter  | `mouseenter` event handler                                         |           `Function`            |                 |
+| onMouseLeave  | `mouseleave` event handler                                         |           `Function`            |                 |
+| pin           | Sets the button edge style                                         |            `string`             | `"round-round"` |
+| qa            | `data-qa` HTML attribute, used for testing                         |            `string`             |                 |
+| rel           | `rel` HTML attribute                                               |            `string`             |                 |
+| selected      | Toggles the `selected` state                                       |                                 |                 |
+| size          | Sets the button size                                               |            `string`             |      `"m"`      |
+| style         | `style` HTML attribute                                             |      `React.CSSProperties`      |                 |
+| tabIndex      | `tabIndex` HTML attribute                                          |            `number`             |                 |
+| target        | `target` HTML attribute                                            |            `string`             |                 |
+| title         | `title` HTML attribute                                             |            `string`             |                 |
+| type          | `type` HTML attribute                                              | `"button"` `"submit"` `"reset"` |   `"button"`    |
+| view          | Sets the button appearance                                         |            `string`             |   `"normal"`    |
+| width         | `"auto"` `"max"`                                                   |        `"auto"` `"max"`         |                 |
 
 ## CSS API
 


### PR DESCRIPTION
Added support for using custom link components (e.g., NextLink) in the Button component via the new `hrefComponent` prop. If `hrefComponent` is not specified, it defaults to `<a>`.

### Details:
- Introduced a new prop `hrefComponent` in `ButtonProps`.
- If `hrefComponent` is provided, it will render the specified component for links instead of  `<a>`.
- Maintains backward compatibility by defaulting to `<a>` when `hrefComponent` is not set.
- Ensures flexibility for projects using custom routing libraries like Next.js.

### Related Tickets & Documents
- Issues: #2007 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en