### PR TITLE
build: replace double quotes in `pr-title.yml`

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install Packages
         run: npm ci
       - name: Run Commitlint
-        run: echo "${{github.event.pull_request.title}}" | npx commitlint
+        run: echo '${{github.event.pull_request.title}}' | npx commitlint


### PR DESCRIPTION
Double quotations and using back ticks in header cause false-positive lint error

With single quotes header is treated as string, without attempts to execute back ticks content as command

<img width="879" alt="Screenshot 2025-02-21 at 12 21 55" src="https://github.com/user-attachments/assets/4168e671-6883-4bc0-8d18-d32e53737dee" />
