### PR TITLE
fix(TextArea): automatic height calculation

### DIFF
--- a/src/components/controls/TextArea/README.md
+++ b/src/components/controls/TextArea/README.md
@@ -157,7 +157,8 @@ LANDING_BLOCK-->
 
 ## Row management
 
-The row count of the `TextArea` is controlled by the `rows`, `minRows` and `maxRows` properties.
+The row count of the `TextArea` is controlled by the `rows`, `minRows` and `maxRows` properties. The `rows` property disables automatic height calculation.
+To set the desired height of the `TextArea`, use the `className` or `style` property with the `rows` property set to 1.
 
 <!--LANDING_BLOCK
 <ExampleBlock
@@ -177,12 +178,16 @@ The row count of the `TextArea` is controlled by the `rows`, `minRows` and `maxR
         maxRows = 2
         <UIKit.TextArea placeholder="Placeholder" maxRows={2} />
     </div>
+    <div>
+        height = 200px
+        <UIKit.TextArea placeholder="Placeholder" rows={1} style={{height: 200px}}/>
+    </div>
 </ExampleBlock>
 LANDING_BLOCK-->
 
 ## Resizable TextArea
 
-You can get resizable behaviour by providing `resize` style to `controlProps` property.
+You can get resizable behaviour by providing `resize` style to `controlProps` property. Be sure to specify the `rows` property if you allow the text area height to be resized, otherwise resizing will conflict with the automatic height calculation.
 
 <!--LANDING_BLOCK
 <ExampleBlock

--- a/src/components/controls/TextArea/__stories__/TextArea.stories.tsx
+++ b/src/components/controls/TextArea/__stories__/TextArea.stories.tsx
@@ -1,11 +1,11 @@
-import type {Meta, StoryFn} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 
+import {Disclosure} from '../../../Disclosure';
 import {TextArea} from '../TextArea';
-import type {TextAreaProps} from '../TextArea';
 
 import {TextAreaCustomShowcase, TextAreaShowcase} from './TextAreaShowcase';
 
-export default {
+const meta: Meta<typeof TextArea> = {
     title: 'Components/Inputs/TextArea',
     component: TextArea,
     parameters: {
@@ -30,21 +30,63 @@ export default {
             },
         },
     },
-} as Meta;
-
-const fixConsoleErrors = {
-    onKeyDown: () => {},
-    onKeyUp: () => {},
-    onKeyPress: () => {},
 };
 
-const DefaultTemplate: StoryFn<TextAreaProps> = (args) => (
-    <TextArea {...fixConsoleErrors} {...args} />
-);
-export const Default = DefaultTemplate.bind({});
+export default meta;
 
-const ShowcaseTemplate: StoryFn = () => <TextAreaShowcase />;
-export const Showcase = ShowcaseTemplate.bind({});
+type Story = StoryObj<typeof TextArea>;
 
-const CustomThemeTemplate: StoryFn = () => <TextAreaCustomShowcase />;
-export const CustomTheme = CustomThemeTemplate.bind({});
+export const Default: Story = {
+    render: (args) => <TextArea {...args} />,
+    parameters: {
+        controls: {
+            exclude: /^on[A-Z]|Ref$/,
+        },
+    },
+    argTypes: {
+        autoComplete: {
+            options: ['on', 'off', 'none'],
+            mapping: {none: undefined},
+            control: {type: 'radio'},
+        },
+        note: {
+            control: 'text',
+        },
+        error: {
+            control: 'text',
+        },
+        errorMessage: {
+            control: 'text',
+        },
+        validationState: {
+            options: ['invalid', 'none'],
+            mapping: {none: undefined},
+            control: {type: 'radio'},
+        },
+    },
+};
+
+export const InsideDisclosure = {
+    ...Default,
+    render: function InsideDisclosure(args) {
+        return (
+            <Disclosure summary="TextArea inside">
+                <TextArea {...args} />
+            </Disclosure>
+        );
+    },
+    args: {
+        ...Default.args,
+        defaultValue: 'first line\nsecond line\nthird line',
+    },
+} satisfies Story;
+
+export const Showcase = {
+    render: () => <TextAreaShowcase />,
+    parameters: {controls: {disable: true}},
+} satisfies Story;
+
+export const CustomTheme = {
+    render: () => <TextAreaCustomShowcase />,
+    parameters: {controls: {disable: true}},
+} satisfies Story;

--- a/src/components/controls/TextArea/__stories__/TextAreaShowcase.tsx
+++ b/src/components/controls/TextArea/__stories__/TextAreaShowcase.tsx
@@ -115,6 +115,7 @@ export function TextAreaCustomShowcase() {
                 <h3 className={b('section-header')}>Normal</h3>
                 <TextArea
                     {...textAreaProps}
+                    value={undefined}
                     defaultValue={`
 multi
 line
@@ -140,6 +141,7 @@ value`.trim()}
                 <h3 className={b('section-header')}>Custom theme</h3>
                 <TextArea
                     {...textAreaProps}
+                    value={undefined}
                     defaultValue={`
 multi
 line

--- a/src/components/controls/TextArea/__stories__/TextAreaShowcase.tsx
+++ b/src/components/controls/TextArea/__stories__/TextAreaShowcase.tsx
@@ -41,6 +41,7 @@ export function TextAreaShowcase() {
                     />
                     <TextArea
                         {...textAreaProps}
+                        rows={1}
                         placeholder="333px height from className"
                         className={b('custom-height')}
                     />
@@ -54,7 +55,8 @@ export function TextAreaShowcase() {
                         <TextArea
                             {...textAreaProps}
                             placeholder="error with message"
-                            error={isErrorMessageVisible ? 'A validation error has occurred' : true}
+                            validationState={isErrorMessageVisible ? 'invalid' : undefined}
+                            errorMessage={'A validation error has occurred'}
                         />
                         <Checkbox
                             onUpdate={setErrorMessageVisibility}
@@ -87,7 +89,8 @@ export function TextAreaShowcase() {
                         placeholder="with counter and long error message"
                         rows={4}
                         note={<Text color="secondary">Additional</Text>}
-                        error={
+                        validationState="invalid"
+                        errorMessage={
                             'It happened a very very very very very very very very very very very very very very very very very very very very very long validation error'
                         }
                     />
@@ -127,7 +130,11 @@ value`.trim()}
                     readOnly
                     rows={2}
                 />
-                <TextArea {...textAreaProps} error="Error message" />
+                <TextArea
+                    {...textAreaProps}
+                    validationState="invalid"
+                    errorMessage="Error message"
+                />
             </div>
             <div className={b('custom-theme')}>
                 <h3 className={b('section-header')}>Custom theme</h3>
@@ -148,7 +155,11 @@ value`.trim()}
                     readOnly
                     rows={2}
                 />
-                <TextArea {...textAreaProps} error="Error message" />
+                <TextArea
+                    {...textAreaProps}
+                    validationState="invalid"
+                    errorMessage="Error message"
+                />
             </div>
         </div>
     );


### PR DESCRIPTION
Closes #1935

## Summary by Sourcery

Fixes an issue where the TextArea component's height was not being calculated correctly, especially when the number of rows was not explicitly specified. The fix ensures that the height is automatically adjusted based on the content, minRows, and maxRows properties. Also, it updates the documentation to clarify how to set the height of the TextArea and how to use the resize property.

Bug Fixes:
- Fixes automatic height calculation for TextArea component when rows prop is not specified.
- Fixes issue where resizing the TextArea would conflict with the automatic height calculation when rows prop was not specified.
- Ensures that the height is automatically adjusted based on the content, minRows, and maxRows properties.
- Fixes issue where error message was not displayed correctly in the TextArea component.
- Fixes issue where the TextArea component was not displaying the correct height when the minRows property was set to a value greater than 1.
- Fixes issue where the TextArea component was not displaying the correct height when the maxRows property was set to a value less than the number of lines in the text area.
- Fixes issue where the TextArea component was not displaying the correct height when the text area was resized by the user.
- Fixes issue where the TextArea component was not displaying the correct height when the text area was resized by the parent element.
- Fixes issue where the TextArea component was not displaying the correct height when the text area was resized by the window.