### PR TITLE
feat(Breadcrumbs): allow to display content after the last breadcrumb item

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -22,18 +22,19 @@ $block: '.#{variables.$ns}breadcrumbs';
         white-space: nowrap;
         color: var(--g-color-text-primary);
 
-        &:last-child {
+        &_current {
             font-weight: var(--g-text-accent-font-weight);
             overflow: hidden;
             margin: -2px;
             padding: 2px;
+            min-width: 25px;
 
             #{$block}__link {
                 @include mixins.overflow-ellipsis();
             }
         }
 
-        &_calculating:last-child {
+        &_calculating {
             overflow: visible;
         }
     }

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -26,6 +26,7 @@ export interface BreadcrumbsProps extends DOMProps, AriaLabelingProps, QAProps {
     children: React.ReactNode;
     disabled?: boolean;
     onAction?: (key: Key) => void;
+    endContent?: React.ReactNode;
 }
 
 export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
@@ -34,8 +35,9 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
 ) {
     const listRef = React.useRef<HTMLOListElement>(null);
     const containerRef = useForkRef(ref, listRef);
+    const endContentRef = React.useRef<HTMLLIElement>(null);
 
-    const items: React.ReactElement[] = [];
+    const items: React.ReactElement<any>[] = [];
     React.Children.forEach(props.children, (child, index) => {
         if (React.isValidElement(child)) {
             if (child.key === undefined || child.key === null) {
@@ -53,10 +55,15 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
             return;
         }
         const listItems = Array.from(list.children) as HTMLElement[];
+        const endElement = endContentRef.current;
+        if (endElement) {
+            listItems.pop();
+        }
         if (listItems.length === 0) {
+            setCalculated(true);
             return;
         }
-        const containerWidth = list.offsetWidth;
+        const containerWidth = list.offsetWidth - (endElement?.offsetWidth ?? 0);
         let newVisibleItemsCount = 0;
         let calculatedWidth = 0;
         let maxItems = props.maxItems || Infinity;
@@ -116,6 +123,10 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     }, [items.length]);
     useResizeObserver({
         ref: listRef,
+        onResize: handleResize,
+    });
+    useResizeObserver({
+        ref: props.endContent ? endContentRef : undefined,
         onResize: handleResize,
     });
 
@@ -184,11 +195,6 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     const breadcrumbsItems = contents.map((child, index) => {
         const isCurrent = index === lastIndex;
         const key = child.key ?? index;
-        const handleAction = () => {
-            if (typeof props.onAction === 'function') {
-                props.onAction(key);
-            }
-        };
 
         const {'data-breadcrumbs-menu-item': isMenu, ...childProps} = child.props;
         let item: React.ReactNode;
@@ -196,6 +202,11 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
             item = child;
         } else {
             const Component = props.itemComponent ?? BreadcrumbsItem;
+            const handleAction = () => {
+                if (typeof props.onAction === 'function') {
+                    props.onAction(key);
+                }
+            };
             const innerProps: BreadcrumbsItemInnerProps = {
                 __current: isCurrent,
                 __disabled: props.disabled || childProps.disabled,
@@ -208,12 +219,22 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
             );
         }
         return (
-            <li key={index} className={b('item', {calculating: !calculated})}>
+            <li
+                key={isMenu ? 'menu' : `item-${key}`}
+                className={b('item', {calculating: isCurrent && !calculated, current: isCurrent})}
+            >
                 {item}
                 {isCurrent ? null : <BreadcrumbsSeparator separator={props.separator} />}
             </li>
         );
     });
+    if (props.endContent) {
+        breadcrumbsItems.push(
+            <li key="end-content" ref={endContentRef} className={b('item')}>
+                {props.endContent}
+            </li>,
+        );
+    }
     return (
         <ol
             ref={containerRef}

--- a/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -131,10 +131,10 @@ function BreadcrumbsItem(props: BreadcrumbsItemProps, ref: React.ForwardedRef<HT
 
     return (
         <Element
-            ref={ref}
             {...restProps}
             {...domProps}
             {...linkProps}
+            ref={ref}
             className={b(
                 'link',
                 {

--- a/src/components/Breadcrumbs/README.md
+++ b/src/components/Breadcrumbs/README.md
@@ -513,6 +513,57 @@ LANDING_BLOCK-->
 
 <!--/GITHUB_BLOCK-->
 
+### End content
+
+<!--LANDING_BLOCK
+
+<ExampleBlock
+    code={`
+<Breadcrumbs endContent={<div style={{paddingInlineStart: 4}}><Button>Push</Button></div>}>
+    <Breadcrumbs.Item>Region</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Country</Breadcrumbs.Item>
+    <Breadcrumbs.Item>City</Breadcrumbs.Item>
+    <Breadcrumbs.Item>District</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Street</Breadcrumbs.Item>
+</Breadcrumbs>
+`}
+>
+    <UIKit.Breadcrumbs endContent={<div style={{paddingInlineStart: 4}}><Button>Push</Button></div>}>
+        <UIKit.Breadcrumbs.Item>Region</UIKit.Breadcrumbs.Item>
+        <UIKit.Breadcrumbs.Item>Country</UIKit.Breadcrumbs.Item>
+        <UIKit.Breadcrumbs.Item>City</UIKit.Breadcrumbs.Item>
+        <UIKit.Breadcrumbs.Item>District</UIKit.Breadcrumbs.Item>
+        <UIKit.Breadcrumbs.Item>Street</UIKit.Breadcrumbs.Item>
+    </UIKit.Breadcrumbs>
+</ExampleBlock>
+
+LANDING_BLOCK-->
+
+<!--GITHUB_BLOCK-->
+
+```jsx
+<Breadcrumbs
+  endContent={
+    <Flex gap={1} spacing={{pl: 1}}>
+      <Button>Test1</Button>
+      <Button>Test2</Button>
+    </Flex>
+  }
+>
+  <Breadcrumbs.Item>Region</Breadcrumbs.Item>
+  <Breadcrumbs.Item>Country</Breadcrumbs.Item>
+  <Breadcrumbs.Item>City</Breadcrumbs.Item>
+  <Breadcrumbs.Item>District</Breadcrumbs.Item>
+  <Breadcrumbs.Item>Street</Breadcrumbs.Item>
+</Breadcrumbs>
+```
+
+<!-- Storybook example -->
+
+<BreadcrumbsEndContent />
+
+<!--/GITHUB_BLOCK-->
+
 ## Properties
 
 | Name             | Description                                                                  | Type                                       | Default |
@@ -531,6 +582,7 @@ LANDING_BLOCK-->
 | aria-label       | Defines a string value that labels the current element.                      | `string`                                   |         |
 | aria-labelledby  | Identifies the element(s) that label the current element.                    | `string`                                   |         |
 | aria-describedby | Identifies the element(s) that describe the object.                          | `string`                                   |         |
+| endContent       | User's node rendered after last breadcrumb item.                             | `React.ReactNode`                          |         |
 
 ### BreadcrumbsItemProps
 

--- a/src/components/Breadcrumbs/__stories__/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/__stories__/Breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {ChevronRight, Flame, House, Rocket} from '@gravity-ui/icons';
 import type {Meta, StoryObj} from '@storybook/react';
 
+import {Button} from '../../Button';
 import {Text} from '../../Text';
 import {Box, Flex} from '../../layout';
 import type {Key} from '../../types';
@@ -153,6 +154,20 @@ export const DisabledItems = {
             </Breadcrumbs.Item>
         </Breadcrumbs>
     ),
+} satisfies Story;
+
+export const EndContent = {
+    render: (args) => {
+        return Default.render({
+            ...args,
+            endContent: (
+                <Flex gap={1} spacing={{pl: 1}}>
+                    <Button>Test1</Button>
+                    <Button>Test2</Button>
+                </Flex>
+            ),
+        });
+    },
 } satisfies Story;
 
 export const ClientNavigation = {

--- a/src/components/Breadcrumbs/__stories__/Docs.mdx
+++ b/src/components/Breadcrumbs/__stories__/Docs.mdx
@@ -16,6 +16,7 @@ export const BreadcrumbsRootContext = () => <Canvas of={Stories.RootContext} sou
 export const BreadcrumbsSeparator = () => <Canvas of={Stories.Separator} sourceState="none" />;
 export const BreadcrumbsWithIcons = () => <Canvas of={Stories.WithIcons} sourceState="none" />;
 export const BreadcrumbsLandmarks = () => <Canvas of={Stories.Landmarks} sourceState="none" />;
+export const BreadcrumbsEndContent = () => <Canvas of={Stories.EndContent} sourceState="none" />;
 export const BreadcrumbsClientNavigation = () => (
     <Canvas of={Stories.ClientNavigation} sourceState="none" />
 );
@@ -39,6 +40,7 @@ export const BreadcrumbsDisabledItems = () => (
             BreadcrumbsWithIcons,
             BreadcrumbsLandmarks,
             BreadcrumbsDisabledItems,
+            BreadcrumbsEndContent,
             BreadcrumbsClientNavigation,
         },
     }}

--- a/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -41,7 +41,7 @@ it('handles multiple items', () => {
 it('should handle forward ref', function () {
     let ref: React.RefObject<any> | undefined;
     const Component = () => {
-        ref = React.useRef();
+        ref = React.useRef(null);
         return (
             <Breadcrumbs ref={ref} aria-label="breadcrumbs-test">
                 <Breadcrumbs.Item>Folder 1</Breadcrumbs.Item>


### PR DESCRIPTION
## Summary by Sourcery

Add support for rendering additional content after the last breadcrumb item

New Features:
- Introduce an `endContent` prop to Breadcrumbs component that allows rendering additional content after the last breadcrumb item

Enhancements:
- Update Breadcrumbs component to dynamically adjust layout and resize handling to accommodate end content
- Modify CSS and rendering logic to support the new end content feature

Documentation:
- Update README and documentation to include examples and description of the new `endContent` prop

Tests:
- Add a new story and test case to demonstrate the end content functionality