### PR TITLE
fix(Breadcrumbs): handle empty string in breadcrumbs item title

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -40,7 +40,7 @@ function BreadcrumbsItem(props: BreadcrumbsItemProps, ref: React.ForwardedRef<HT
     } = props as BreadcrumbsItemProps & BreadcrumbsItemInnerProps;
 
     let title = props.title;
-    if (!title && typeof children === 'string') {
+    if (typeof title !== 'string' && typeof children === 'string') {
         title = children;
     }
 


### PR DESCRIPTION
Closes https://github.com/gravity-ui/uikit/issues/2192