### PR TITLE
feat(Popover): add zIndex to Popover props

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -36,6 +36,7 @@ export interface PopoverProps
             | 'initialFocus'
             | 'returnFocus'
             | 'disableVisuallyHiddenDismiss'
+            | 'zIndex'
         > {
     children:
         | ((props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => React.ReactElement)


### PR DESCRIPTION
Hello!
As part of the task [#298](https://github.com/gravity-ui/markdown-editor/issues/298) in Markdown Editor, we encountered the difficulty of managing layers of drop-down elements of the HelpMark component, which uses PopoverProps. To fix the defect with the overlapping of elements, when the editor toolbar goes into the position sticky, it is necessary to manage the zindex of the drop-down element of the HelpMark component.

## Summary by Sourcery

New Features:
- Introduce a new zIndex prop to the Popover component to provide more flexibility in layering and positioning

