### PR TITLE
feat(Tabs): pass all props to the root component

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -155,6 +155,8 @@ LANDING_BLOCK-->
 
 ### Properties
 
+`TabList` accepts any valid `div` element props in addition to these:
+
 | Name            | Description                                                                          |           Type            | Default |
 | :-------------- | :----------------------------------------------------------------------------------- | :-----------------------: | :-----: |
 | children        | List of tabs, probably with some wrappers                                            |     `React.ReactNode`     |         |
@@ -316,23 +318,28 @@ LANDING_BLOCK-->
 
 ### Properties
 
-| Name     | Description                             |       Type        | Default |
-| :------- | --------------------------------------- | :---------------: | :-----: |
-| value    | Tab value                               |     `string`      |         |
-| title    | Tab title                               |     `string`      |         |
-| icon     | Icon displayed at the start             | `React.ReactNode` |         |
-| counter  | Content displayed at the end            | `number` `string` |         |
-| href     | A URL to link to.                       |     `string `     |         |
-| label    | `<Label>` displayed at the end          | `React.ReactNode` |         |
-| disabled | Inactive state                          |     `boolean`     |         |
-| children | Tab's content                           | `React.ReactNode` |         |
-| qa       | HTML `data-qa` attribute, used in tests |     `string`      |         |
+`Tab` accepts any valid `button` or `a` element props in addition to these:
+
+| Name      | Description                             |        Type         | Default |
+| :-------- | --------------------------------------- | :-----------------: | :-----: |
+| value     | Tab value                               |      `string`       |         |
+| title     | Tab title                               |      `string`       |         |
+| icon      | Icon displayed at the start             |  `React.ReactNode`  |         |
+| counter   | Content displayed at the end            |  `number` `string`  |         |
+| href      | A URL to link to.                       |      `string `      |         |
+| label     | `<Label>` displayed at the end          |  `React.ReactNode`  |         |
+| disabled  | Inactive state                          |      `boolean`      |         |
+| component | Overrides the root component            | `React.ElementType` |         |
+| children  | Tab's content                           |  `React.ReactNode`  |         |
+| qa        | HTML `data-qa` attribute, used in tests |      `string`       |         |
 
 ## TabPanel
 
 Is a container element for content associated with a tab
 
 ### Properties
+
+`TabPanel` accepts any valid `div` element props in addition to these:
 
 | Name     | Description                             |       Type        | Default |
 | :------- | :-------------------------------------- | :---------------: | :-----: |

--- a/src/components/tabs/hooks/useTab.ts
+++ b/src/components/tabs/hooks/useTab.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
 import {KeyCode} from '../../../constants';
-import {filterDOMProps} from '../../utils/filterDOMProps';
 import {TAB_DATA_ATTRIBUTE, bTab} from '../constants';
 import {TabContext} from '../contexts/TabContext';
-import type {TabProps} from '../types';
+import type {TabComponentElementType, TabProps} from '../types';
 
-export function useTab(tabProps: TabProps) {
+export function useTab<T extends TabComponentElementType>(
+    tabProps: TabProps<T>,
+): React.HTMLAttributes<HTMLElement> & {[key: `data-${string}`]: string | undefined} {
     const tabContext = React.useContext(TabContext);
 
     if (!tabContext) {
@@ -21,19 +22,34 @@ export function useTab(tabProps: TabProps) {
     const isDisabled = tabProps.disabled;
     const isFocused = tabContext.isFocused;
 
-    const onClick = () => {
+    const onClick = (event: React.MouseEvent) => {
         if (!tabProps.disabled) {
             tabContext.onUpdate?.(tabProps.value);
+            tabProps.onClick?.(event);
         }
     };
 
     const onKeyDown = (event: React.KeyboardEvent) => {
         if ((event.key === KeyCode.SPACEBAR || event.key === KeyCode.ENTER) && !tabProps.disabled) {
             tabContext.onUpdate?.(tabProps.value);
+            tabProps.onKeyDown?.(event);
         }
     };
 
+    const {
+        value: _value,
+        icon: _icon,
+        counter: _counter,
+        label: _label,
+        disabled: _disabled,
+        href: _href,
+        component: _component,
+        qa: _qa,
+        ...htmlProps
+    } = tabProps;
+
     return {
+        ...htmlProps,
         role: 'tab',
         'aria-selected': isSelected,
         'aria-disabled': isDisabled,
@@ -42,11 +58,8 @@ export function useTab(tabProps: TabProps) {
         tabIndex: isSelected && !isDisabled && !isFocused ? 0 : -1,
         onClick,
         onKeyDown,
-        title: tabProps.title,
-        style: tabProps.style,
         className: bTab({active: isSelected, disabled: isDisabled}, tabProps.className),
         'data-qa': tabProps.qa,
         [TAB_DATA_ATTRIBUTE]: tabProps.value,
-        ...filterDOMProps(tabProps, {labelable: true}),
     };
 }

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {KeyCode} from '../../../constants';
 import {useDirection} from '../../theme';
-import {filterDOMProps} from '../../utils/filterDOMProps';
 import {TAB_DATA_ATTRIBUTE, bTabList} from '../constants';
 import {TabContext} from '../contexts/TabContext';
 import type {TabListProps} from '../types';
@@ -71,8 +70,10 @@ const focusFurthestTab = (event: React.KeyboardEvent, isInverse: boolean): HTMLE
     return lastFocusableTabElement;
 };
 
-export function useTabList(tabListProps: TabListProps) {
-    const tabContextProps = React.useContext(TabContext);
+export function useTabList(
+    tabListProps: TabListProps,
+): React.HTMLAttributes<HTMLDivElement> & {[key: `data-${string}`]: string | undefined} {
+    const tabContext = React.useContext(TabContext);
     const isRTL = useDirection() === 'rtl';
 
     const activateOnFocus = (tabElement: HTMLElement) => {
@@ -80,11 +81,11 @@ export function useTabList(tabListProps: TabListProps) {
 
         if (tabListProps.activateOnFocus && value) {
             tabListProps.onUpdate?.(value);
-            tabContextProps?.onUpdate?.(value);
+            tabContext?.onUpdate?.(value);
         }
     };
 
-    const onKeyDown = (event: React.KeyboardEvent) => {
+    const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         switch (event.code) {
             case KeyCode.ARROW_LEFT: {
                 event.preventDefault();
@@ -107,15 +108,25 @@ export function useTabList(tabListProps: TabListProps) {
                 break;
             }
         }
+
+        tabListProps.onKeyDown?.(event);
     };
 
+    const {
+        value: _value,
+        onUpdate: _onUpdate,
+        size: _size,
+        activateOnFocus: _activateOnFocus,
+        qa: _qa,
+        ...htmlProps
+    } = tabListProps;
+
     return {
+        ...htmlProps,
         role: 'tablist',
         'aria-orientation': 'horizontal' as const,
         onKeyDown,
-        style: tabListProps.style,
         className: bTabList({size: tabListProps.size ?? 'm'}, tabListProps.className),
         'data-qa': tabListProps.qa,
-        ...filterDOMProps(tabListProps, {labelable: true}),
     };
 }

--- a/src/components/tabs/hooks/useTabPanel.ts
+++ b/src/components/tabs/hooks/useTabPanel.ts
@@ -1,31 +1,33 @@
 import * as React from 'react';
 
-import {filterDOMProps} from '../../utils/filterDOMProps';
 import {bTabPanel} from '../constants';
 import {TabContext} from '../contexts/TabContext';
 import type {TabPanelProps} from '../types';
 
-export function useTabPanel(tabPanelProps: TabPanelProps) {
-    const tabContextProps = React.useContext(TabContext);
+export function useTabPanel(
+    tabPanelProps: TabPanelProps,
+): React.HTMLAttributes<HTMLDivElement> & {[key: `data-${string}`]: string | undefined} {
+    const tabContext = React.useContext(TabContext);
 
-    if (!tabContextProps) {
+    if (!tabContext) {
         throw new Error('<TabPanel> must be used within <TabProvider>');
     }
 
-    const currentValue = tabContextProps.value;
-    const parentId = tabContextProps.id;
+    const currentValue = tabContext.value;
+    const parentId = tabContext.id;
     const tabId = `${parentId}:t:${tabPanelProps.value}`;
     const panelId = `${parentId}:p:${tabPanelProps.value}`;
 
     const isSelected = currentValue === tabPanelProps.value;
 
+    const {value: _value, qa: _qa, ...htmlProps} = tabPanelProps;
+
     return {
+        ...htmlProps,
         role: 'tabpanel',
         'aria-labelledby': tabId,
         id: panelId,
-        style: tabPanelProps.style,
         className: bTabPanel({hidden: !isSelected}, tabPanelProps.className),
         'data-qa': tabPanelProps.qa,
-        ...filterDOMProps(tabPanelProps, {labelable: true}),
     };
 }

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -2,4 +2,13 @@ export {TabProvider} from './TabProvider';
 export {TabList} from './TabList';
 export {Tab} from './Tab';
 export {TabPanel} from './TabPanel';
-export type {TabProviderProps, TabListProps, TabProps, TabPanelProps, TabSize} from './types';
+export type {
+    TabProviderProps,
+    TabListProps,
+    TabProps,
+    TabButtonProps,
+    TabLinkProps,
+    TabComponentProps,
+    TabPanelProps,
+    TabSize,
+} from './types';

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 
 import type {LabelProps} from '../Label';
-import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
+import type {DOMProps, QAProps} from '../types';
 
 export type TabSize = 'm' | 'l' | 'xl';
 
@@ -11,7 +11,10 @@ export interface TabProviderProps {
     children?: React.ReactNode;
 }
 
-export interface TabListProps extends AriaLabelingProps, DOMProps, QAProps {
+export interface TabListProps
+    extends DOMProps,
+        QAProps,
+        Omit<React.HTMLAttributes<HTMLDivElement>, 'style'> {
     onUpdate?: (value: string) => void;
     value?: string;
     size?: TabSize;
@@ -20,12 +23,10 @@ export interface TabListProps extends AriaLabelingProps, DOMProps, QAProps {
     children?: React.ReactNode;
 }
 
-export interface TabProps extends AriaLabelingProps, DOMProps, QAProps {
+interface TabCommonProps extends QAProps, DOMProps {
     value: string;
-    title?: string;
     icon?: React.ReactNode;
     counter?: number | string;
-    href?: string;
     label?: {
         content: React.ReactNode;
         theme?: LabelProps['theme'];
@@ -34,7 +35,37 @@ export interface TabProps extends AriaLabelingProps, DOMProps, QAProps {
     children?: React.ReactNode;
 }
 
-export interface TabPanelProps extends AriaLabelingProps, DOMProps, QAProps {
+export interface TabButtonProps
+    extends TabCommonProps,
+        Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'disabled' | 'style'> {
+    component?: never;
+    href?: never;
+}
+
+export interface TabLinkProps
+    extends TabCommonProps,
+        Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'style'> {
+    component?: never;
+    href: string;
+}
+
+export type TabComponentElementType = Exclude<React.ElementType, 'a' | 'button'> | undefined;
+
+export type TabComponentProps<T extends Exclude<TabComponentElementType, undefined>> =
+    TabCommonProps &
+        React.ComponentPropsWithoutRef<T> & {
+            component: T;
+        };
+
+export type TabProps<T extends TabComponentElementType = undefined> =
+    | TabButtonProps
+    | TabLinkProps
+    | TabComponentProps<Exclude<T, undefined>>;
+
+export interface TabPanelProps
+    extends DOMProps,
+        QAProps,
+        Omit<React.HTMLAttributes<HTMLDivElement>, 'style'> {
     value: string;
     children?: React.ReactNode;
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhance the Tab component to support more flexible prop passing and component rendering

New Features:
- Add support for rendering Tab with a custom component type
- Allow passing through all props to the root component
- Improve type safety for Tab component props

Enhancements:
- Refactor Tab component to support more dynamic rendering
- Improve type definitions for Tab component
- Add more flexible prop handling in hooks

Documentation:
- Update README.md to reflect new Tab component capabilities
- Add documentation for new component prop and extended prop support