### PR TITLE
feat: extract mergeRefs helper from useForkRef

### DIFF
--- a/src/hooks/useForkRef/index.ts
+++ b/src/hooks/useForkRef/index.ts
@@ -1,3 +1,4 @@
 export {useForkRef} from './useForkRef';
+export {mergeRefs} from './mergeRefs';
 export {setRef} from './setRef';
 export type {UseForkRefProps, UseForkRefResult} from './useForkRef';

--- a/src/hooks/useForkRef/mergeRefs.ts
+++ b/src/hooks/useForkRef/mergeRefs.ts
@@ -1,0 +1,11 @@
+import type * as React from 'react';
+
+import {setRef} from './setRef';
+
+export function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> {
+    return function mergedRefs(value) {
+        for (const ref of refs) {
+            setRef(ref, value);
+        }
+    };
+}

--- a/src/hooks/useForkRef/setRef.ts
+++ b/src/hooks/useForkRef/setRef.ts
@@ -1,10 +1,9 @@
-export function setRef<T>(
-    ref: React.MutableRefObject<T | null> | React.RefCallback<T | null> | null | undefined,
-    value: T | null,
-) {
+import type * as React from 'react';
+
+export function setRef<T>(ref: React.Ref<T | null> | undefined, value: T | null) {
     if (typeof ref === 'function') {
         ref(value);
     } else if (ref) {
-        ref.current = value;
+        (ref as React.MutableRefObject<T | null>).current = value;
     }
 }

--- a/src/hooks/useForkRef/setRef.ts
+++ b/src/hooks/useForkRef/setRef.ts
@@ -4,6 +4,7 @@ export function setRef<T>(ref: React.Ref<T | null> | undefined, value: T | null)
     if (typeof ref === 'function') {
         ref(value);
     } else if (ref) {
-        (ref as React.MutableRefObject<T | null>).current = value;
+        //@ts-expect-error
+        ref.current = value;
     }
 }

--- a/src/hooks/useForkRef/useForkRef.ts
+++ b/src/hooks/useForkRef/useForkRef.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {setRef} from './setRef';
+import {mergeRefs} from './mergeRefs';
 
 export type UseForkRefProps<K> = Array<React.Ref<K> | undefined>;
 export type UseForkRefResult<W> = React.RefCallback<W> | null;
@@ -11,11 +11,7 @@ export function useForkRef<T>(...refs: UseForkRefProps<T>): UseForkRefResult<T> 
             return null;
         }
 
-        return (value: T | null) => {
-            for (const ref of refs) {
-                setRef(ref, value);
-            }
-        };
+        return mergeRefs(...refs);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, refs);
 }


### PR DESCRIPTION
## Summary by Sourcery

Extract a new helper function `mergeRefs` from the existing `useForkRef` hook to improve code reusability and modularity.

New Features:
- Introduce a new `mergeRefs` utility function that can merge multiple React refs into a single ref callback

Enhancements:
- Refactor `useForkRef` to use the new `mergeRefs` helper function
- Improve type handling for ref types in `setRef` function

Chores:
- Update index file to export the new `mergeRefs` function