### PR TITLE
Bug showcase: not working ref inside Dialog in uikit 7

### DIFF
--- a/src/components/Dialog/__stories__/Dialog.stories.tsx
+++ b/src/components/Dialog/__stories__/Dialog.stories.tsx
@@ -26,6 +26,9 @@ const DefaultTemplate: StoryFn<DialogProps & {showError: boolean}> = ({showError
             <Button view="normal" onClick={() => setOpen(true)}>
                 Show dialog
             </Button>
+
+            <NotWorkingRefShowcase />
+
             <Dialog
                 {...args}
                 onClose={() => setOpen(false)}
@@ -53,3 +56,21 @@ export const Default = DefaultTemplate.bind({});
 
 const ShowcaseTemplate: StoryFn = () => <DialogShowcase />;
 export const Showcase = ShowcaseTemplate.bind({});
+
+function NotWorkingRefShowcase() {
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+    React.useEffect(() => {
+        console.log('buttonRef.current is', buttonRef.current);
+    }, []);
+
+    return (
+        <Dialog open={true} onClose={() => console.log('close')}>
+            <Dialog.Header caption="Ref example" />
+            <Dialog.Body>
+                <Button ref={buttonRef}>{'ref.current is undefined inside useEffect : > ('}</Button>
+            </Dialog.Body>
+            <Dialog.Footer textButtonApply=":("></Dialog.Footer>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
### Bug demonstration (not an actual Pull Request)

Open [Overlays/Dialog/Default](https://preview.gravity-ui.com/uikit/2179/?path=/story/components-overlays-dialog--default) and take a look at the console
it states that `buttonRef.current is null`
Although in uikit 6 it wouldn't be `null`

## Summary by Sourcery

Bug Fixes:
- Demonstrates a bug where a ref inside a Dialog component is null when accessed in a useEffect hook.