### PR TITLE
fix(Label): use `body-short` font for text content

### DIFF
--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -25,12 +25,11 @@ $transition-timing-function: ease-in-out;
     isolation: isolate;
 
     &__text {
-        @include mixins.text-body-1();
+        @include mixins.text-body-short();
         display: flex;
         align-items: baseline;
         margin: 0 var(--_--margin-inline);
         width: 100%;
-        line-height: var(--_--height);
         text-align: center;
         white-space: nowrap;
         overflow: hidden;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace text-body-1 mixin with text-body-short mixin in Label component text styling