### PR TITLE
fix: tree shaking when using configure

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -67,7 +67,6 @@ export * from './utils/event-broker';
 export {getComponentName} from './utils/getComponentName';
 export * from './utils/withEventBrokerDomHandlers';
 export * from './utils/layer-manager';
-export {Lang, configure, getConfig} from './utils/configure';
 export * from './utils/xpath';
 export {getUniqId} from './utils/common';
 export {getElementRef} from './utils/getElementRef';

--- a/src/i18n/addLanguageKeysets.test.ts
+++ b/src/i18n/addLanguageKeysets.test.ts
@@ -1,5 +1,5 @@
-import {configure} from '../components';
 import i18n from '../components/ActionsPanel/i18n';
+import {configure} from '../utils/configure';
 
 import {addLanguageKeysets} from './addLanguageKeysets';
 import type {PartialKeysets} from './types';

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,6 +1,6 @@
 import {I18N} from '@gravity-ui/i18n';
 
-import {getConfig, subscribeConfigure} from '../components/utils/configure';
+import {getConfig, subscribeConfigure} from '../utils/configure';
 
 const {lang, fallbackLang} = getConfig();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export {Lang, configure, getConfig} from './utils/configure';
 export * from './components';
 export * from './hooks';
 export * from './utils/dom';

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,4 +1,4 @@
-import type {StringWithSuggest} from '../../types/utils';
+import type {StringWithSuggest} from '../types/utils';
 
 export enum Lang {
     Ru = 'ru',


### PR DESCRIPTION
When using the `configure` function, all components are included in the production build when bundling via Vite.
Tree-shaking does not work.

The problem occurs due to barrel re-exports. To prevent this issue, it's necessary to move the configure export to a higher level.

![telegram-cloud-photo-size-2-5188458929410141926-y](https://github.com/user-attachments/assets/f6a357fb-c25a-4989-884e-4a43d7eccb74)

## Summary by Sourcery

Refactor the configuration and export of language configuration to improve tree shaking in Vite builds

Bug Fixes:
- Resolve tree shaking issues when using the configure function in production builds by restructuring exports

Enhancements:
- Moved configuration-related exports to a higher-level module to enable better tree shaking