### PR TITLE
fix(Popover): remove force safePolygon workaround

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -61,8 +61,7 @@ export function Popover({
     trigger,
     openDelay = DEFAULT_OPEN_DELAY,
     closeDelay = DEFAULT_CLOSE_DELAY,
-    // Force enable to workaround https://github.com/floating-ui/floating-ui/issues/3261
-    // enableSafePolygon,
+    enableSafePolygon,
     className,
     ...restProps
 }: PopoverProps) {
@@ -84,7 +83,7 @@ export function Popover({
         enabled: trigger !== 'click',
         delay: {open: openDelay, close: closeDelay},
         move: false,
-        handleClose: safePolygon(),
+        handleClose: enableSafePolygon ? safePolygon() : undefined,
     });
     const click = useClick(context);
     const role = useRole(context, {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Restore the original behavior of safePolygon handling by making it optional and controllable via the enableSafePolygon prop