### PR TITLE
Bug Demo: Select doesn't close on Esc inside a Dialog

### DIFF
--- a/src/components/Dialog/__stories__/Dialog.stories.tsx
+++ b/src/components/Dialog/__stories__/Dialog.stories.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import type {Meta, StoryFn} from '@storybook/react';
 
 import {Button} from '../../Button';
-import {Dialog} from '../Dialog';
+import {Select} from '../../Select/Select';
 import type {DialogProps} from '../Dialog';
+import {Dialog} from '../Dialog';
 
 import {DialogShowcase} from './DialogShowcase';
 
@@ -21,6 +22,9 @@ export default {
 const DefaultTemplate: StoryFn<DialogProps & {showError: boolean}> = ({showError, ...args}) => {
     const dialogTitleId = 'app-confirmation-dialog-title';
     const [open, setOpen] = React.useState(false);
+
+    const initialFocusRef = React.useRef<HTMLButtonElement>(null);
+
     return (
         <React.Fragment>
             <Button view="normal" onClick={() => setOpen(true)}>
@@ -30,13 +34,21 @@ const DefaultTemplate: StoryFn<DialogProps & {showError: boolean}> = ({showError
                 {...args}
                 onClose={() => setOpen(false)}
                 open={open}
-                onEnterKeyDown={() => {
-                    alert('onEnterKeyDown');
-                }}
+                initialFocus={initialFocusRef}
                 aria-labelledby={dialogTitleId}
             >
                 <Dialog.Header caption="Caption" id={dialogTitleId} />
-                <Dialog.Body>Dialog.Body</Dialog.Body>
+                <Dialog.Body>
+                    <Select
+                        ref={initialFocusRef}
+                        options={[
+                            {value: 'valueA', content: 'Value A'},
+                            {value: 'valueB', content: 'Value B'},
+                            {value: 'valueC', content: 'Value C'},
+                            {value: 'valueD', content: 'Value D'},
+                        ]}
+                    />
+                </Dialog.Body>
                 <Dialog.Footer
                     onClickButtonCancel={() => setOpen(false)}
                     onClickButtonApply={() => alert('onApply')}


### PR DESCRIPTION
### How to reproduce

- Open [storybook for Dialog](https://preview.gravity-ui.com/uikit/2251/?path=/story/components-overlays-dialog--default)
- Open the dialog
- Open the select
- Press Esc
- Select doesn't close

## Summary by Sourcery

Update the Dialog story to include a Select component to demonstrate an interaction issue.

Tests:
- Add a Select component within the Dialog story.
- Set initial focus on the Select component in the Dialog story.