### PR TITLE
fix(Select): fix closing inside Dialog

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -199,6 +199,10 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
                 e.preventDefault();
                 toggleOpen();
             }
+            if (e.key === KeyCode.ESCAPE && open) {
+                e.preventDefault();
+                toggleOpen(false);
+            }
 
             listRef?.current?.onKeyDown(e);
         },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -200,7 +200,6 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
                 toggleOpen();
             }
             if (e.key === KeyCode.ESCAPE && open) {
-                e.preventDefault();
                 toggleOpen(false);
             }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve Select component's keyboard interaction, specifically handling Escape key to close the popup in different contexts

Bug Fixes:
- Fixed Select component not closing on Escape key press, including when used inside a Dialog

Tests:
- Added test cases for closing Select popup on Escape key press in standard and Dialog contexts