### PR TITLE
test(DefinitionList): skip flaky test

### DIFF
--- a/src/components/DefinitionList/__tests__/DefinitionList.visual.test.tsx
+++ b/src/components/DefinitionList/__tests__/DefinitionList.visual.test.tsx
@@ -5,7 +5,8 @@ import type {DefinitionListProps} from '../types';
 
 import {DefinitionListStories} from './stories';
 
-test.describe('DefinitionList', {tag: '@DefinitionList'}, () => {
+// Test is flaky. Screenshot height randomly changes by 6px.
+test.describe.skip('DefinitionList', {tag: '@DefinitionList'}, () => {
     test('render story <Default>', async ({mount, expectScreenshot}) => {
         await mount(<DefinitionListStories.Default />);
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Skip flaky DefinitionList visual test.