### PR TITLE
feat: add select autofocus props

### DIFF
--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -284,6 +284,8 @@ LANDING_BLOCK-->
 
 To enable filter section, use the `filterable` property. Its default value is `false`.
 
+To disable filter control autofocus, use the `autoFocus={false}` property.
+
 <!--LANDING_BLOCK
 
 <ExampleBlock
@@ -1125,6 +1127,7 @@ LANDING_BLOCK-->
 | defaultValue                                              | Default values that represent selected options in case of using an uncontrolled state                                            | `string[]`                               |                                                          |
 | disabled                                                  | Shows that the user cannot work with the control                                                                                 | `boolean`                                | `false`                                                  |
 | [filterable](#filtering-options)                          | Shows that select popup has a filter section                                                                                     | `boolean`                                | `false`                                                  |
+| [autoFocus](#filtering-options)                           | The filter control `autofocus`                                                                                                   | `boolean`                                | `true`                                                   |
 | filterOption                                              | Used to compare option with filter                                                                                               | `function`                               |                                                          |
 | filterPlaceholder                                         | Default filter input placeholder text                                                                                            | `string`                                 |                                                          |
 | [getOptionHeight](#render-options-with-different-heights) | Used to set height of customized user options                                                                                    | `function`                               |                                                          |

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -91,6 +91,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
         multiple = false,
         disabled = false,
         filterable = false,
+        autoFocus = true,
         filter: propsFilter,
         disablePortal,
         hasClear = false,
@@ -222,12 +223,10 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
     });
 
     React.useEffect(() => {
-        if (open) {
-            if (filterable) {
-                filterRef.current?.focus();
-            }
+        if (open && filterable && autoFocus) {
+            filterRef.current?.focus();
         }
-    }, [open, filterable]);
+    }, [open, filterable, autoFocus]);
 
     const mods: CnMods = {
         ...(width === 'max' && {width}),

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -144,6 +144,7 @@ export type SelectProps<T = any> = QAProps &
         validationState?: 'invalid';
         multiple?: boolean;
         filterable?: boolean;
+        autoFocus?: boolean;
         filter?: string;
         onFilterChange?: (filter: string) => void;
         disablePortal?: boolean;


### PR DESCRIPTION
Optional autofocus. This is useful for mobiles when you don't want to open the keyboard.