### PR TITLE
fix(ThemeProvider): do not update class name in case of null body

### DIFF
--- a/src/components/theme/dom-helpers.ts
+++ b/src/components/theme/dom-helpers.ts
@@ -17,6 +17,11 @@ export function updateBodyClassName({
 }) {
     const bodyEl = document.body;
 
+    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-body-dev
+    if (!bodyEl) {
+        return;
+    }
+
     if (!bodyEl.classList.contains(rootClassName)) {
         bodyEl.classList.add(rootClassName);
     }


### PR DESCRIPTION
We need it to avoid such problem:
![image](https://github.com/user-attachments/assets/8c604b1d-86c6-4561-9ef1-b321e02dc403)
