### PR TITLE
feat: add link reset mixin

### DIFF
--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -21,6 +21,11 @@
     cursor: pointer;
 }
 
+@mixin link-reset() {
+    color: inherit;
+    text-decoration: inherit;
+}
+
 @mixin expand-interactive-area($h: 4px, $v: $h) {
     position: relative;
 


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a `link-reset()` mixin that removes default link styling, allowing links to blend with surrounding text