### PR TITLE
feat(DropdownMenu): remove deprecated prop switcher

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -64,11 +64,6 @@ export type DropdownMenuProps<T> = {
     disabled?: boolean;
     /**
      * Menu toggle control.
-     * @deprecated Use renderSwitcher instead
-     */
-    switcher?: React.ReactNode;
-    /**
-     * Menu toggle control.
      */
     renderSwitcher?: (props: SwitcherProps) => React.ReactNode;
     switcherWrapperClassName?: string;
@@ -106,7 +101,6 @@ const DropdownMenu = <T,>({
     hideOnScroll = true,
     data,
     disabled,
-    switcher,
     renderSwitcher,
     switcherWrapperClassName,
     defaultSwitcherProps,
@@ -172,12 +166,11 @@ const DropdownMenu = <T,>({
                 className={cnDropdownMenu('switcher-wrapper', switcherWrapperClassName)}
                 {...(renderSwitcher ? {} : switcherProps)}
             >
-                {renderSwitcher?.(switcherProps) || switcher || (
+                {renderSwitcher?.(switcherProps) || (
                     <Button
                         view="flat"
                         size={size}
-                        // FIXME remove switcher prop and uncomment onClick handler
-                        // onClick={handleSwitcherClick}
+                        onClick={handleSwitcherClick}
                         {...defaultSwitcherProps}
                         className={cnDropdownMenu('switcher-button', defaultSwitcherClassName)}
                         disabled={disabled}

--- a/src/components/PlaceholderContainer/__stories__/PlaceholderContainer.stories.tsx
+++ b/src/components/PlaceholderContainer/__stories__/PlaceholderContainer.stories.tsx
@@ -66,12 +66,12 @@ const actionComponentTest = (
                 {text: 'text 2', action: () => {}},
             ]}
             onSwitcherClick={(e) => e?.stopPropagation()}
-            switcher={
+            renderSwitcher={() => (
                 <Button>
                     Text
                     <Icon data={ChevronDown} size={16} />
                 </Button>
-            }
+            )}
         />
     </div>
 );


### PR DESCRIPTION
### Description
The deprecated `switcher` property has been removed from the `DropdownMenu` component.

issue #1408 