### PR TITLE
fix: add export for Stepper component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -47,6 +47,7 @@ export * from './Select';
 export * from './Sheet';
 export * from './Skeleton';
 export * from './Slider';
+export * from './Stepper';
 export * from './Spin';
 export * from './Switch';
 export * from './Table';


### PR DESCRIPTION
add export of `Stepper` component to components/index

## Summary by Sourcery

Enhancements:
- Add export for Stepper component to make it directly importable from the components index