### PR TITLE
fix(Breadcrumbs): change more button border radius to default --g-border-radius-m

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -79,10 +79,6 @@ $block: '.#{variables.$ns}breadcrumbs';
         padding: 0 var(--g-spacing-2);
     }
 
-    &__more-button {
-        --g-button-border-radius: var(--g-focus-border-radius);
-    }
-
     &__menu {
         margin-inline: calc(-1 * var(--g-spacing-2));
 

--- a/src/components/Breadcrumbs/BreadcrumbsDropdownMenu.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsDropdownMenu.tsx
@@ -83,7 +83,6 @@ export function BreadcrumbsDropdownMenu({
                 {...getReferenceProps()}
                 title={i18n('label_more')}
                 aria-label={i18n('label_more')}
-                className={b('more-button')}
                 size="s"
                 view="flat"
                 disabled={disabled}


### PR DESCRIPTION
Closes #2132 

## Summary by Sourcery

Bug Fixes:
- Remove custom border radius styling for the Breadcrumbs more button, reverting to the default medium border radius