### PR TITLE
fix(Dialog): fixed dialog overflow, added header caption control to story

### DIFF
--- a/src/components/Dialog/DialogHeader/DialogHeader.scss
+++ b/src/components/Dialog/DialogHeader/DialogHeader.scss
@@ -18,5 +18,6 @@ $block: '.#{variables.$ns}dialog-header';
 
     &__caption {
         @include mixins.text-subheader-3();
+        word-break: break-word;
     }
 }

--- a/src/components/Dialog/__stories__/Dialog.stories.tsx
+++ b/src/components/Dialog/__stories__/Dialog.stories.tsx
@@ -15,10 +15,17 @@ export default {
         showError: {
             type: 'boolean',
         },
+        headerCaption: {
+            type: 'string',
+        },
     },
 } as Meta<DialogProps>;
 
-const DefaultTemplate: StoryFn<DialogProps & {showError: boolean}> = ({showError, ...args}) => {
+const DefaultTemplate: StoryFn<DialogProps & {showError: boolean; headerCaption: string}> = ({
+    showError,
+    headerCaption = 'Caption',
+    ...args
+}) => {
     const dialogTitleId = 'app-confirmation-dialog-title';
     const [open, setOpen] = React.useState(false);
     return (
@@ -35,7 +42,7 @@ const DefaultTemplate: StoryFn<DialogProps & {showError: boolean}> = ({showError
                 }}
                 aria-labelledby={dialogTitleId}
             >
-                <Dialog.Header caption="Caption" id={dialogTitleId} />
+                <Dialog.Header caption={headerCaption} id={dialogTitleId} />
                 <Dialog.Body>Dialog.Body</Dialog.Body>
                 <Dialog.Footer
                     onClickButtonCancel={() => setOpen(false)}


### PR DESCRIPTION
If `Dialog` header has a long word, layout breaks:
![image](https://github.com/user-attachments/assets/1f3cd580-2265-49ec-a648-2bd712c7a32c)
I added `word-break: break-word` so that it looks a bit nicer:
![image](https://github.com/user-attachments/assets/a649304a-9a4b-42e9-acfd-55bd48e5ac12)

Tested on phrase «Are you sure you want to launch aaa/bbbbbbbbbb/ccccccccccccc/ddddddddddd/eeeeeeeeeee/fffffffffff?».