### PR TITLE
fix(Dialog): pass className to `DialogBody` content

### DIFF
--- a/src/components/Dialog/DialogBody/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody/DialogBody.tsx
@@ -24,8 +24,8 @@ export function DialogBody(props: DialogBodyProps) {
     });
 
     return (
-        <div className={b({'has-borders': hasBorders}, className)}>
-            <div ref={contentRef} className={b('content')}>
+        <div className={b({'has-borders': hasBorders})}>
+            <div ref={contentRef} className={b('content', className)}>
                 {props.children}
             </div>
         </div>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly apply the passed className to the inner content div of the DialogBody component instead of the outer wrapper div