### PR TITLE
perf(Table): do not create empty values array in getBodyCellContent

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -179,6 +179,8 @@ interface TableDefaultProps {
 
 const b = block('table');
 
+const EMPTY_VALUES = [undefined, null, ''];
+
 export class Table<I extends TableDataItem = Record<string, string>> extends React.Component<
     TableProps<I>,
     TableState
@@ -248,7 +250,7 @@ export class Table<I extends TableDataItem = Record<string, string>> extends Rea
         } else if (_has(item, id)) {
             value = _get(item, id);
         }
-        if ([undefined, null, ''].includes(value as any) && placeholderValue) {
+        if (EMPTY_VALUES.includes(value as any) && placeholderValue) {
             return placeholderValue;
         }
 


### PR DESCRIPTION
Currently, the array of `undefined`, `null` and `''` is created and then discarded by the garbage collector on every call to `getBodyCellContent`
For 100 rows and 3 columns that is 300 allocations of an array. For bigger tables the performance overhead would be bigger.
On my machine (mac with M3 pro), for a moderately small table of 100 rows and 3 columns firefox claims to have spent 23 ms garbage collecting inside this function. This isn't much, but the optimization is easy.

This PR extracts this array into a separate variable outside of the class

## Summary by Sourcery

Optimize performance by extracting an empty values array outside of the Table component to reduce unnecessary array allocations

Enhancements:
- Improve performance by moving the empty values check array to a constant outside the class, reducing garbage collection overhead

Chores:
- Refactor empty values check to use a pre-defined constant array