### PR TITLE
fix(TextInput): make caret transparent when unfocused

### DIFF
--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -102,6 +102,10 @@ $block: '.#{variables.$ns}text-input';
             outline: none;
         }
 
+        &:not(:focus) {
+            caret-color: transparent;
+        }
+
         &[type='number'] {
             appearance: textfield;
         }


### PR DESCRIPTION
Issue: https://github.com/gravity-ui/uikit/issues/2244

## Summary by Sourcery

Bug Fixes:
- Resolve visual issue with text input caret visibility when the input is not focused