### PR TITLE
feat!: remove old deprications

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,11 +1,4 @@
-import {List, listDefaultProps} from './List';
-import type {ListProps} from './types';
-
 export * from './List';
 export * from './types';
 export * from './components/ListItem';
 export {ListQa} from './constants';
-
-/** @deprecated Use `<List/>` */
-export const ListWrapper = (props: ListProps<any>) => <List {...props} />;
-ListWrapper.defaultProps = listDefaultProps;

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -10,8 +10,6 @@ import {eventBroker} from '../utils/event-broker';
 const b = block('menu');
 
 export interface MenuItemProps extends DOMProps, QAProps {
-    /** @deprecated use `iconStart` instead */
-    icon?: React.ReactNode;
     iconStart?: React.ReactNode;
     iconEnd?: React.ReactNode;
     title?: string;
@@ -31,8 +29,7 @@ export interface MenuItemProps extends DOMProps, QAProps {
 
 export const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(function MenuItem(
     {
-        icon,
-        iconStart = icon,
+        iconStart,
         iconEnd,
         title,
         disabled,

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -257,7 +257,7 @@ export const NumberInput = React.forwardRef<HTMLSpanElement, NumberInputProps>(f
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             ref={ref}
-            unstable_endContent={
+            endContent={
                 <React.Fragment>
                     {endContent}
                     {hiddenControls ? null : (

--- a/src/components/Select/__tests__/utils.tsx
+++ b/src/components/Select/__tests__/utils.tsx
@@ -93,14 +93,10 @@ export const generateOptionsGroups = (
 };
 
 export const renderControl = (args: SelectRenderControlProps) => {
-    const {onClear, onClick, onKeyDown, ref} = args;
+    const {onClear, triggerProps, ref} = args;
     return (
         <div>
-            <button
-                ref={ref as React.RefObject<HTMLButtonElement>}
-                onClick={onClick}
-                onKeyDown={onKeyDown}
-            ></button>
+            <button {...triggerProps} ref={ref as React.RefObject<HTMLButtonElement>}></button>
             <button onClick={onClear}>Clear</button>
         </div>
     );

--- a/src/components/Select/components/SelectControl/SelectControl.tsx
+++ b/src/components/Select/components/SelectControl/SelectControl.tsx
@@ -172,16 +172,11 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
     if (renderControl) {
         return renderControl(
             {
-                onKeyDown,
                 onClear: clearValue,
-                onClick: handleControlClick,
                 renderClear: renderClearIcon,
                 renderCounter: renderCounterComponent,
                 ref,
                 open,
-                popupId,
-                selectId,
-                activeIndex,
                 disabled,
                 triggerProps,
             },

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -28,20 +28,10 @@ export type SelectRenderTriggerProps = AriaLabelingProps &
 
 export type SelectRenderControlProps = {
     onClear: () => void;
-    /** @deprecated use triggerProps instead */
-    onClick: (e: React.MouseEvent<HTMLElement>) => void;
-    /** @deprecated use triggerProps instead */
-    onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
     renderClear: (args: SelectRenderClearArgs) => React.ReactNode;
     renderCounter: () => React.ReactNode;
     ref: React.Ref<HTMLElement>;
     open: boolean;
-    /** @deprecated use triggerProps instead */
-    popupId: string;
-    /** @deprecated use triggerProps instead */
-    selectId: string;
-    /** @deprecated use triggerProps instead */
-    activeIndex?: number;
     disabled?: boolean;
     triggerProps: SelectRenderTriggerProps;
 };

--- a/src/components/controls/PasswordInput/PasswordInput.tsx
+++ b/src/components/controls/PasswordInput/PasswordInput.tsx
@@ -41,7 +41,6 @@ export const PasswordInput = (props: PasswordInputProps) => {
         autoComplete,
         controlProps,
         endContent,
-        rightContent,
         hideCopyButton = false,
         hideRevealButton = false,
         showCopyTooltip = false,
@@ -65,7 +64,7 @@ export const PasswordInput = (props: PasswordInputProps) => {
 
     const additionalEndContent = (
         <React.Fragment>
-            {endContent || rightContent}
+            {endContent}
             {inputValue && !hideCopyButton && !props.disabled ? (
                 <ClipboardButton
                     view="flat-secondary"
@@ -103,7 +102,7 @@ export const PasswordInput = (props: PasswordInputProps) => {
         <TextInput
             {...props}
             type={revealValue ? 'text' : 'password'}
-            unstable_endContent={additionalEndContent}
+            endContent={additionalEndContent}
             autoComplete={autoComplete ? autoComplete : 'new-password'}
             controlProps={{
                 ...controlProps,

--- a/src/components/controls/TextInput/README.md
+++ b/src/components/controls/TextInput/README.md
@@ -160,7 +160,7 @@ LANDING_BLOCK-->
 
 Allows you to set the label to the left of control.
 
-- label occupies the leftmost position relative to the control. That is, the elements added via `leftContent` property will be located to the right.
+- label occupies the leftmost position relative to the control. That is, the elements added via `startContent` property will be located to the right.
 - label can take up no more than half the width of the entire TextInput's space.
 
 <!--LANDING_BLOCK
@@ -185,18 +185,18 @@ LANDING_BLOCK-->
 
 ## Additional content
 
-### Left content
+### Start content
 
-Allows you to add content to the left of the control. Located to the right of the label added via `label` property.
+Allows you to add content to the left of the control (or to the right in case of using [rtl](https://developer.mozilla.org/en-US/docs/Glossary/RTL)). Located to the left (or to the right in case of using rtl) of the label added via `label` property.
 
 <!--LANDING_BLOCK
 <ExampleBlock
-    code={`<TextInput placeholder="Placeholder" label="Label" leftContent={<Label size="s">Left</Label>} />`}
+    code={`<TextInput placeholder="Placeholder" label="Label" startContent={<Label size="s">Left</Label>} />`}
 >
     <UIKit.TextInput
         placeholder="Search"
         label="Label"
-        leftContent={<UIKit.Label size="s">Left</UIKit.Label>}
+        startContent={<UIKit.Label size="s">Left</UIKit.Label>}
     />
 </ExampleBlock>
 LANDING_BLOCK-->
@@ -204,23 +204,23 @@ LANDING_BLOCK-->
 <!--GITHUB_BLOCK-->
 
 ```tsx
-<TextInput leftContent={<Label>Left</Label>} />
+<TextInput startContent={<Label>Left</Label>} />
 ```
 
 <!--/GITHUB_BLOCK-->
 
-### Right content
+### End content
 
-Allows you to add content to the right of the control. Located to the right of the clear button added via `hasClear` property.
+Allows you to add content to the right (or to the left in case of using [rtl](https://developer.mozilla.org/en-US/docs/Glossary/RTL)) of the control. Located to the right (or to the left in case of using rtl) of the clear button added via `hasClear` property.
 
 <!--LANDING_BLOCK
 <ExampleBlock
-    code={`<TextInput placeholder="Placeholder" rightContent={<Label size="s">Right</Label>} hasClear/>`}
+    code={`<TextInput placeholder="Placeholder" endContent={<Label size="s">Right</Label>} hasClear/>`}
 >
     <UIKit.TextInput
         hasClear
         placeholder="Placeholder"
-        rightContent={<UIKit.Label size="s">Right</UIKit.Label>}
+        endContent={<UIKit.Label size="s">Right</UIKit.Label>}
     />
 </ExampleBlock>
 LANDING_BLOCK-->
@@ -228,7 +228,7 @@ LANDING_BLOCK-->
 <!--GITHUB_BLOCK-->
 
 ```tsx
-<TextInput rightContent={<Label>Right</Label>} />
+<TextInput endContent={<Label>Right</Label>} />
 ```
 
 <!--/GITHUB_BLOCK-->
@@ -243,13 +243,13 @@ LANDING_BLOCK-->
 | controlProps    | The control's html attributes                                                                                           |             `React.InputHTMLAttributes<HTMLInputElement>`             |                 |
 | controlRef      | React ref provided to the control                                                                                       |                     `React.Ref<HTMLInputElement>`                     |                 |
 | defaultValue    | The control's default value, used when the component is not controlled                                                  |                               `string`                                |                 |
-| disabled        | Indicates that the user cannot interact with the control                                                                |                               `boolean`                               |     `false`     |
+| disabled        | Indicates that the user cannot interact with the control                                                                |                           `React.ReactNode`                           |                 |
+| endContent      | User`s node rendered after input node, clear button and error icon                                                      |                               `string`                                |                 |
 | errorMessage    | Error text                                                                                                              |                               `string`                                |                 |
 | errorPlacement  | Error placement                                                                                                         |                          `outside` `inside`                           |    `outside`    |
 | hasClear        | Shows the icon for clearing control's value                                                                             |                               `boolean`                               |     `false`     |
 | id              | The control's `id` attribute                                                                                            |                               `string`                                |                 |
 | label           | Help text rendered to the left of the input node                                                                        |                               `string`                                |                 |
-| leftContent     | The user`s node rendered before label and input                                                                         |                           `React.ReactNode`                           |                 |
 | name            | The `name` attribute of the control. If unspecified, it will be autogenerated if not specified                          |                               `string`                                |                 |
 | note            | An optional element displayed under the bottom-right corner of the control that shares a space with the error container |                           `React.ReactNode`                           |                 |
 | onBlur          | Fires when the control lost focus. Provides focus event as a callback's argument                                        |                              `function`                               |                 |
@@ -262,8 +262,8 @@ LANDING_BLOCK-->
 | placeholder     | Text that appears in the control when it has no value set                                                               |                               `string`                                |                 |
 | qa              | Test ID attribute (`data-qa`)                                                                                           |                               `string`                                |
 | readOnly        | Indicates that the user cannot change control's value                                                                   |                               `boolean`                               |     `false`     |
-| rightContent    | User`s node rendered after the input node and clear button                                                              |                           `React.ReactNode`                           |                 |
 | size            | The size of the control                                                                                                 |                       `"s"` `"m"` `"l"` `"xl"`                        |      `"m"`      |
+| startContent    | User`s node rendered before label and input node                                                                        |                           `React.ReactNode`                           |                 |
 | tabIndex        | The `tabindex` attribute of the control                                                                                 |                               `string`                                |                 |
 | type            | The type of the control                                                                                                 | `"email"` `"number"` `"password"` `"search"` `"tel"` `"text"` `"url"` |                 |
 | validationState | Validation state                                                                                                        |                              `"invalid"`                              |                 |

--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -321,13 +321,11 @@ $block: '.#{variables.$ns}text-input';
     }
 
     &_has-end-content {
+        --_--error-icon-padding-inline: 0;
+
         #{$block}__control {
             padding-inline-end: 2px;
         }
-    }
-
-    &_has-unstable-end-content {
-        --_--error-icon-padding-inline: 0;
     }
 
     &_state {

--- a/src/components/controls/TextInput/TextInput.tsx
+++ b/src/components/controls/TextInput/TextInput.tsx
@@ -38,22 +38,10 @@ export type TextInputProps = BaseInputControlProps<HTMLInputElement> & {
     controlProps?: React.InputHTMLAttributes<HTMLInputElement>;
     /** Help text rendered to the left of the input node */
     label?: string;
-    /** User`s node rendered before label and input node
-     * @deprecated use `startContent` instead
-     */
-    leftContent?: React.ReactNode;
-    /** User`s node rendered after input node and clear button
-     * @deprecated use `endContent` instead
-     */
-    rightContent?: React.ReactNode;
     /** User`s node rendered before label and input node */
     startContent?: React.ReactNode;
-    /** User`s node rendered after input node and clear button */
+    /** User`s node rendered after input node, clear button and error icon */
     endContent?: React.ReactNode;
-    /** User`s node rendered after input node, clear button and error icon.
-     * This prop will replace current `endContent` prop in next major
-     */
-    unstable_endContent?: React.ReactNode;
     /** An optional element displayed under the lower right corner of the control and sharing the place with the error container */
     note?: React.ReactNode;
 };
@@ -85,11 +73,8 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
             className,
             qa,
             controlProps: controlPropsProp,
-            leftContent,
-            rightContent,
-            startContent = leftContent,
-            endContent = rightContent,
-            unstable_endContent: unstableEndContent,
+            startContent,
+            endContent,
             note,
             onUpdate,
             onChange,
@@ -117,8 +102,7 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
             validationState === 'invalid' && Boolean(errorMessage) && errorPlacement === 'inside';
         const isClearControlVisible = Boolean(hasClear && !disabled && !readOnly && inputValue);
         const isStartContentVisible = Boolean(startContent);
-        const isUnstableEndContentVisible = Boolean(unstableEndContent);
-        const isEndContentVisible = Boolean(endContent) && !isUnstableEndContentVisible;
+        const isEndContentVisible = Boolean(endContent);
         const isAutoCompleteOff =
             isLabelVisible && !idProp && !name && typeof autoComplete === 'undefined';
 
@@ -208,11 +192,7 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
                         pin: view === 'clear' ? undefined : pin,
                         'has-clear': isClearControlVisible,
                         'has-start-content': isStartContentVisible,
-                        'has-end-content':
-                            isClearControlVisible ||
-                            isEndContentVisible ||
-                            isUnstableEndContentVisible,
-                        'has-unstable-end-content': isUnstableEndContentVisible,
+                        'has-end-content': isClearControlVisible || isEndContentVisible,
                     },
                     className,
                 )}
@@ -252,11 +232,6 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
                             className={b('clear', {size})}
                         />
                     )}
-                    {isEndContentVisible && (
-                        <AdditionalContent placement="end" onClick={handleAdditionalContentClick}>
-                            {endContent}
-                        </AdditionalContent>
-                    )}
                     {isErrorIconVisible && (
                         <Popover content={errorMessage}>
                             <span data-qa={CONTROL_ERROR_ICON_QA}>
@@ -268,9 +243,9 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
                             </span>
                         </Popover>
                     )}
-                    {isUnstableEndContentVisible && (
+                    {isEndContentVisible && (
                         <AdditionalContent placement="end" onClick={handleAdditionalContentClick}>
-                            {unstableEndContent}
+                            {endContent}
                         </AdditionalContent>
                     )}
                 </span>

--- a/src/components/controls/TextInput/__stories__/TextInputShowcase.tsx
+++ b/src/components/controls/TextInput/__stories__/TextInputShowcase.tsx
@@ -44,7 +44,6 @@ const EyeButton = (props: {
 export function TextInputShowcase(args: TextInputProps) {
     const [value, setValue] = React.useState('');
     const [isErrorMessageVisible, setErrorMessageVisibility] = React.useState(false);
-    const [isUseUnstableEndContent, setUseUnstableEndContent] = React.useState(false);
     const [hideValue, setHideValue] = React.useState(false);
     const additionalContentExmpleInputType = hideValue ? 'password' : undefined;
 
@@ -170,64 +169,36 @@ export function TextInputShowcase(args: TextInputProps) {
 
             <div className={b('text-input-examples')}>
                 <h2 className={b('title')}>TextInput (with additional content)</h2>
-
                 <div className={'size-examples'}>
                     <h3 className={b('section-header')}>Sizes:</h3>
-
-                    <div className={b('row', {type: 'checkbox'})}>
-                        <Checkbox
-                            content="Use unstable_endContent"
-                            onUpdate={setUseUnstableEndContent}
-                            checked={isUseUnstableEndContent}
-                        />
-                    </div>
-
                     <TextInput
                         {...textInputProps}
                         size="s"
                         placeholder="s"
                         type={additionalContentExmpleInputType}
-                        leftContent={<Icon data={Key} />}
-                        {...{
-                            [isUseUnstableEndContent ? 'unstable_endContent' : 'rightContent']: (
-                                <EyeButton
-                                    size="s"
-                                    opened={hideValue}
-                                    onClick={handleEyeButtonClick}
-                                />
-                            ),
-                        }}
+                        startContent={<Icon data={Key} />}
+                        endContent={
+                            <EyeButton size="s" opened={hideValue} onClick={handleEyeButtonClick} />
+                        }
                     />
                     <TextInput
                         {...textInputProps}
                         placeholder="m"
                         type={additionalContentExmpleInputType}
-                        leftContent={<Icon data={Key} />}
-                        {...{
-                            [isUseUnstableEndContent ? 'unstable_endContent' : 'rightContent']: (
-                                <EyeButton
-                                    size="m"
-                                    opened={hideValue}
-                                    onClick={handleEyeButtonClick}
-                                />
-                            ),
-                        }}
+                        startContent={<Icon data={Key} />}
+                        endContent={
+                            <EyeButton size="m" opened={hideValue} onClick={handleEyeButtonClick} />
+                        }
                     />
                     <TextInput
                         {...textInputProps}
                         size="l"
                         placeholder="l"
                         type={additionalContentExmpleInputType}
-                        leftContent={<Icon data={Key} />}
-                        {...{
-                            [isUseUnstableEndContent ? 'unstable_endContent' : 'rightContent']: (
-                                <EyeButton
-                                    size="l"
-                                    opened={hideValue}
-                                    onClick={handleEyeButtonClick}
-                                />
-                            ),
-                        }}
+                        startContent={<Icon data={Key} />}
+                        endContent={
+                            <EyeButton size="l" opened={hideValue} onClick={handleEyeButtonClick} />
+                        }
                     />
                     <TextInput
                         {...textInputProps}
@@ -235,16 +206,14 @@ export function TextInputShowcase(args: TextInputProps) {
                         placeholder="xl"
                         type={additionalContentExmpleInputType}
                         label={LABEL}
-                        leftContent={<Icon data={Key} />}
-                        {...{
-                            [isUseUnstableEndContent ? 'unstable_endContent' : 'rightContent']: (
-                                <EyeButton
-                                    size="xl"
-                                    opened={hideValue}
-                                    onClick={handleEyeButtonClick}
-                                />
-                            ),
-                        }}
+                        startContent={<Icon data={Key} />}
+                        endContent={
+                            <EyeButton
+                                size="xl"
+                                opened={hideValue}
+                                onClick={handleEyeButtonClick}
+                            />
+                        }
                     />
                 </div>
 
@@ -257,8 +226,8 @@ export function TextInputShowcase(args: TextInputProps) {
                             placeholder="error with message"
                             error={isErrorMessageVisible ? 'A validation error has occurred' : true}
                             type={additionalContentExmpleInputType}
-                            leftContent={<Icon data={Key} />}
-                            rightContent={
+                            startContent={<Icon data={Key} />}
+                            endContent={
                                 <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
                             }
                         />
@@ -283,24 +252,10 @@ export function TextInputShowcase(args: TextInputProps) {
                     />
                     <TextInput
                         {...textInputProps}
-                        placeholder="inside error placement with unstable_endContent"
-                        label={LABEL}
-                        type={additionalContentExmpleInputType}
-                        startContent={<Icon data={Key} />}
-                        unstable_endContent={
-                            <EyeButton opened={hideValue} disabled onClick={handleEyeButtonClick} />
-                        }
-                        validationState="invalid"
-                        errorMessage="A validation error has occurred"
-                        errorPlacement="inside"
-                        hasClear
-                    />
-                    <TextInput
-                        {...textInputProps}
                         placeholder="disabled"
                         type={additionalContentExmpleInputType}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
+                        startContent={<Icon data={Key} />}
+                        endContent={
                             <EyeButton opened={hideValue} disabled onClick={handleEyeButtonClick} />
                         }
                         disabled
@@ -310,10 +265,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         placeholder="readonly"
                         type={additionalContentExmpleInputType}
                         value="readonlyValue"
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         readOnly
                     />
                     <TextInput
@@ -321,10 +274,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         placeholder="clear"
                         type={additionalContentExmpleInputType}
                         label={LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         hasClear
                     />
                     <TextInput
@@ -334,20 +285,16 @@ export function TextInputShowcase(args: TextInputProps) {
                         defaultValue="defaultValue"
                         type={additionalContentExmpleInputType}
                         label={LONG_LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                     />
                     <TextInput
                         {...textInputProps}
                         placeholder="with note"
                         type={additionalContentExmpleInputType}
                         label={LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         note={<Text color="secondary">Additional</Text>}
                         hasClear
                     />
@@ -393,10 +340,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         placeholder="clear"
                         type={additionalContentExmpleInputType}
                         label={LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         hasClear
                     />
                     <TextInput
@@ -407,10 +352,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         defaultValue="defaultValue"
                         type={additionalContentExmpleInputType}
                         label={LONG_LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         hasClear
                     />
                 </div>
@@ -460,10 +403,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         placeholder="clear"
                         type={additionalContentExmpleInputType}
                         label={LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         hasClear
                     />
                     <TextInput
@@ -475,10 +416,8 @@ export function TextInputShowcase(args: TextInputProps) {
                         defaultValue="defaultValue"
                         type={additionalContentExmpleInputType}
                         label={LONG_LABEL}
-                        leftContent={<Icon data={Key} />}
-                        rightContent={
-                            <EyeButton opened={hideValue} onClick={handleEyeButtonClick} />
-                        }
+                        startContent={<Icon data={Key} />}
+                        endContent={<EyeButton opened={hideValue} onClick={handleEyeButtonClick} />}
                         hasClear
                     />
                 </div>

--- a/src/components/layout/LayoutProvider/LayoutProvider.tsx
+++ b/src/components/layout/LayoutProvider/LayoutProvider.tsx
@@ -32,23 +32,3 @@ export function PrivateLayoutProvider({
     const value = React.useMemo(() => ({activeMediaQuery, theme}), [activeMediaQuery, theme]);
     return <LayoutContext.Provider value={value}>{children}</LayoutContext.Provider>;
 }
-
-interface LayoutProviderProps {
-    theme?: RecursivePartial<LayoutTheme>;
-    /**
-     * During ssr you can override default (`s`) media screen size if needed
-     */
-    initialMediaQuery?: MediaType;
-    children: React.ReactNode;
-}
-
-/**
- * @deprecated - already used as part of ThemeProvider. To override layout theme use `layout` prop
- *
- * Provide context for layout components and current media queries.
- * ---
- * Storybook - https://preview.gravity-ui.com/uikit/?path=/docs/layout--playground#layoutprovider-and-layouttheme
- */
-export function LayoutProvider({children}: LayoutProviderProps) {
-    return children;
-}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -4,7 +4,6 @@ export * from './Row/Row';
 export * from './Flex/Flex';
 export * from './Box/Box';
 export * from './Container/Container';
-export {LayoutProvider} from './LayoutProvider/LayoutProvider';
 export * from './spacing/spacing';
 
 export * from './hooks/useLayoutContext';


### PR DESCRIPTION
**List**
- ListWrapper removed, use `<List />` instead

**MenuItem**
- props `icon` removed, use `iconStart` instead

**Select**
- `onKeyDown`, `onClick`, `popupId`, `selectId`, `activeIndex` removed from `renderControl` signature, use `triggerProps` instead

**TextInput**
- `leftContent` removed, use `startContent` instead
- `rightContent` removed, use `endContent` instead

**layout**:
- `LayoutProvider` removed, use `ThemeProviderProps['layout']` instead