### PR TITLE
feat(FilePreview): add export of FilePreviewAction type

### DIFF
--- a/src/components/FilePreview/FilePreview.tsx
+++ b/src/components/FilePreview/FilePreview.tsx
@@ -21,7 +21,7 @@ import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
 import {FilePreviewActions} from './FilePreviewActions/FilePreviewActions';
-import type {FilePreviewActionProps, FileType} from './types';
+import type {FilePreviewAction, FileType} from './types';
 import {getFileType} from './utils';
 
 import './FilePreview.scss';
@@ -53,7 +53,7 @@ interface FilePreviewBaseProps extends QAProps {
 }
 
 interface DefaultFilePreviewProps extends FilePreviewBaseProps {
-    actions?: FilePreviewActionProps[];
+    actions?: FilePreviewAction[];
     view?: 'default';
 }
 

--- a/src/components/FilePreview/FilePreviewActions/DesktopActionsMenu/DesktopActionsMenu.tsx
+++ b/src/components/FilePreview/FilePreviewActions/DesktopActionsMenu/DesktopActionsMenu.tsx
@@ -3,14 +3,14 @@ import {ActionTooltip} from '../../../ActionTooltip';
 import {Button} from '../../../Button';
 import type {ButtonButtonProps, ButtonLinkProps} from '../../../Button';
 import {block} from '../../../utils/cn';
-import type {FilePreviewActionProps} from '../../types';
+import type {FilePreviewAction} from '../../types';
 
 import './DesktopActionsMenu.scss';
 
 const cn = block('file-preview-actions-desktop');
 
 export interface DesktopActionsMenuProps {
-    actions: FilePreviewActionProps[];
+    actions: FilePreviewAction[];
     hoverabelPanelClassName: string;
 }
 

--- a/src/components/FilePreview/FilePreviewActions/FilePreviewActions.tsx
+++ b/src/components/FilePreview/FilePreviewActions/FilePreviewActions.tsx
@@ -1,5 +1,5 @@
 import {useMobile} from '../../mobile';
-import type {FilePreviewActionProps} from '../types';
+import type {FilePreviewAction} from '../types';
 
 import {DesktopActionsMenu} from './DesktopActionsMenu/DesktopActionsMenu';
 import {MobileActionsMenu} from './MobileActionsMenu/MobileActionsMenu';
@@ -8,7 +8,7 @@ export interface FilePreviewActionsProps {
     hoverabelPanelClassName: string;
     fileName: string;
     isCustomImage?: boolean;
-    actions: FilePreviewActionProps[];
+    actions: FilePreviewAction[];
 }
 
 export const FilePreviewActions = ({

--- a/src/components/FilePreview/FilePreviewActions/MobileActionsMenu/MobileActionsMenu.tsx
+++ b/src/components/FilePreview/FilePreviewActions/MobileActionsMenu/MobileActionsMenu.tsx
@@ -9,19 +9,19 @@ import type {ListProps} from '../../../List';
 import {Sheet} from '../../../Sheet';
 import {Text} from '../../../Text';
 import {block} from '../../../utils/cn';
-import type {FilePreviewActionProps} from '../../types';
+import type {FilePreviewAction} from '../../types';
 
 import './MobileActionsMenu.scss';
 
 const cn = block('file-preview-actions-mobile');
 
 export interface MobileActionsMenuProps {
-    actions: FilePreviewActionProps[];
+    actions: FilePreviewAction[];
     fileName: string;
     isCustomImage?: boolean;
 }
 
-const renderListItem = (item: FilePreviewActionProps) => {
+const renderListItem = (item: FilePreviewAction) => {
     return (
         <div className={cn('list-item')}>
             {item.icon}
@@ -40,7 +40,7 @@ export const MobileActionsMenu = ({actions, fileName, isCustomImage}: MobileActi
     }, []);
 
     const handleItemClick = React.useCallback<
-        NonNullable<ListProps<FilePreviewActionProps>['onItemClick']>
+        NonNullable<ListProps<FilePreviewAction>['onItemClick']>
     >((item, _, __, event) => {
         if (event) {
             // function can be called only on a mobile device

--- a/src/components/FilePreview/README.md
+++ b/src/components/FilePreview/README.md
@@ -88,7 +88,7 @@ LANDING_BLOCK-->
 | description         | Description displayed under the file name                                                                        | `string`              |          |           |
 | className           | Class name for the file container                                                                                | `string`              |          |           |
 | onClick             | Click handler for the file container                                                                             | `function`            |          |           |
-| [actions](#actions) | Аn array of interactive actions                                                                                  | `FilePreviewAction[]` |          | `[]`      |
+| [actions](#actions) | An array of interactive actions                                                                                  | `FilePreviewAction[]` |          | `[]`      |
 | view                | The file preview view mode (the text is not visible for the `compact` view)                                      | `default`, `compact`  |          | `default` |
 
 #### Actions

--- a/src/components/FilePreview/README.md
+++ b/src/components/FilePreview/README.md
@@ -81,15 +81,15 @@ LANDING_BLOCK-->
 
 ### Properties
 
-| Name                | Description                                                                                                      | Type                       | Required | Default   |
-| :------------------ | :--------------------------------------------------------------------------------------------------------------- | :------------------------- | :------: | :-------- |
-| file                | The File interface provides information about files and allows JavaScript in a web page to access their content. | `File`                     |   yes    |           |
-| imageSrc            | source for image preview                                                                                         | `string`                   |          |           |
-| description         | Description displayed under the file name                                                                        | `string`                   |          |           |
-| className           | Class name for the file container                                                                                | `string`                   |          |           |
-| onClick             | Click handler for the file container                                                                             | `function`                 |          |           |
-| [actions](#actions) | Аn array of interactive actions                                                                                  | `FilePreviewActionProps[]` |          | `[]`      |
-| view                | The file preview view mode (the text is not visible for the `compact` view)                                      | `default`, `compact`       |          | `default` |
+| Name                | Description                                                                                                      | Type                  | Required | Default   |
+| :------------------ | :--------------------------------------------------------------------------------------------------------------- | :-------------------- | :------: | :-------- |
+| file                | The File interface provides information about files and allows JavaScript in a web page to access their content. | `File`                |   yes    |           |
+| imageSrc            | source for image preview                                                                                         | `string`              |          |           |
+| description         | Description displayed under the file name                                                                        | `string`              |          |           |
+| className           | Class name for the file container                                                                                | `string`              |          |           |
+| onClick             | Click handler for the file container                                                                             | `function`            |          |           |
+| [actions](#actions) | Аn array of interactive actions                                                                                  | `FilePreviewAction[]` |          | `[]`      |
+| view                | The file preview view mode (the text is not visible for the `compact` view)                                      | `default`, `compact`  |          | `default` |
 
 #### Actions
 

--- a/src/components/FilePreview/index.ts
+++ b/src/components/FilePreview/index.ts
@@ -1,4 +1,4 @@
 export {FilePreview} from './FilePreview';
 export type {FilePreviewProps} from './FilePreview';
-export type {FileType} from './types';
+export type {FileType, FilePreviewAction} from './types';
 export {getFileType} from './utils';

--- a/src/components/FilePreview/types.ts
+++ b/src/components/FilePreview/types.ts
@@ -16,7 +16,7 @@ export const FILE_TYPES = [
 
 export type FileType = (typeof FILE_TYPES)[number];
 
-export type FilePreviewActionProps = {
+export type FilePreviewAction = {
     id?: string;
     icon: React.ReactNode;
     title: string;


### PR DESCRIPTION
## Summary by Sourcery

Rename and export FilePreviewActionProps type to FilePreviewAction across the FilePreview component

New Features:
- Export the FilePreviewAction type from the FilePreview component's index file

Enhancements:
- Rename FilePreviewActionProps type to FilePreviewAction for improved clarity and consistency