### PR TITLE
feat: always render Modal and Popup with FloatingTree

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -147,12 +147,14 @@ function ModalComponent({
                 return;
             }
 
-            const closeReason =
-                reason === 'escape-key'
-                    ? 'escapeKeyDown'
-                    : reason === 'outside-press'
-                      ? 'outsideClick'
-                      : reason;
+            let closeReason;
+            if (reason === 'escape-key') {
+                closeReason = 'escapeKeyDown';
+            } else if (reason === 'outside-press') {
+                closeReason = 'outsideClick';
+            } else {
+                closeReason = reason;
+            }
 
             if (closeReason === 'escapeKeyDown' && onEscapeKeyDown) {
                 onEscapeKeyDown(event as KeyboardEvent);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -35,7 +35,7 @@ import i18n from './i18n';
 
 import './Modal.scss';
 
-export type ModalCloseReason = 'outsideClick' | 'escapeKeyDown';
+export type ModalCloseReason = 'outsideClick' | 'escapeKeyDown' | string | undefined;
 
 export interface ModalProps extends DOMProps, AriaLabelingProps, QAProps {
     open?: boolean;
@@ -147,7 +147,12 @@ function ModalComponent({
                 return;
             }
 
-            const closeReason = reason === 'escape-key' ? 'escapeKeyDown' : 'outsideClick';
+            const closeReason =
+                reason === 'escape-key'
+                    ? 'escapeKeyDown'
+                    : reason === 'outside-press'
+                      ? 'outsideClick'
+                      : reason;
 
             if (closeReason === 'escapeKeyDown' && onEscapeKeyDown) {
                 onEscapeKeyDown(event as KeyboardEvent);

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -47,7 +47,7 @@ import {arrowStylesMiddleware, getOffsetOptions, getPlacementOptions} from './ut
 
 import './Popup.scss';
 
-export type PopupCloseReason = 'outsideClick' | 'escapeKeyDown';
+export type PopupCloseReason = 'outsideClick' | 'escapeKeyDown' | string | undefined;
 
 export interface PopupProps extends DOMProps, AriaLabelingProps, QAProps {
     children?: React.ReactNode;
@@ -210,7 +210,12 @@ function PopupComponent({
                 return;
             }
 
-            const closeReason = reason === 'escape-key' ? 'escapeKeyDown' : 'outsideClick';
+            const closeReason =
+                reason === 'escape-key'
+                    ? 'escapeKeyDown'
+                    : reason === 'outside-press'
+                      ? 'outsideClick'
+                      : reason;
 
             if (closeReason === 'escapeKeyDown' && onEscapeKeyDown) {
                 onEscapeKeyDown(event as KeyboardEvent);

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -210,12 +210,14 @@ function PopupComponent({
                 return;
             }
 
-            const closeReason =
-                reason === 'escape-key'
-                    ? 'escapeKeyDown'
-                    : reason === 'outside-press'
-                      ? 'outsideClick'
-                      : reason;
+            let closeReason;
+            if (reason === 'escape-key') {
+                closeReason = 'escapeKeyDown';
+            } else if (reason === 'outside-press') {
+                closeReason = 'outsideClick';
+            } else {
+                closeReason = reason;
+            }
 
             if (closeReason === 'escapeKeyDown' && onEscapeKeyDown) {
                 onEscapeKeyDown(event as KeyboardEvent);


### PR DESCRIPTION
## Summary by Sourcery

Modify Popup and Modal components to always render with FloatingTree, ensuring proper nested floating UI behavior

New Features:
- Add support for nested floating UI components by wrapping Popup and Modal with FloatingTree when no parent floating node exists

Enhancements:
- Refactor Popup and Modal components to use FloatingNode and support nested floating UI contexts
- Improve floating UI component rendering by adding explicit node ID management