### PR TITLE
ci: cancel running title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,11 +8,14 @@ on:
       - reopened
       - edited
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   verify_title:
     name: Verify Title
     runs-on: ubuntu-latest
-    if: ${{github.event.action != 'edited' || github.event.changes.title}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the CI workflow to cancel in-progress title checks when a new push occurs on the same branch.