### PR TITLE
fix(Popover): always enable safePolygon to workaround `useHover` issue

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -61,7 +61,8 @@ export function Popover({
     trigger,
     openDelay = DEFAULT_OPEN_DELAY,
     closeDelay = DEFAULT_CLOSE_DELAY,
-    enableSafePolygon,
+    // Force enable to workaround https://github.com/floating-ui/floating-ui/issues/3261
+    // enableSafePolygon,
     className,
     ...restProps
 }: PopoverProps) {
@@ -83,7 +84,7 @@ export function Popover({
         enabled: trigger !== 'click',
         delay: {open: openDelay, close: closeDelay},
         move: false,
-        handleClose: enableSafePolygon ? safePolygon() : undefined,
+        handleClose: safePolygon(),
     });
     const click = useClick(context);
     const role = useRole(context, {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure consistent hover interaction by permanently enabling safePolygon for the Popover component