### PR TITLE
fix(types): support pass var with type React.CSSProperties to style prop

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -93,6 +93,8 @@ export interface FocusEventHandlers<Target = Element> {
     onBlur?: React.FocusEventHandler<Target>;
 }
 
-export interface CSSProperties extends React.CSSProperties {
-    [key: `--${string}`]: string | number;
-}
+export type CSSProperties =
+    | (React.CSSProperties & {
+          [key: `--${string}`]: string | number;
+      })
+    | React.CSSProperties;


### PR DESCRIPTION
## Summary by Sourcery

Enhance type support for CSS properties by allowing more flexible type definitions for style props

Bug Fixes:
- Improve type compatibility for style props by allowing React.CSSProperties and custom CSS variable definitions

Enhancements:
- Modify CSSProperties type to support both standard React CSS properties and custom CSS variables with more flexible type checking