### PR TITLE
feat(Tab): add `onClick` handler

### DIFF
--- a/src/components/tabs/hooks/useTab.ts
+++ b/src/components/tabs/hooks/useTab.ts
@@ -21,14 +21,18 @@ export function useTab(tabProps: TabProps) {
     const isDisabled = tabProps.disabled;
     const isFocused = tabContext.isFocused;
 
-    const onClick = () => {
+    const onClick: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement> = (event) => {
         if (!tabProps.disabled) {
+            tabProps.onClick?.(event);
             tabContext.onUpdate?.(tabProps.value);
         }
     };
 
-    const onKeyDown = (event: React.KeyboardEvent) => {
+    const onKeyDown: React.KeyboardEventHandler<HTMLAnchorElement | HTMLButtonElement> = (
+        event,
+    ) => {
         if ((event.key === KeyCode.SPACEBAR || event.key === KeyCode.ENTER) && !tabProps.disabled) {
+            tabProps.onClick?.(event);
             tabContext.onUpdate?.(tabProps.value);
         }
     };

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -32,6 +32,11 @@ export interface TabProps extends AriaLabelingProps, DOMProps, QAProps {
     };
     disabled?: boolean;
     children?: React.ReactNode;
+    onClick?: (
+        event:
+            | React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>
+            | React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement>,
+    ) => void;
 }
 
 export interface TabPanelProps extends AriaLabelingProps, DOMProps, QAProps {


### PR DESCRIPTION
## Summary by Sourcery

Add optional `onClick` handler to Tab component to support custom click event handling

New Features:
- Introduce an optional `onClick` prop to the Tab component that allows custom event handling for mouse and keyboard interactions

Enhancements:
- Update `useTab` hook to invoke the optional `onClick` handler before updating the tab context