### PR TITLE
feat: new Menu implementation

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -100,22 +100,21 @@ function BreadcrumbsItem(props: BreadcrumbsItemProps, ref: React.ForwardedRef<HT
         const active = !disabled && activeIndex === index;
         return (
             <ListItemView
-                {...getItemProps({
-                    ...restProps,
-                    ...domProps,
-                    ...linkProps,
-                    role: 'menuitem',
-                    active,
-                })}
                 ref={(node: HTMLElement | null) => {
                     listItemsRef.current[index ?? 0] = node;
                 }}
                 nestedLevel={popupStyle === 'staircase' ? index : undefined}
-                tabIndex={active ? 0 : -1}
                 active={active}
                 size="m"
                 className={b('menu-link', props.className)}
                 component={Element}
+                componentProps={getItemProps({
+                    ...restProps,
+                    ...domProps,
+                    ...linkProps,
+                    role: 'menuitem',
+                    tabIndex: active ? 0 : -1,
+                })}
                 disabled={disabled}
             >
                 {children}

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -49,7 +49,8 @@ $block: '.#{variables.$ns}button';
         transition: background-color 0.15s linear;
     }
 
-    &:hover {
+    &:hover,
+    &[aria-haspopup][aria-expanded='true'] {
         color: var(--g-button-text-color-hover, var(--_--text-color-hover));
 
         &::before {

--- a/src/components/Button/README-ru.md
+++ b/src/components/Button/README-ru.md
@@ -266,7 +266,7 @@ LANDING_BLOCK-->
 
 `loading` — когда в фоновом режиме выполняются асинхронные процессы.
 
-`selected` — когда пользователь может может включить (**Enable**) или отключить (**Disable**) кнопку.
+`selected` — когда пользователь может включить (**Enable**) или отключить (**Disable**) кнопку.
 
 <!--LANDING_BLOCK
 
@@ -290,6 +290,32 @@ LANDING_BLOCK-->
 <Button size="l" disabled>Disabled</Button>
 <Button size="l" loading>Loading</Button>
 <Button size="l" selected>Selected</Button>
+```
+
+<!--/GITHUB_BLOCK-->
+
+### Переключатель меню
+
+`Button` автоматически меняет свой внешний вид при передаче специальных aria-атрибутов (`aria-haspopup`, `aria-expanded`):
+
+<!--LANDING_BLOCK
+
+<ExampleBlock
+    code={`
+<Button aria-haspopup="menu" aria-expanded="true">Menu</Button>
+`}
+>
+    <UIKit.Button aria-haspopup="menu" aria-expanded="true">Menu</UIKit.Button>
+</ExampleBlock>
+
+LANDING_BLOCK-->
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+<Button aria-haspopup="menu" aria-expanded="true">
+  Menu
+</Button>
 ```
 
 <!--/GITHUB_BLOCK-->

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -294,6 +294,32 @@ LANDING_BLOCK-->
 
 <!--/GITHUB_BLOCK-->
 
+### Menu trigger
+
+`Button` automatically changes its appearance when corresponding aria-attributes (`aria-haspopup`, `aria-expanded`) are passed:
+
+<!--LANDING_BLOCK
+
+<ExampleBlock
+    code={`
+<Button aria-haspopup="menu" aria-expanded="true">Menu</Button>
+`}
+>
+    <UIKit.Button aria-haspopup="menu" aria-expanded="true">Menu</UIKit.Button>
+</ExampleBlock>
+
+LANDING_BLOCK-->
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+<Button aria-haspopup="menu" aria-expanded="true">
+  Menu
+</Button>
+```
+
+<!--/GITHUB_BLOCK-->
+
 ## Size
 
 Use the `size` property to manage the `Button` size. The default size is `m`.

--- a/src/components/lab/ListItemView/ListItemView.scss
+++ b/src/components/lab/ListItemView/ListItemView.scss
@@ -21,14 +21,14 @@ $block: '.#{variables.$ns}lab-list-item-view';
 */
 #{$block} {
     /* Sizes */
-    --_--min-height: var(--g-list-item-view-min-height, #{variables.$m-height});
+    --_--min-height: var(--g-list-item-view-min-height, 28px);
     --_--border-radius: var(--g-list-item-view-border-radius, var(--g-border-radius-m));
     --_--padding-inline: var(--g-list-item-view-padding-inline, var(--g-spacing-2));
     --_--padding-block: var(--g-list-item-view-padding-block, var(--g-spacing-1));
     --_--line-height: var(--g-list-item-view-line-height, 18px);
 
     --_--controls-gap: var(--g-list-item-view-controls-gap, var(--g-spacing-1));
-    --_--controls-size: var(--g-list-item-view-controls-size, #{variables.$s-height});
+    --_--controls-size: var(--g-list-item-view-controls-size, 20px);
     --_--controls-border-radius: var(
         --g-list-item-view-controls-border-radius,
         var(--g-border-radius-s)
@@ -170,48 +170,48 @@ $block: '.#{variables.$ns}lab-list-item-view';
 
     &_size {
         &_s {
-            --_--min-height: #{variables.$s-height};
+            --_--min-height: 24px;
             --_--border-radius: var(--g-border-radius-s);
             --_--padding-inline: var(--g-spacing-2);
             --_--padding-block: var(--g-spacing-half);
 
             --_--controls-gap: var(--g-spacing-2);
-            --_--controls-size: #{variables.$xs-height};
+            --_--controls-size: 20px;
             --_--controls-border-radius: var(--g-border-radius-xs);
             --_--controls-icon-size: 12px;
         }
 
         &_m {
-            --_--min-height: #{variables.$m-height};
+            --_--min-height: 28px;
             --_--border-radius: var(--g-border-radius-m);
             --_--padding-inline: var(--g-spacing-2);
             --_--padding-block: var(--g-spacing-1);
 
             --_--controls-gap: var(--g-spacing-2);
-            --_--controls-size: #{variables.$s-height};
+            --_--controls-size: 24px;
             --_--controls-border-radius: var(--g-border-radius-s);
             --_--controls-icon-size: 16px;
         }
 
         &_l {
-            --_--min-height: #{variables.$l-height};
+            --_--min-height: 32px;
             --_--border-radius: var(--g-border-radius-l);
             --_--padding-inline: var(--g-spacing-2);
             --_--padding-block: var(--g-spacing-2);
             --_--controls-gap: var(--g-spacing-2);
-            --_--controls-size: #{variables.$m-height};
+            --_--controls-size: 24px;
             --_--controls-border-radius: var(--g-border-radius-m);
             --_--controls-icon-size: 16px;
         }
 
         &_xl {
-            --_--min-height: #{variables.$xl-height};
+            --_--min-height: 36px;
             --_--border-radius: var(--g-border-radius-xl);
             --_--padding-inline: var(--g-spacing-2);
             --_--padding-block: var(--g-spacing-3);
 
             --_--controls-gap: var(--g-spacing-2);
-            --_--controls-size: #{variables.$l-height};
+            --_--controls-size: 24px;
             --_--controls-border-radius: var(--g-border-radius-l);
             --_--controls-icon-size: 16px;
 

--- a/src/components/lab/ListItemView/ListItemView.scss
+++ b/src/components/lab/ListItemView/ListItemView.scss
@@ -69,6 +69,9 @@ $block: '.#{variables.$ns}lab-list-item-view';
 }
 
 #{$block} {
+    @include mixins.button-reset();
+    @include mixins.link-reset();
+
     display: grid;
     box-sizing: border-box;
     grid-template:
@@ -81,6 +84,7 @@ $block: '.#{variables.$ns}lab-list-item-view';
     background: var(--_--background-color);
     color: var(--_--text-color);
 
+    width: 100%;
     padding-inline: var(--_--padding-inline);
     padding-block: var(--_--padding-block);
     outline: none;
@@ -216,6 +220,7 @@ $block: '.#{variables.$ns}lab-list-item-view';
     }
 
     &_is-container {
+        display: block;
         --_--padding-inline: 0;
         --_--padding-block: 0;
     }
@@ -224,7 +229,8 @@ $block: '.#{variables.$ns}lab-list-item-view';
         --_--background-color: var(--_--background-color-hover);
     }
 
-    &:hover {
+    &:not(&_hovered_no):hover,
+    &_hovered_yes {
         --_--background-color: var(--_--background-color-hover);
     }
 
@@ -239,6 +245,8 @@ $block: '.#{variables.$ns}lab-list-item-view';
     }
 
     &_disabled {
+        pointer-events: none;
+
         &,
         &:hover,
         &:focus {

--- a/src/components/lab/ListItemView/ListItemView.tsx
+++ b/src/components/lab/ListItemView/ListItemView.tsx
@@ -21,6 +21,7 @@ export interface ListItemViewProps<T extends React.ElementType = 'div'> extends 
     size?: 's' | 'm' | 'l' | 'xl';
     selected?: boolean;
     active?: boolean;
+    hovered?: boolean;
     onClick?: (e: React.MouseEvent) => void;
     disabled?: boolean;
     selectionStyle?: 'check' | 'highlight' | 'none';
@@ -34,6 +35,7 @@ export interface ListItemViewProps<T extends React.ElementType = 'div'> extends 
     endContent?: React.ReactNode;
     isContainer?: boolean;
     component?: T;
+    componentProps?: React.ComponentProps<T>;
 }
 
 export const ListItemView = React.forwardRef(ListItemViewComponent) as <
@@ -50,6 +52,7 @@ export function ListItemViewComponent(
         size,
         active,
         selected,
+        hovered,
         disabled,
         onClick,
         selectionStyle,
@@ -60,20 +63,20 @@ export function ListItemViewComponent(
         children,
         isContainer = false,
         component: Component = 'div',
+        componentProps,
         collapsible: _collapsible,
         description,
         draggable: _draggable,
         startContent: _startContent,
         endContent: _endContent,
         nestedLevel: _nestedLevel,
-        ...restProps
     } = props;
     const containerRef = React.useRef(null);
     const componentRef = useForkRef(containerRef, ref);
     return (
         <Component
             ref={componentRef}
-            {...restProps}
+            {...componentProps}
             {...filterDOMProps(props)}
             className={b(
                 {
@@ -81,12 +84,13 @@ export function ListItemViewComponent(
                     selected: selected && selectionStyle === 'highlight',
                     disabled,
                     active,
+                    hovered: typeof hovered === 'boolean' && (hovered ? 'yes' : 'no'),
                     'is-container': isContainer,
                     'has-description': Boolean(description),
                 },
-                className,
+                componentProps?.className ?? className,
             )}
-            style={style}
+            style={componentProps?.style ?? style}
             onClick={(e) => {
                 if (disabled) {
                     e.preventDefault();
@@ -101,15 +105,19 @@ export function ListItemViewComponent(
                     return;
                 }
 
-                if (typeof onClick === 'function') {
-                    onClick(e);
+                if (
+                    typeof onClick === 'function' ||
+                    typeof componentProps?.onClick === 'function'
+                ) {
+                    onClick?.(e);
+                    componentProps?.onClick?.(e);
                 } else if (typeof onCollapseChange === 'function') {
                     onCollapseChange(!collapsed);
                 }
             }}
         >
             {isContainer ? (
-                <Slot name="container">{children}</Slot>
+                children
             ) : (
                 <ListItemViewContent {...props}>{children}</ListItemViewContent>
             )}

--- a/src/components/lab/Menu/Menu.scss
+++ b/src/components/lab/Menu/Menu.scss
@@ -1,6 +1,6 @@
 @use '../../variables';
 
-$b: '.#{variables.$ns}menu2';
+$b: '.#{variables.$ns}lab-menu';
 
 #{$b} {
     padding: 4px;

--- a/src/components/lab/Menu/Menu.scss
+++ b/src/components/lab/Menu/Menu.scss
@@ -1,0 +1,7 @@
+@use '../../variables';
+
+$b: '.#{variables.$ns}menu2';
+
+#{$b} {
+    padding: 4px;
+}

--- a/src/components/lab/Menu/Menu.tsx
+++ b/src/components/lab/Menu/Menu.tsx
@@ -35,7 +35,7 @@ import {isComponentType} from './utils';
 
 import './Menu.scss';
 
-const b = block('menu2');
+const b = block('lab-menu');
 
 // The component is needed to run submenu logic hooks.
 // We get <nodeId> of the Popup using "useFloatingParentNodeId" here

--- a/src/components/lab/Menu/Menu.tsx
+++ b/src/components/lab/Menu/Menu.tsx
@@ -1,0 +1,308 @@
+import * as React from 'react';
+
+import {
+    Composite,
+    CompositeItem,
+    FloatingList,
+    flip,
+    offset,
+    safePolygon,
+    shift,
+    useClick,
+    useDismiss,
+    useFloatingParentNodeId,
+    useFloatingRootContext,
+    useFloatingTree,
+    useHover,
+    useInteractions,
+    useListNavigation,
+    useRole,
+} from '@floating-ui/react';
+import type {VirtualElement} from '@floating-ui/react';
+
+import {useControlledState, useForkRef} from '../../../hooks';
+import {Popup} from '../../Popup';
+import {useDirection} from '../../theme';
+import {block} from '../../utils/cn';
+import {getElementRef} from '../../utils/getElementRef';
+
+import {MenuContext} from './MenuContext';
+import {MenuDivider} from './MenuDivider';
+import {MenuItem} from './MenuItem';
+import {MenuTrigger} from './MenuTrigger';
+import type {MenuProps} from './types';
+import {isComponentType} from './utils';
+
+import './Menu.scss';
+
+const b = block('menu2');
+
+// The component is needed to run submenu logic hooks.
+// We get <nodeId> of the Popup using "useFloatingParentNodeId" here
+// and <parentId> from using "useFloatingParentNodeId" outside the Popup.
+function MenuPopupContent({
+    open,
+    onRequestClose,
+    parentId,
+    children,
+    className,
+    style,
+    qa,
+}: Pick<MenuProps, 'children' | 'className' | 'style' | 'qa'> & {
+    open: boolean;
+    onRequestClose: () => void;
+    parentId: string | null;
+}) {
+    const tree = useFloatingTree();
+    const nodeId = useFloatingParentNodeId();
+
+    React.useEffect(() => {
+        if (!tree) return;
+
+        function handleTreeClick() {
+            // Closing only the root Menu so the closing animation runs once for all menus due to shared portal container
+            if (!parentId) {
+                onRequestClose();
+            }
+        }
+
+        function handleSubMenuOpen(event: {nodeId: string; parentId: string}) {
+            // Closing on sibling submenu open
+            if (event.nodeId !== nodeId && event.parentId === parentId) {
+                onRequestClose();
+            }
+        }
+
+        tree.events.on('click', handleTreeClick);
+        tree.events.on('menuopen', handleSubMenuOpen);
+
+        return () => {
+            tree.events.off('click', handleTreeClick);
+            tree.events.off('menuopen', handleSubMenuOpen);
+        };
+    }, [onRequestClose, tree, nodeId, parentId]);
+
+    React.useEffect(() => {
+        if (open && tree) {
+            tree.events.emit('menuopen', {parentId, nodeId});
+        }
+    }, [open, tree, nodeId, parentId]);
+
+    return (
+        <div className={b(null, className)} style={style} data-qa={qa}>
+            {children}
+        </div>
+    );
+}
+
+export function Menu({
+    trigger,
+    inline = false,
+    defaultOpen,
+    open,
+    onOpenChange,
+    placement = 'bottom-start',
+    disabled,
+    children,
+    size = 'm',
+    className,
+    style,
+    qa,
+}: MenuProps) {
+    const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
+    const [floatingElement, setFloatingElement] = React.useState<HTMLDivElement | null>(null);
+    const [isOpen, setIsOpen] = useControlledState(open, defaultOpen ?? false, onOpenChange);
+    const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+
+    const isRTL = useDirection() === 'rtl';
+
+    const itemsRef = React.useRef<Array<HTMLElement | null>>([]);
+    const parentMenu = React.useContext(MenuContext);
+
+    const parentId = useFloatingParentNodeId();
+    const isNested = Boolean(parentId);
+
+    const floatingContext = useFloatingRootContext({
+        open: isOpen && !disabled,
+        onOpenChange: setIsOpen,
+        elements: {
+            reference: anchorElement,
+            floating: floatingElement,
+        },
+    });
+    const hover = useHover(floatingContext, {
+        enabled: isNested,
+        delay: {open: 100},
+        handleClose: safePolygon({blockPointerEvents: true}),
+    });
+    const click = useClick(floatingContext, {
+        toggle: !isNested,
+        ignoreMouse: isNested,
+    });
+    const dismiss = useDismiss(floatingContext, {bubbles: true});
+    const role = useRole(floatingContext, {role: 'menu'});
+    const listNavigation = useListNavigation(floatingContext, {
+        listRef: itemsRef,
+        activeIndex,
+        nested: isNested,
+        onNavigate: setActiveIndex,
+        rtl: isRTL,
+    });
+    const middlewares = [offset({mainAxis: 4, alignmentAxis: isNested ? -4 : 0}), flip(), shift()];
+    const interactions = [hover, click, dismiss, role, listNavigation];
+    const {getReferenceProps, getItemProps} = useInteractions(interactions);
+
+    const anchorRef = useForkRef(
+        setAnchorElement,
+        React.isValidElement(trigger) ? getElementRef(trigger) : undefined,
+    );
+    const anchorProps = React.isValidElement<any>(trigger)
+        ? getReferenceProps(trigger.props)
+        : getReferenceProps();
+    const anchorNode = React.isValidElement<any>(trigger)
+        ? React.cloneElement(trigger, {
+              ref: anchorRef,
+              ...anchorProps,
+          })
+        : typeof trigger === 'function'
+          ? trigger(anchorProps, anchorRef)
+          : null;
+
+    const handleContentRequestClose = React.useCallback(() => {
+        setIsOpen(false);
+    }, [setIsOpen]);
+
+    const getItemPropsInline = React.useCallback(
+        (userProps?: React.HTMLAttributes<HTMLElement>) => {
+            const handleItemPointerEnter = (event: React.PointerEvent<HTMLElement>) => {
+                userProps?.onPointerEnter?.(event);
+
+                const element = event.currentTarget;
+                const index = [
+                    ...(element.closest('[role="menu"]')?.querySelectorAll('[role="menuitem"]') ??
+                        []),
+                ].indexOf(element);
+
+                if (
+                    !(element as HTMLButtonElement).disabled &&
+                    !element.ariaDisabled &&
+                    index >= 0
+                ) {
+                    element.focus();
+                    setActiveIndex(index);
+                } else {
+                    setActiveIndex(null);
+                }
+            };
+
+            const handleItemPointerLeave = (event: React.PointerEvent<HTMLElement>) => {
+                userProps?.onPointerLeave?.(event);
+                setActiveIndex(null);
+            };
+
+            return {
+                // Clear attribute set by Floating UI Composite (we don't use it)
+                'data-active': undefined,
+                ...userProps,
+                onPointerEnter: handleItemPointerEnter,
+                onPointerLeave: handleItemPointerLeave,
+            };
+        },
+        [],
+    );
+
+    const contextValue = React.useMemo(
+        () => ({
+            inline: parentMenu?.inline ?? inline,
+            size: parentMenu?.size ?? size,
+            activeIndex,
+            getItemProps: inline ? getItemPropsInline : getItemProps,
+        }),
+        [parentMenu, inline, size, activeIndex, getItemPropsInline, getItemProps],
+    );
+
+    React.useEffect(() => {
+        if (!anchorNode) {
+            if (trigger) {
+                floatingContext.refs.setPositionReference(trigger as VirtualElement);
+                setIsOpen(true);
+            } else {
+                setIsOpen(false);
+            }
+        }
+    }, [trigger]);
+
+    if (inline) {
+        const preparedChildren = React.Children.toArray(children).map((child, index) => {
+            if (!React.isValidElement(child) || !isComponentType(child, 'Menu.Item')) {
+                return child;
+            }
+
+            return (
+                <CompositeItem
+                    key={index}
+                    render={(props) => React.cloneElement(child, {...child.props, ...props})}
+                />
+            );
+        });
+
+        return (
+            <MenuContext.Provider value={contextValue}>
+                <Composite
+                    render={
+                        <div
+                            role="menu"
+                            className={b(null, className)}
+                            style={style}
+                            data-qa={qa}
+                        />
+                    }
+                    orientation="vertical"
+                    loop={false}
+                    rtl={isRTL}
+                    // @ts-expect-error
+                    activeIndex={activeIndex}
+                    onNavigate={setActiveIndex}
+                >
+                    {preparedChildren}
+                </Composite>
+            </MenuContext.Provider>
+        );
+    }
+
+    return (
+        <React.Fragment>
+            {anchorNode}
+            <Popup
+                open={floatingContext.open}
+                placement={isNested ? `${isRTL ? 'left' : 'right'}-start` : placement}
+                disablePortal={isNested}
+                floatingContext={floatingContext}
+                floatingRef={setFloatingElement}
+                floatingMiddlewares={middlewares}
+                floatingInteractions={interactions}
+            >
+                <MenuContext.Provider value={contextValue}>
+                    <FloatingList elementsRef={itemsRef}>
+                        <MenuPopupContent
+                            open={isOpen}
+                            onRequestClose={handleContentRequestClose}
+                            parentId={parentId}
+                            className={className}
+                            style={style}
+                            qa={qa}
+                        >
+                            {children}
+                        </MenuPopupContent>
+                    </FloatingList>
+                </MenuContext.Provider>
+            </Popup>
+        </React.Fragment>
+    );
+}
+
+Menu.displayName = 'Menu';
+
+Menu.Trigger = MenuTrigger;
+Menu.Item = MenuItem;
+Menu.Divider = MenuDivider;

--- a/src/components/lab/Menu/Menu.tsx
+++ b/src/components/lab/Menu/Menu.tsx
@@ -139,7 +139,7 @@ export function Menu({
         toggle: !isNested,
         ignoreMouse: isNested,
     });
-    const dismiss = useDismiss(floatingContext, {bubbles: true});
+    const dismiss = useDismiss(floatingContext, {enabled: !isNested});
     const role = useRole(floatingContext, {role: 'menu'});
     const listNavigation = useListNavigation(floatingContext, {
         listRef: itemsRef,
@@ -161,8 +161,8 @@ export function Menu({
         : getReferenceProps();
     const anchorNode = React.isValidElement<any>(trigger)
         ? React.cloneElement(trigger, {
-              ref: anchorRef,
               ...anchorProps,
+              ref: anchorRef,
           })
         : typeof trigger === 'function'
           ? trigger(anchorProps, anchorRef)
@@ -277,6 +277,8 @@ export function Menu({
                 open={floatingContext.open}
                 placement={isNested ? `${isRTL ? 'left' : 'right'}-start` : placement}
                 disablePortal={isNested}
+                disableEscapeKeyDown={isNested}
+                disableOutsideClick={isNested}
                 floatingContext={floatingContext}
                 floatingRef={setFloatingElement}
                 floatingMiddlewares={middlewares}

--- a/src/components/lab/Menu/MenuContext.ts
+++ b/src/components/lab/Menu/MenuContext.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import type {MenuSize} from './types';
+
+export interface MenuContextProps {
+    size: MenuSize;
+    activeIndex: number | null;
+    getItemProps: (userProps?: React.HTMLProps<HTMLElement>) => Record<string, unknown>;
+    inline: boolean;
+}
+
+export const MenuContext = React.createContext<MenuContextProps | null>(null);
+
+MenuContext.displayName = 'MenuContext';

--- a/src/components/lab/Menu/MenuDivider.scss
+++ b/src/components/lab/Menu/MenuDivider.scss
@@ -1,6 +1,6 @@
 @use '../../variables';
 
-$b: '.#{variables.$ns}menu2-divider';
+$b: '.#{variables.$ns}lab-menu-divider';
 
 #{$b} {
     padding-block: 4px;

--- a/src/components/lab/Menu/MenuDivider.scss
+++ b/src/components/lab/Menu/MenuDivider.scss
@@ -1,0 +1,14 @@
+@use '../../variables';
+
+$b: '.#{variables.$ns}menu2-divider';
+
+#{$b} {
+    padding-block: 4px;
+
+    &::before {
+        content: '';
+        display: block;
+        height: 1px;
+        background-color: var(--g-color-line-generic);
+    }
+}

--- a/src/components/lab/Menu/MenuDivider.scss
+++ b/src/components/lab/Menu/MenuDivider.scss
@@ -3,12 +3,5 @@
 $b: '.#{variables.$ns}lab-menu-divider';
 
 #{$b} {
-    padding-block: 4px;
-
-    &::before {
-        content: '';
-        display: block;
-        height: 1px;
-        background-color: var(--g-color-line-generic);
-    }
+    margin-block: 4px;
 }

--- a/src/components/lab/Menu/MenuDivider.tsx
+++ b/src/components/lab/Menu/MenuDivider.tsx
@@ -2,7 +2,7 @@ import {block} from '../../utils/cn';
 
 import './MenuDivider.scss';
 
-const b = block('menu2-divider');
+const b = block('lab-menu-divider');
 
 export function MenuDivider() {
     return <div className={b()} />;

--- a/src/components/lab/Menu/MenuDivider.tsx
+++ b/src/components/lab/Menu/MenuDivider.tsx
@@ -1,3 +1,4 @@
+import {Divider} from '../../Divider';
 import {block} from '../../utils/cn';
 
 import './MenuDivider.scss';
@@ -5,7 +6,7 @@ import './MenuDivider.scss';
 const b = block('lab-menu-divider');
 
 export function MenuDivider() {
-    return <div className={b()} />;
+    return <Divider className={b()} />;
 }
 
 MenuDivider.displayName = 'Menu.Divider';

--- a/src/components/lab/Menu/MenuDivider.tsx
+++ b/src/components/lab/Menu/MenuDivider.tsx
@@ -1,0 +1,11 @@
+import {block} from '../../utils/cn';
+
+import './MenuDivider.scss';
+
+const b = block('menu2-divider');
+
+export function MenuDivider() {
+    return <div className={b()} />;
+}
+
+MenuDivider.displayName = 'Menu.Divider';

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -84,7 +84,7 @@ $b: '.#{variables.$ns}lab-menu-item';
         }
 
         &_l {
-            --_--padding-block: 8px;
+            --_--padding-block: 6px;
             --_--padding-inline: 12px;
             --_--icon-size: 16px;
             --_--icon-offset: 6px;

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -4,28 +4,15 @@
 $b: '.#{variables.$ns}menu2-item';
 
 #{$b} {
-    --_--min-height: auto;
     --_--padding-block: 0;
     --_--padding-inline: 0;
-    --_--border-radius: 0;
     --_--icon-size: 0;
     --_--icon-offset: 0;
     --_--submenu-icon-shift: 0;
-    --_--font: var(--g-text-body-1-font);
-    --_--text-color: var(--g-color-text-primary);
-    --_--background-color: transparent;
 
-    @include mixins.button-reset();
-    @include mixins.link-reset();
     display: flex;
     align-items: center;
-    width: 100%;
-    color: var(--_--text-color);
-    background-color: var(--_--background-color);
-    min-height: var(--_--min-height);
     padding: var(--_--padding-block) var(--_--padding-inline);
-    border-radius: var(--_--border-radius);
-    font: var(--_--font);
 
     &::before,
     &__icon {
@@ -59,89 +46,57 @@ $b: '.#{variables.$ns}menu2-item';
 
     &_theme {
         &_info {
-            --_--text-color: var(--g-color-text-info);
+            --g-list-item-view-text-color: var(--g-color-text-info);
         }
 
         &_success {
-            --_--text-color: var(--g-color-text-positive);
+            --g-list-item-view-text-color: var(--g-color-text-positive);
         }
 
         &_warning {
-            --_--text-color: var(--g-color-text-warning);
+            --g-list-item-view-text-color: var(--g-color-text-warning);
         }
 
         &_danger {
-            --_--text-color: var(--g-color-text-danger);
+            --g-list-item-view-text-color: var(--g-color-text-danger);
         }
 
         &_utility {
-            --_--text-color: var(--g-color-text-utility);
+            --g-list-item-view-text-color: var(--g-color-text-utility);
         }
-    }
-
-    &_active {
-        --_--background-color: var(--g-color-base-generic-hover);
-    }
-
-    &_has-focus-inside,
-    &[aria-haspopup][aria-expanded='true']:not(&_active) {
-        --_--background-color: var(--g-color-base-generic);
-    }
-
-    &_selected {
-        --_--background-color: var(--g-color-base-selection);
-    }
-
-    &_selected#{$b}_active {
-        --_--background-color: var(--g-color-base-selection-hover);
-    }
-
-    &_disabled {
-        --_--text-color: var(--g-color-text-hint);
-
-        cursor: default;
     }
 
     &_size {
         &_s {
-            --_--min-height: 24px;
             --_--padding-block: 2px;
             --_--padding-inline: 8px;
-            --_--border-radius: var(--g-border-radius-xs);
             --_--icon-size: 14px;
             --_--icon-offset: 4px;
             --_--submenu-icon-shift: 7px;
         }
 
         &_m {
-            --_--min-height: 28px;
             --_--padding-block: 4px;
             --_--padding-inline: 12px;
-            --_--border-radius: var(--g-border-radius-s);
             --_--icon-size: 16px;
             --_--icon-offset: 6px;
             --_--submenu-icon-shift: 8px;
         }
 
         &_l {
-            --_--min-height: 32px;
             --_--padding-block: 8px;
             --_--padding-inline: 12px;
-            --_--border-radius: var(--g-border-radius-m);
             --_--icon-size: 16px;
             --_--icon-offset: 6px;
             --_--submenu-icon-shift: 8px;
         }
 
         &_xl {
-            --_--min-height: 36px;
             --_--padding-block: 8px;
             --_--padding-inline: 16px;
-            --_--border-radius: var(--g-border-radius-l);
             --_--icon-size: 20px;
             --_--icon-offset: 6px;
             --_--submenu-icon-shift: 10px;
-            --_--font: var(--g-text-body-2-font);
         }
     }
 }

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -1,0 +1,123 @@
+@use '../../variables';
+@use '../../../../styles/mixins';
+
+$b: '.#{variables.$ns}menu2-item';
+
+#{$b} {
+    --_--min-height: auto;
+    --_--padding-block: 0;
+    --_--padding-inline: 0;
+    --_--border-radius: 0;
+    --_--icon-size: 0;
+    --_--icon-offset: 0;
+    --_--submenu-icon-shift: 0;
+    --_--font: var(--g-text-body-1-font);
+    --_--text-color: var(--g-color-text-primary);
+    --_--background-color: transparent;
+
+    @include mixins.button-reset();
+    @include mixins.link-reset();
+    display: flex;
+    align-items: center;
+    width: 100%;
+    color: var(--_--text-color);
+    background-color: var(--_--background-color);
+    min-height: var(--_--min-height);
+    padding: var(--_--padding-block) var(--_--padding-inline);
+    border-radius: var(--_--border-radius);
+    font: var(--_--font);
+
+    &::before,
+    &__icon {
+        position: relative;
+        inset-inline-end: var(--_--icon-offset);
+        min-width: var(--_--icon-size);
+        height: var(--_--icon-size);
+    }
+
+    &::after,
+    &__arrow {
+        position: relative;
+        inset-inline-start: var(--_--submenu-icon-shift);
+        margin-inline-start: auto;
+        min-width: var(--_--icon-size);
+        height: var(--_--icon-size);
+        color: var(--g-color-text-secondary);
+    }
+
+    @at-root #{$b}:not(:has(> #{$b}__icon)):has(~ #{$b} > #{$b}__icon)::before,
+        #{$b}:has(> #{$b}__icon) ~ #{$b}:not(:has(> #{$b}__icon))::before {
+        content: '';
+    }
+
+    @at-root #{$b}:not(:has(> #{$b}__arrow)):has(~ #{$b} > #{$b}__arrow)::after,
+        #{$b}:has(> #{$b}__arrow) ~ #{$b}:not(:has(> #{$b}__arrow))::after {
+        content: '';
+    }
+
+    &_active {
+        --_--background-color: var(--g-color-base-generic-hover);
+    }
+
+    &_has-focus-inside,
+    &[aria-haspopup][aria-expanded='true']:not(&_active) {
+        --_--background-color: var(--g-color-base-generic);
+    }
+
+    &_selected {
+        --_--background-color: var(--g-color-base-selection);
+    }
+
+    &_selected#{$b}_active {
+        --_--background-color: var(--g-color-base-selection-hover);
+    }
+
+    &_disabled {
+        --_--text-color: var(--g-color-text-hint);
+
+        cursor: default;
+    }
+
+    &_size {
+        &_s {
+            --_--min-height: 24px;
+            --_--padding-block: 2px;
+            --_--padding-inline: 8px;
+            --_--border-radius: var(--g-border-radius-xs);
+            --_--icon-size: 14px;
+            --_--icon-offset: 4px;
+            --_--submenu-icon-shift: 7px;
+        }
+
+        &_m {
+            --_--min-height: 28px;
+            --_--padding-block: 4px;
+            --_--padding-inline: 12px;
+            --_--border-radius: var(--g-border-radius-s);
+            --_--icon-size: 16px;
+            --_--icon-offset: 6px;
+            --_--submenu-icon-shift: 8px;
+        }
+
+        &_l {
+            --_--min-height: 36px;
+            --_--padding-block: 8px;
+            --_--padding-inline: 16px;
+            --_--border-radius: var(--g-border-radius-m);
+            --_--icon-size: 16px;
+            --_--icon-offset: 6px;
+            --_--submenu-icon-shift: 8px;
+        }
+
+        &_xl {
+            --_--min-height: 44px;
+            --_--padding-block: 12px;
+            --_--padding-inline: 16px;
+            --_--border-radius: var(--g-border-radius-l);
+            --_--icon-size: 20px;
+            --_--icon-offset: 6px;
+            --_--submenu-icon-shift: 10px;
+            --_--font: var(--g-text-body-2-font);
+        }
+    }
+}

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -55,6 +55,28 @@ $b: '.#{variables.$ns}menu2-item';
         content: '';
     }
 
+    &_theme {
+        &_info {
+            --_--text-color: var(--g-color-text-info);
+        }
+
+        &_success {
+            --_--text-color: var(--g-color-text-positive);
+        }
+
+        &_warning {
+            --_--text-color: var(--g-color-text-warning);
+        }
+
+        &_danger {
+            --_--text-color: var(--g-color-text-danger);
+        }
+
+        &_utility {
+            --_--text-color: var(--g-color-text-utility);
+        }
+    }
+
     &_active {
         --_--background-color: var(--g-color-base-generic-hover);
     }

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -1,7 +1,7 @@
 @use '../../variables';
 @use '../../../../styles/mixins';
 
-$b: '.#{variables.$ns}menu2-item';
+$b: '.#{variables.$ns}lab-menu-item';
 
 #{$b} {
     --_--padding-block: 0;

--- a/src/components/lab/Menu/MenuItem.scss
+++ b/src/components/lab/Menu/MenuItem.scss
@@ -37,6 +37,8 @@ $b: '.#{variables.$ns}menu2-item';
 
     &::after,
     &__arrow {
+        display: flex;
+        align-items: center;
         position: relative;
         inset-inline-start: var(--_--submenu-icon-shift);
         margin-inline-start: auto;
@@ -122,9 +124,9 @@ $b: '.#{variables.$ns}menu2-item';
         }
 
         &_l {
-            --_--min-height: 36px;
+            --_--min-height: 32px;
             --_--padding-block: 8px;
-            --_--padding-inline: 16px;
+            --_--padding-inline: 12px;
             --_--border-radius: var(--g-border-radius-m);
             --_--icon-size: 16px;
             --_--icon-offset: 6px;
@@ -132,8 +134,8 @@ $b: '.#{variables.$ns}menu2-item';
         }
 
         &_xl {
-            --_--min-height: 44px;
-            --_--padding-block: 12px;
+            --_--min-height: 36px;
+            --_--padding-block: 8px;
             --_--padding-inline: 16px;
             --_--border-radius: var(--g-border-radius-l);
             --_--icon-size: 20px;

--- a/src/components/lab/Menu/MenuItem.tsx
+++ b/src/components/lab/Menu/MenuItem.tsx
@@ -1,0 +1,213 @@
+import * as React from 'react';
+
+import {useFloatingTree, useListItem} from '@floating-ui/react';
+import {ChevronLeft, ChevronRight} from '@gravity-ui/icons';
+
+import {useForkRef} from '../../../hooks';
+import {BUTTON_ICON_SIZE_MAP} from '../../Button/constants';
+import {Icon} from '../../Icon';
+import {useDirection} from '../../theme';
+import {block} from '../../utils/cn';
+
+import {MenuContext} from './MenuContext';
+import {MenuItemContext} from './MenuItemContext';
+import type {
+    MenuItemButtonProps,
+    MenuItemComponentElementType,
+    MenuItemComponentProps,
+    MenuItemLinkProps,
+    MenuItemProps,
+    MenuProps,
+} from './types';
+import {isComponentType} from './utils';
+
+import './MenuItem.scss';
+
+function isMenuItemComponentProps<T extends MenuItemComponentElementType>(
+    p: MenuItemProps<T>,
+): p is MenuItemComponentProps<Exclude<T, undefined>> {
+    return p.component !== undefined;
+}
+
+const b = block('menu2-item');
+
+export const MenuItem = React.forwardRef(
+    <T extends MenuItemComponentElementType>(
+        props: MenuItemProps<T>,
+        ref:
+            | React.Ref<HTMLButtonElement>
+            | React.Ref<HTMLAnchorElement>
+            | React.Ref<T extends string ? React.ComponentRef<T> : T>,
+    ) => {
+        const {
+            selected = false,
+            disabled = false,
+            icon,
+            arrow,
+            children,
+            className,
+            qa,
+            ...rest
+        } = props;
+        const [hasFocusInside, setHasFocusInside] = React.useState(false);
+
+        const isRTL = useDirection() === 'rtl';
+
+        const menuContext = React.useContext(MenuContext);
+        const menuItemContext = React.useContext(MenuItemContext);
+
+        if (!menuContext) {
+            throw new Error('<MenuItem> must be used within <Menu>');
+        }
+
+        const item = useListItem();
+        const tree = useFloatingTree();
+        const isActive = item.index === menuContext.activeIndex;
+        const tabIndex = (menuContext.inline && item.index === 0) || isActive ? 0 : -1;
+
+        let content: React.ReactElement<MenuItemProps>;
+        let submenu: React.ReactElement<MenuProps> | null = null;
+        const preparedChildren: React.ReactNode[] = [];
+
+        if (icon) {
+            preparedChildren.push(
+                <div key="icon" className={b('icon')} aria-hidden>
+                    {icon}
+                </div>,
+            );
+        }
+
+        for (const child of React.Children.toArray(children)) {
+            if (!menuContext.inline && isComponentType(child, 'Menu')) {
+                submenu = child;
+            } else {
+                preparedChildren.push(child);
+            }
+        }
+
+        if (arrow || submenu) {
+            preparedChildren.push(
+                <div key="arrow" className={b('arrow')} aria-hidden>
+                    {arrow ? (
+                        arrow
+                    ) : (
+                        <Icon
+                            data={isRTL ? ChevronLeft : ChevronRight}
+                            size={BUTTON_ICON_SIZE_MAP[menuContext.size]}
+                        />
+                    )}
+                </div>,
+            );
+        }
+
+        const handleRef = useForkRef(ref as any, item.ref);
+
+        const handleClick = (event: React.MouseEvent) => {
+            props.onClick?.(event);
+
+            if (!submenu) {
+                tree?.events.emit('click');
+            }
+        };
+        const handleFocus = (event: React.FocusEvent) => {
+            props.onFocus?.(event);
+            setHasFocusInside(false);
+            menuItemContext?.setHasFocusInside(true);
+        };
+
+        const commonProps = {
+            role: 'menuitem',
+            tabIndex,
+            className: b(
+                {
+                    size: menuContext.size,
+                    active: isActive,
+                    selected,
+                    disabled,
+                    'has-focus-inside': hasFocusInside,
+                },
+                className,
+            ),
+            'data-qa': qa,
+            ...menuContext.getItemProps({
+                ...rest,
+                onClick: handleClick,
+                onFocus: handleFocus,
+            }),
+        };
+
+        if (isMenuItemComponentProps(props)) {
+            content = React.createElement(
+                props.component,
+                {
+                    ...rest,
+                    ...commonProps,
+                    ref: handleRef,
+                    'aria-disabled': disabled ?? undefined,
+                },
+                preparedChildren,
+            );
+        } else if (typeof props.href !== 'undefined') {
+            content = (
+                <a
+                    {...(rest as Pick<typeof props, keyof typeof rest>)}
+                    {...commonProps}
+                    ref={handleRef as React.Ref<HTMLAnchorElement>}
+                    rel={props.target === '_blank' && !rest.rel ? 'noopener noreferrer' : rest.rel}
+                    aria-disabled={disabled ?? undefined}
+                >
+                    {preparedChildren}
+                </a>
+            );
+        } else {
+            content = (
+                <button
+                    {...(rest as Pick<typeof props, keyof typeof rest>)}
+                    {...commonProps}
+                    ref={handleRef as React.Ref<HTMLButtonElement>}
+                    type="button"
+                    disabled={disabled}
+                    aria-pressed={selected}
+                >
+                    {preparedChildren}
+                </button>
+            );
+        }
+
+        const contextValue = React.useMemo(
+            () => ({
+                setHasFocusInside,
+            }),
+            [],
+        );
+
+        if (submenu) {
+            return (
+                <MenuItemContext.Provider value={contextValue}>
+                    {React.cloneElement<MenuProps>(submenu, {
+                        trigger: content,
+                        onOpenChange: (open, event, reason) => {
+                            submenu.props.onOpenChange?.(open, event, reason);
+
+                            if (!open) {
+                                setHasFocusInside(false);
+                            }
+                        },
+                    })}
+                </MenuItemContext.Provider>
+            );
+        }
+
+        return content;
+    },
+) as (<T extends MenuItemComponentElementType, P extends MenuItemProps<T>>(
+    props: P extends {component: Exclude<T, undefined>}
+        ? MenuItemComponentProps<Exclude<T, undefined>> & {
+              ref?: React.Ref<T extends string ? React.ComponentRef<T> : T>;
+          }
+        : P extends {href: string}
+          ? MenuItemLinkProps & {ref?: React.Ref<HTMLAnchorElement>}
+          : MenuItemButtonProps & {ref?: React.Ref<HTMLButtonElement>},
+) => React.ReactElement) & {displayName?: string};
+
+MenuItem.displayName = 'Menu.Item';

--- a/src/components/lab/Menu/MenuItem.tsx
+++ b/src/components/lab/Menu/MenuItem.tsx
@@ -40,6 +40,7 @@ export const MenuItem = React.forwardRef(
             | React.Ref<T extends string ? React.ComponentRef<T> : T>,
     ) => {
         const {
+            theme,
             selected = false,
             disabled = false,
             icon,
@@ -120,6 +121,7 @@ export const MenuItem = React.forwardRef(
             tabIndex,
             className: b(
                 {
+                    theme,
                     size: menuContext.size,
                     active: isActive,
                     selected,

--- a/src/components/lab/Menu/MenuItem.tsx
+++ b/src/components/lab/Menu/MenuItem.tsx
@@ -38,7 +38,7 @@ function isMenuItemLinkProps<T extends MenuItemComponentElementType>(
     return p.href !== undefined;
 }
 
-const b = block('menu2-item');
+const b = block('lab-menu-item');
 
 export const MenuItem = React.forwardRef(
     <T extends MenuItemComponentElementType>(

--- a/src/components/lab/Menu/MenuItemContext.ts
+++ b/src/components/lab/Menu/MenuItemContext.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface MenuItemContextProps {
+    setHasFocusInside: (hasFocusInside: boolean) => void;
+}
+
+export const MenuItemContext = React.createContext<MenuItemContextProps | null>(null);
+
+MenuItemContext.displayName = 'MenuItemContext';

--- a/src/components/lab/Menu/MenuTrigger.tsx
+++ b/src/components/lab/Menu/MenuTrigger.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import {Ellipsis, EllipsisVertical} from '@gravity-ui/icons';
+
+import {Button} from '../../Button';
+import type {ButtonButtonProps} from '../../Button';
+import {BUTTON_ICON_SIZE_MAP} from '../../Button/constants';
+import {Icon} from '../../Icon';
+
+export interface MenuTriggerProps extends ButtonButtonProps {
+    icon?: 'horizontal' | 'vertical';
+}
+
+export const MenuTrigger = React.forwardRef<HTMLButtonElement, MenuTriggerProps>(
+    ({size = 'm', children, icon = 'horizontal', ...restProps}, ref) => {
+        return (
+            <Button ref={ref} size={size} {...restProps}>
+                {children ? (
+                    children
+                ) : (
+                    <Icon
+                        data={icon === 'vertical' ? EllipsisVertical : Ellipsis}
+                        size={BUTTON_ICON_SIZE_MAP[size]}
+                    />
+                )}
+            </Button>
+        );
+    },
+);
+
+MenuTrigger.displayName = 'Menu.Trigger';

--- a/src/components/lab/Menu/README.md
+++ b/src/components/lab/Menu/README.md
@@ -1,0 +1,132 @@
+# unstable_Menu
+
+> The `unstable_Menu` component is future replacement of current components `Menu` and `DropdownMenu`. The component is unstable,
+> so it means breaking changes can occur during minor or patch releases. Be aware of that.
+
+The `unstable_Menu` component displays list of choices in the `Popup` when interacting with its trigger, typically a button.
+
+There are a collection of related components:
+
+- `unstable_Menu` - the container of the menu
+- `unstable_MenuItem` - an option to select from the menu
+- `unstable_MenuDivider` - a divider for grouping options
+- `unstable_MenuTrigger` - a built-in default trigger, `Button` with ellipsis icon
+
+## Basic usage
+
+```jsx
+import {
+  unstable_Menu as Menu,
+  unstable_MenuItem as MenuItem,
+  unstable_MenuDvivider as MenuDivider,
+  unstable_MenuTrigger as MenuTrigger,
+} from '@gravity-ui/uikit/unstable';
+
+function BasicMenu() {
+  return (
+    <Menu trigger={<MenuTrigger />}>
+      <MenuItem>Copy</MenuItem>
+      <MenuItem>Move</MenuItem>
+      <MenuDivider />
+      <MenuItem theme="danger">Delete</MenuItem>
+    </Menu>
+  );
+}
+```
+
+## Custom trigger
+
+You can render any kind of component as a trigger if it accepts basic HTMLAttributes as props and a ref for HTMLElement.
+For more complex components you can use a function variant of `trigger` prop that have `triggerProps` as the first argument
+and `triggerRef` as the second argument which you should pass to your component.
+
+## Context menu
+
+To implement context menu pattern you should use "virtual element" as a trigger:
+
+```jsx
+import {
+  unstable_Menu as Menu,
+  unstable_MenuItem as MenuItem,
+  unstable_MenuDvivider as MenuDivider,
+  unstable_MenuTrigger as MenuTrigger,
+} from '@gravity-ui/uikit/unstable';
+
+function ContextMenu() {
+  const [trigger, setTrigger] = React.useState(null);
+
+  React.useEffect(() => {
+    const handleContextMenu = (event) => {
+      event.preventDefault();
+      setTrigger({
+        getBoundingClientRect() {
+          return {
+            width: 0,
+            height: 0,
+            x: event.clientX,
+            y: event.clientY,
+            top: event.clientY,
+            right: event.clientX,
+            bottom: event.clientY,
+            left: event.clientX,
+          };
+        },
+      });
+    };
+    document.addEventListener('contextmenu', handleContextMenu);
+    return () => document.removeEventListener('contextmenu', handleContextMenu);
+  }, []);
+
+  return (
+    <Menu trigger={trigger}>
+      <MenuItem>Copy</MenuItem>
+      <MenuItem>Move</MenuItem>
+      <MenuDivider />
+      <MenuItem theme="danger">Delete</MenuItem>
+    </Menu>
+  );
+}
+```
+
+## Inline mode
+
+By default `unstable_Menu` is rendered inside the `Popup`. But you can render it inline using `inline` prop in your own container.
+
+## Properties
+
+| Name         | Description                                     |                                  Type                                   | Default |
+| :----------- | :---------------------------------------------- | :---------------------------------------------------------------------: | :-----: |
+| className    | HTML `class` attribute                          |                          `React.CSSProperties`                          |         |
+| style        | HTML `style` attribute                          |                                `string`                                 |         |
+| qa           | Test ID (`data-qa` attribute)                   |                                `string`                                 |         |
+| open         | Controlled state for `open`                     |                                `boolean`                                |         |
+| defaultOpen  | Uncontrolled state for `open`                   |                                `boolean`                                |         |
+| children     | Menu related components (items, dividers, etc.) |                            `React.ReactNode`                            |         |
+| disabled     | Disabled state                                  |                                `boolean`                                | `false` |
+| inline       | Renders the menu inline                         |                                `boolean`                                | `false` |
+| trigger      | Trigger element which opens the menu            | `React.ReactElement` `(triggerProps, triggerRef) => React.ReactElement` |         |
+| onOpenChange | Callback for `open` state change                |    `(open: boolean, event: Event, reason: OpenChangeReason) => void`    |         |
+| size         | The `unstable_Menu` size                        |                        `"s"` `"m"` `"l"` `"xl"`                         |  `"m"`  |
+
+### unstable_MenuItem
+
+`unstable_MenuItem` accepts any valid `button` or `a` element props in addition to these:
+
+| Name      | Description                         |                                Type                                |  Default   |
+| :-------- | :---------------------------------- | :----------------------------------------------------------------: | :--------: |
+| qa        | Test ID (`data-qa` attribute)       |                              `string`                              |            |
+| theme     | The `unstable_MenuItem` theme       | `"normal"` `"info"` `"success"` `"warning"` `"danger"` `"utility"` | `"normal"` |
+| selected  | Selected state                      |                             `boolean`                              |  `false`   |
+| disabled  | Disabled state                      |                             `boolean`                              |  `false`   |
+| icon      | Render slot for an icon             |                         `React.ReactNode`                          |            |
+| arrow     | Render slot for a nested menu arrow |                         `React.ReactNode`                          |            |
+| children  | Content                             |                         `React.ReactNode`                          |            |
+| component | Custom root component               |                        `React.ElementType`                         |            |
+
+### unstable_MenuTrigger
+
+`unstable_MenuTrigger` accepts any `Button` component props in addition to these:
+
+| Name | Description             |            Type             |    Default     |
+| :--- | :---------------------- | :-------------------------: | :------------: |
+| icon | Type of icon to display | `"horizontal"` `"vertical"` | `"horizontal"` |

--- a/src/components/lab/Menu/__stories__/Menu.stories.tsx
+++ b/src/components/lab/Menu/__stories__/Menu.stories.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import type {VirtualElement} from '@floating-ui/react';
+import {LayoutColumns3, LayoutRows3} from '@gravity-ui/icons';
+import type {Meta, StoryObj} from '@storybook/react';
+
+import {BUTTON_ICON_SIZE_MAP} from '../../../Button/constants';
+import {Icon} from '../../../Icon';
+import {Label} from '../../../Label';
+import {Sheet} from '../../../Sheet';
+import {Menu} from '../Menu';
+import {MenuItem} from '../MenuItem';
+import {MenuTrigger} from '../MenuTrigger';
+
+import {getMenuItems} from './utils';
+
+const meta: Meta<typeof Menu> = {
+    title: 'Lab/Menu',
+    component: Menu,
+    parameters: {
+        layout: 'centered',
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Menu>;
+
+export const Default = {
+    render: (args) => {
+        return (
+            <Menu {...args} trigger={<MenuTrigger aria-label="Actions" />}>
+                {getMenuItems(args)}
+            </Menu>
+        );
+    },
+} satisfies Story;
+
+export const Context = {
+    render: (args) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [anchor, setAnchor] = React.useState<VirtualElement | null>(null);
+
+        const handleContextMenu = (event: React.MouseEvent) => {
+            event.preventDefault();
+            setAnchor({
+                getBoundingClientRect() {
+                    return {
+                        width: 0,
+                        height: 0,
+                        x: event.clientX,
+                        y: event.clientY,
+                        top: event.clientY,
+                        right: event.clientX,
+                        bottom: event.clientY,
+                        left: event.clientX,
+                    };
+                },
+            });
+        };
+
+        return (
+            <React.Fragment>
+                <div
+                    onContextMenu={handleContextMenu}
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: 300,
+                        height: 300,
+                        border: '2px dashed var(--g-color-line-focus)',
+                        borderRadius: 12,
+                    }}
+                >
+                    Right click in the area to open the menu
+                </div>
+                <Menu {...args} trigger={anchor}>
+                    {getMenuItems(args)}
+                </Menu>
+            </React.Fragment>
+        );
+    },
+} satisfies Story;
+
+export const InsideSheet = {
+    render: (args) => {
+        return (
+            <Sheet visible>
+                <Menu {...args}>{getMenuItems(args, true)}</Menu>
+            </Sheet>
+        );
+    },
+    args: {
+        inline: true,
+    },
+} satisfies Story;
+
+export const Selection = {
+    render: (args) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [value, setValue] = React.useState('row');
+        const items = [
+            {
+                value: 'row',
+                title: 'Row',
+                icon: <Icon data={LayoutRows3} size={BUTTON_ICON_SIZE_MAP[args.size ?? 'm']} />,
+            },
+            {
+                value: 'column',
+                title: 'Column',
+                icon: <Icon data={LayoutColumns3} size={BUTTON_ICON_SIZE_MAP[args.size ?? 'm']} />,
+            },
+        ];
+
+        return (
+            <Menu
+                {...args}
+                trigger={
+                    <Label value={items.find((item) => item.value === value)?.title}>
+                        Direction
+                    </Label>
+                }
+            >
+                {items.map((item) => (
+                    <MenuItem
+                        key={item.value}
+                        icon={item.icon}
+                        selected={item.value === value}
+                        onClick={() => setValue(item.value)}
+                    >
+                        {item.title}
+                    </MenuItem>
+                ))}
+            </Menu>
+        );
+    },
+} satisfies Story;

--- a/src/components/lab/Menu/__stories__/Menu.stories.tsx
+++ b/src/components/lab/Menu/__stories__/Menu.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import type {VirtualElement} from '@floating-ui/react';
-import {LayoutColumns3, LayoutRows3} from '@gravity-ui/icons';
+import {Envelope, LayoutColumns3, LayoutRows3, LogoTelegram, Smartphone} from '@gravity-ui/icons';
+import {action} from '@storybook/addon-actions';
 import type {Meta, StoryObj} from '@storybook/react';
 
 import {BUTTON_ICON_SIZE_MAP} from '../../../Button/constants';
@@ -12,7 +13,7 @@ import {Menu} from '../Menu';
 import {MenuItem} from '../MenuItem';
 import {MenuTrigger} from '../MenuTrigger';
 
-import {getMenuItems} from './utils';
+import {getFullFeaturedMenuItems, getSimpleMenuItems} from './utils';
 
 const meta: Meta<typeof Menu> = {
     title: 'Lab/Menu',
@@ -28,15 +29,39 @@ type Story = StoryObj<typeof Menu>;
 
 export const Default = {
     render: (args) => {
+        return <Menu {...args}>{getSimpleMenuItems(args)}</Menu>;
+    },
+    args: {
+        trigger: <MenuTrigger aria-label="Actions" />,
+        onOpenChange: action('onOpenChange'),
+    },
+} satisfies Story;
+
+export const IconStory = {
+    ...Default,
+    name: 'Icon',
+    render: (args) => {
         return (
             <Menu {...args} trigger={<MenuTrigger aria-label="Actions" />}>
-                {getMenuItems(args)}
+                {getSimpleMenuItems(args, true)}
+            </Menu>
+        );
+    },
+} satisfies Story;
+
+export const FullFeatured = {
+    ...Default,
+    render: (args) => {
+        return (
+            <Menu {...args} trigger={<MenuTrigger aria-label="Actions" />}>
+                {getFullFeaturedMenuItems(args)}
             </Menu>
         );
     },
 } satisfies Story;
 
 export const Context = {
+    ...Default,
     render: (args) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const [anchor, setAnchor] = React.useState<VirtualElement | null>(null);
@@ -76,7 +101,7 @@ export const Context = {
                     Right click in the area to open the menu
                 </div>
                 <Menu {...args} trigger={anchor}>
-                    {getMenuItems(args)}
+                    {getFullFeaturedMenuItems(args)}
                 </Menu>
             </React.Fragment>
         );
@@ -84,10 +109,11 @@ export const Context = {
 } satisfies Story;
 
 export const InsideSheet = {
+    ...Default,
     render: (args) => {
         return (
             <Sheet visible>
-                <Menu {...args}>{getMenuItems(args, true)}</Menu>
+                <Menu {...args}>{getFullFeaturedMenuItems(args, true)}</Menu>
             </Sheet>
         );
     },
@@ -97,6 +123,7 @@ export const InsideSheet = {
 } satisfies Story;
 
 export const Selection = {
+    ...Default,
     render: (args) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const [value, setValue] = React.useState('row');
@@ -132,6 +159,37 @@ export const Selection = {
                         {item.title}
                     </MenuItem>
                 ))}
+            </Menu>
+        );
+    },
+} satisfies Story;
+
+export const Links = {
+    ...Default,
+    render: (args) => {
+        return (
+            <Menu {...args}>
+                <Menu.Item
+                    href="#mail"
+                    icon={<Icon data={Envelope} size={BUTTON_ICON_SIZE_MAP[args.size ?? 'm']} />}
+                >
+                    Mail
+                </Menu.Item>
+                <Menu.Item
+                    href="#sms"
+                    icon={<Icon data={Smartphone} size={BUTTON_ICON_SIZE_MAP[args.size ?? 'm']} />}
+                    disabled
+                >
+                    SMS
+                </Menu.Item>
+                <Menu.Item
+                    href="#telegram"
+                    icon={
+                        <Icon data={LogoTelegram} size={BUTTON_ICON_SIZE_MAP[args.size ?? 'm']} />
+                    }
+                >
+                    Telegram
+                </Menu.Item>
             </Menu>
         );
     },

--- a/src/components/lab/Menu/__stories__/Menu.stories.tsx
+++ b/src/components/lab/Menu/__stories__/Menu.stories.tsx
@@ -20,6 +20,17 @@ const meta: Meta<typeof Menu> = {
     component: Menu,
     parameters: {
         layout: 'centered',
+        a11y: {
+            element: '#storybook-root',
+            config: {
+                rules: [
+                    {
+                        id: 'color-contrast',
+                        enabled: false,
+                    },
+                ],
+            },
+        },
     },
 };
 

--- a/src/components/lab/Menu/__stories__/utils.tsx
+++ b/src/components/lab/Menu/__stories__/utils.tsx
@@ -31,7 +31,11 @@ export function getSimpleMenuItems(args: MenuProps, icon?: boolean) {
         <MenuItem key="move" icon={icon ? <Icon data={ArrowsExpand} size={iconSize} /> : undefined}>
             Move
         </MenuItem>,
-        <MenuItem key="delete" icon={icon ? <Icon data={TrashBin} size={iconSize} /> : undefined}>
+        <MenuItem
+            key="delete"
+            icon={icon ? <Icon data={TrashBin} size={iconSize} /> : undefined}
+            theme="danger"
+        >
             Delete
         </MenuItem>,
     ];
@@ -64,11 +68,7 @@ export function getFullFeaturedMenuItems(args: MenuProps, inline?: boolean) {
             Cut
         </Menu.Item>,
         <Menu.Divider key="divider1" />,
-        <Menu.Item
-            key="delete"
-            icon={<Icon data={TrashBin} size={iconSize} />}
-            style={{color: 'var(--g-color-text-danger)'}}
-        >
+        <Menu.Item key="delete" icon={<Icon data={TrashBin} size={iconSize} />} theme="danger">
             Delete
         </Menu.Item>,
     ];

--- a/src/components/lab/Menu/__stories__/utils.tsx
+++ b/src/components/lab/Menu/__stories__/utils.tsx
@@ -2,6 +2,8 @@ import {
     ArrowRotateLeft,
     ArrowRotateRight,
     ArrowShapeTurnUpRight,
+    ArrowsExpand,
+    Copy,
     Envelope,
     LogoTelegram,
     MusicNote,
@@ -16,9 +18,26 @@ import {BUTTON_ICON_SIZE_MAP} from '../../../Button/constants';
 import {Hotkey} from '../../../Hotkey';
 import {Icon} from '../../../Icon';
 import {Menu} from '../Menu';
+import {MenuItem} from '../MenuItem';
 import type {MenuProps} from '../types';
 
-export function getMenuItems(args: MenuProps, inline?: boolean) {
+export function getSimpleMenuItems(args: MenuProps, icon?: boolean) {
+    const iconSize = BUTTON_ICON_SIZE_MAP[args.size ?? 'm'];
+
+    return [
+        <MenuItem key="copy" icon={icon ? <Icon data={Copy} size={iconSize} /> : undefined}>
+            Copy
+        </MenuItem>,
+        <MenuItem key="move" icon={icon ? <Icon data={ArrowsExpand} size={iconSize} /> : undefined}>
+            Move
+        </MenuItem>,
+        <MenuItem key="delete" icon={icon ? <Icon data={TrashBin} size={iconSize} /> : undefined}>
+            Delete
+        </MenuItem>,
+    ];
+}
+
+export function getFullFeaturedMenuItems(args: MenuProps, inline?: boolean) {
     const iconSize = BUTTON_ICON_SIZE_MAP[args.size ?? 'm'];
 
     const items = [

--- a/src/components/lab/Menu/__stories__/utils.tsx
+++ b/src/components/lab/Menu/__stories__/utils.tsx
@@ -1,0 +1,90 @@
+import {
+    ArrowRotateLeft,
+    ArrowRotateRight,
+    ArrowShapeTurnUpRight,
+    Envelope,
+    LogoTelegram,
+    MusicNote,
+    Picture,
+    Scissors,
+    Text,
+    TrashBin,
+    Video,
+} from '@gravity-ui/icons';
+
+import {BUTTON_ICON_SIZE_MAP} from '../../../Button/constants';
+import {Hotkey} from '../../../Hotkey';
+import {Icon} from '../../../Icon';
+import {Menu} from '../Menu';
+import type {MenuProps} from '../types';
+
+export function getMenuItems(args: MenuProps, inline?: boolean) {
+    const iconSize = BUTTON_ICON_SIZE_MAP[args.size ?? 'm'];
+
+    const items = [
+        <Menu.Item
+            key="undo"
+            icon={<Icon data={ArrowRotateLeft} size={iconSize} />}
+            arrow={<Hotkey value="mod z" />}
+        >
+            Undo
+        </Menu.Item>,
+        <Menu.Item
+            key="redo"
+            icon={<Icon data={ArrowRotateRight} size={iconSize} />}
+            arrow={<Hotkey value="mod y" />}
+            disabled
+        >
+            Redo
+        </Menu.Item>,
+        <Menu.Item
+            key="cut"
+            icon={<Icon data={Scissors} size={iconSize} />}
+            arrow={<Hotkey value="mod x" />}
+        >
+            Cut
+        </Menu.Item>,
+        <Menu.Divider key="divider1" />,
+        <Menu.Item
+            key="delete"
+            icon={<Icon data={TrashBin} size={iconSize} />}
+            style={{color: 'var(--g-color-text-danger)'}}
+        >
+            Delete
+        </Menu.Item>,
+    ];
+
+    if (!inline) {
+        items.push(
+            <Menu.Divider key="divider2" />,
+            <Menu.Item key="copy">
+                Copy as
+                <Menu>
+                    <Menu.Item icon={<Icon data={Text} size={iconSize} />}>Text</Menu.Item>
+                    <Menu.Item icon={<Icon data={Video} size={iconSize} />}>Video</Menu.Item>
+                    <Menu.Item icon={<Icon data={Picture} size={iconSize} />}>
+                        Image
+                        <Menu>
+                            <Menu.Item>.png</Menu.Item>
+                            <Menu.Item>.jpg</Menu.Item>
+                            <Menu.Item>.svg</Menu.Item>
+                            <Menu.Item>.gif</Menu.Item>
+                        </Menu>
+                    </Menu.Item>
+                    <Menu.Item icon={<Icon data={MusicNote} size={iconSize} />}>Audio</Menu.Item>
+                </Menu>
+            </Menu.Item>,
+            <Menu.Item key="share" icon={<Icon data={ArrowShapeTurnUpRight} size={iconSize} />}>
+                Share
+                <Menu>
+                    <Menu.Item icon={<Icon data={Envelope} size={iconSize} />}>Mail</Menu.Item>
+                    <Menu.Item icon={<Icon data={LogoTelegram} size={iconSize} />}>
+                        Telegram
+                    </Menu.Item>
+                </Menu>
+            </Menu.Item>,
+        );
+    }
+
+    return items;
+}

--- a/src/components/lab/Menu/__tests__/Menu.test.tsx
+++ b/src/components/lab/Menu/__tests__/Menu.test.tsx
@@ -1,0 +1,189 @@
+import userEvent from '@testing-library/user-event';
+
+import {act, getAllByRole, render, screen, waitFor} from '../../../../../test-utils/utils';
+import {Menu} from '../Menu';
+
+const TRIGGER_QA = 'trigger';
+const MENU_QA = 'menu';
+const SUBMENU_QA = 'submenu';
+
+function renderSimpleMenu() {
+    return render(
+        <Menu trigger={<Menu.Trigger qa={TRIGGER_QA} />} qa={MENU_QA}>
+            <Menu.Item>Item 1</Menu.Item>
+            <Menu.Item>Item 2</Menu.Item>
+            <Menu.Item>Item 3</Menu.Item>
+        </Menu>,
+    );
+}
+
+function renderComplexMenu() {
+    return render(
+        <Menu trigger={<Menu.Trigger qa={TRIGGER_QA} />} qa={MENU_QA}>
+            <Menu.Item>Item 1</Menu.Item>
+            <Menu.Item>Item 2</Menu.Item>
+            <Menu.Item>
+                Item 3
+                <Menu qa={SUBMENU_QA}>
+                    <Menu.Item>Item 4</Menu.Item>
+                    <Menu.Item>Item 4</Menu.Item>
+                </Menu>
+            </Menu.Item>
+        </Menu>,
+    );
+}
+
+describe('Menu', () => {
+    test('should render default trigger', () => {
+        renderSimpleMenu();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(trigger).toBeVisible();
+    });
+
+    test('should open menu by click', async () => {
+        renderSimpleMenu();
+        const user = userEvent.setup();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+        await user.click(trigger);
+        await waitFor(() => {
+            expect(screen.getByTestId(MENU_QA)).toBeVisible();
+        });
+    });
+
+    test.each(['{Space}', '{Enter}', '{ArrowDown}', '{ArrowUp}'])(
+        'should open menu by keyboard %s',
+        async (key) => {
+            renderSimpleMenu();
+            const user = userEvent.setup();
+            const trigger = screen.getByTestId(TRIGGER_QA);
+
+            expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+            trigger.focus();
+            await user.keyboard(key === '{Space}' ? ' ' : key);
+            await waitFor(() => {
+                expect(screen.getByTestId(MENU_QA)).toBeVisible();
+            });
+
+            const items = screen.getAllByRole('menuitem');
+
+            if (key === '{ArrowUp}') {
+                expect(items[items.length - 1]).toHaveClass(/active/);
+            } else {
+                expect(items[0]).toHaveClass(/active/);
+            }
+        },
+    );
+
+    test('should close menu by selecting an item', async () => {
+        renderSimpleMenu();
+        const user = userEvent.setup();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+        await user.click(trigger);
+        await waitFor(() => {
+            expect(screen.getByTestId(MENU_QA)).toBeVisible();
+        });
+
+        const items = screen.getAllByRole('menuitem');
+
+        await user.click(items[1]);
+        await waitFor(() => {
+            expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+        });
+    });
+
+    test('should have correct keyboard navigation', async () => {
+        renderSimpleMenu();
+        const user = userEvent.setup();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+        trigger.focus();
+        await user.keyboard(' ');
+        await waitFor(() => {
+            expect(screen.getByTestId(MENU_QA)).toBeVisible();
+        });
+
+        const items = screen.getAllByRole('menuitem');
+
+        expect(items[0]).toHaveClass(/active/);
+        await user.keyboard('{ArrowDown}');
+        expect(items[1]).toHaveClass(/active/);
+        await user.keyboard('{ArrowDown}');
+        expect(items[2]).toHaveClass(/active/);
+        await user.keyboard('{ArrowDown}');
+        expect(items[2]).toHaveClass(/active/);
+        await user.keyboard('{ArrowUp}');
+        expect(items[1]).toHaveClass(/active/);
+        await user.keyboard('{ArrowUp}');
+        expect(items[0]).toHaveClass(/active/);
+        await user.keyboard('{ArrowUp}');
+        expect(items[0]).toHaveClass(/active/);
+    });
+
+    test('should open submenu by hover', async () => {
+        renderComplexMenu();
+        const user = userEvent.setup();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+        await user.click(trigger);
+        await waitFor(() => {
+            expect(screen.getByTestId(MENU_QA)).toBeVisible();
+        });
+
+        const items = screen.getAllByRole('menuitem');
+
+        expect(screen.queryByTestId(SUBMENU_QA)).not.toBeInTheDocument();
+
+        await user.hover(items[2]);
+        await waitFor(() => {
+            expect(screen.getByTestId(SUBMENU_QA)).toBeVisible();
+        });
+    });
+
+    test('should open/close submenu by keyboard', async () => {
+        renderComplexMenu();
+        const user = userEvent.setup();
+        const trigger = screen.getByTestId(TRIGGER_QA);
+
+        expect(screen.queryByTestId(MENU_QA)).not.toBeInTheDocument();
+
+        await user.click(trigger);
+        await waitFor(() => {
+            expect(screen.getByTestId(MENU_QA)).toBeVisible();
+        });
+
+        const items = screen.getAllByRole('menuitem', {});
+
+        expect(screen.queryByTestId(SUBMENU_QA)).not.toBeInTheDocument();
+
+        act(() => {
+            items[2].focus();
+        });
+        await user.keyboard('{ArrowRight}');
+        await waitFor(() => {
+            expect(screen.getByTestId(SUBMENU_QA)).toBeVisible();
+        });
+
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const subitems = getAllByRole(screen.getByTestId(SUBMENU_QA), 'menuitem');
+        expect(items[2]).toHaveClass(/hovered/);
+        expect(subitems[0]).toHaveClass(/active/);
+
+        await user.keyboard('{ArrowLeft}');
+        await waitFor(() => {
+            expect(screen.queryByTestId(SUBMENU_QA)).not.toBeInTheDocument();
+        });
+        expect(items[2]).toHaveClass(/active/);
+    });
+});

--- a/src/components/lab/Menu/index.ts
+++ b/src/components/lab/Menu/index.ts
@@ -1,0 +1,5 @@
+export * from './Menu';
+export * from './MenuTrigger';
+export * from './MenuItem';
+export * from './MenuDivider';
+export * from './types';

--- a/src/components/lab/Menu/types.ts
+++ b/src/components/lab/Menu/types.ts
@@ -7,6 +7,8 @@ import type {DOMProps, QAProps} from '../../types';
 
 export type MenuSize = 's' | 'm' | 'l' | 'xl';
 
+export type MenuItemTheme = 'normal' | 'info' | 'success' | 'warning' | 'danger' | 'utility';
+
 export interface MenuProps
     extends Pick<PopupProps, 'open' | 'onOpenChange' | 'placement'>,
         DOMProps,
@@ -24,6 +26,7 @@ export interface MenuProps
 }
 
 interface MenuItemCommonProps extends QAProps {
+    theme?: MenuItemTheme;
     selected?: boolean;
     disabled?: boolean;
     icon?: React.ReactElement;

--- a/src/components/lab/Menu/types.ts
+++ b/src/components/lab/Menu/types.ts
@@ -1,0 +1,59 @@
+import type * as React from 'react';
+
+import type {VirtualElement} from '@floating-ui/react';
+
+import type {PopupProps} from '../../Popup';
+import type {DOMProps, QAProps} from '../../types';
+
+export type MenuSize = 's' | 'm' | 'l' | 'xl';
+
+export interface MenuProps
+    extends Pick<PopupProps, 'open' | 'onOpenChange' | 'placement'>,
+        DOMProps,
+        QAProps {
+    size?: MenuSize;
+    defaultOpen?: boolean;
+    disabled?: boolean;
+    trigger?:
+        | ((props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => React.ReactElement)
+        | React.ReactElement
+        | VirtualElement
+        | null;
+    inline?: boolean;
+    children?: React.ReactNode;
+}
+
+interface MenuItemCommonProps extends QAProps {
+    selected?: boolean;
+    disabled?: boolean;
+    icon?: React.ReactElement;
+    arrow?: React.ReactElement;
+    children?: React.ReactNode;
+}
+
+export interface MenuItemButtonProps
+    extends MenuItemCommonProps,
+        Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'> {
+    component?: never;
+    href?: never;
+}
+
+export interface MenuItemLinkProps
+    extends MenuItemCommonProps,
+        React.AnchorHTMLAttributes<HTMLAnchorElement> {
+    component?: never;
+    href: string;
+}
+
+export type MenuItemComponentProps<T extends Exclude<MenuItemComponentElementType, undefined>> =
+    MenuItemCommonProps &
+        React.ComponentPropsWithoutRef<T> & {
+            component: T;
+        };
+
+export type MenuItemComponentElementType = Exclude<React.ElementType, 'a' | 'button'> | undefined;
+
+export type MenuItemProps<T extends MenuItemComponentElementType = undefined> =
+    | MenuItemLinkProps
+    | MenuItemButtonProps
+    | MenuItemComponentProps<Exclude<T, undefined>>;

--- a/src/components/lab/Menu/utils.ts
+++ b/src/components/lab/Menu/utils.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export function isComponentType(component: unknown, type: string): component is React.ReactElement {
+    if (!React.isValidElement(component)) {
+        return false;
+    }
+
+    if (typeof component.type === 'string') {
+        return false;
+    }
+
+    return (component.type as React.ComponentType).displayName === type;
+}

--- a/src/components/utils/mergeProps.ts
+++ b/src/components/utils/mergeProps.ts
@@ -1,0 +1,33 @@
+import type * as React from 'react';
+
+export function mergeProps(...propsList: (React.HTMLProps<HTMLElement> & {})[]) {
+    const eventMap = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    return propsList.reduce((acc: Record<string, unknown>, props) => {
+        Object.entries(props).forEach(([key, value]) => {
+            if (
+                key.startsWith('on') &&
+                key.charCodeAt(2) >= /* A */ 65 &&
+                key.charCodeAt(2) <= /* Z */ 90
+            ) {
+                if (!eventMap.has(key)) {
+                    eventMap.set(key, []);
+                }
+
+                if (typeof value === 'function') {
+                    eventMap.get(key)?.push(value);
+
+                    acc[key] = (...args: unknown[]) => {
+                        return eventMap
+                            .get(key)
+                            ?.map((fn) => fn(...args))
+                            .find((v) => v !== undefined);
+                    };
+                }
+            } else {
+                acc[key] = value;
+            }
+        });
+        return acc;
+    }, {});
+}

--- a/src/unstable.ts
+++ b/src/unstable.ts
@@ -30,3 +30,19 @@ export {
     TreeList as unstable_TreeList,
     type TreeListProps as unstable_TreeListProps,
 } from './components/TreeList';
+
+export {
+    Menu as unstable_Menu,
+    MenuItem as unstable_MenuItem,
+    MenuTrigger as unstable_MenuTrigger,
+    MenuDivider as unstable_MenuDivider,
+    type MenuSize as unstable_MenuSize,
+    type MenuProps as unstable_MenuProps,
+    type MenuItemTheme as unstable_MenuItemTheme,
+    type MenuItemProps as unstable_MenuItemProps,
+    type MenuItemButtonProps as unstable_MenuItemButtonProps,
+    type MenuItemLinkProps as unstable_MenuItemLinkProps,
+    type MenuItemComponentProps as unstable_MenuItemComponentProps,
+    type MenuItemComponentElementType as unstable_MenuItemComponentElementType,
+    type MenuTriggerProps as unstable_MenuTriggerProps,
+} from './components/lab/Menu';


### PR DESCRIPTION
It is a rework of current components, `Menu` and `DropdownMenu`. More details in [RFC](https://github.com/gravity-ui/rfc/issues/21).

## Summary by Sourcery

Implement a new Menu component with advanced features, including nested menus, keyboard navigation, and accessibility support

New Features:
- Create a comprehensive Menu component with support for nested menus
- Add MenuTrigger, MenuItem, and MenuDivider subcomponents
- Implement advanced keyboard navigation and accessibility features
- Support for inline and popup menu styles

Enhancements:
- Improve ListItemView component with additional props and styling
- Add support for aria attributes in Button component
- Enhance component flexibility with new props and interactions

Tests:
- Add comprehensive test suite for Menu component
- Test keyboard navigation, submenu interactions, and accessibility