### PR TITLE
ci: fix playwright report path

### DIFF
--- a/.github/workflows/pr-visual-tests.yml
+++ b/.github/workflows/pr-visual-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: ./playwright-report
+          path: ./playwright/report
           retention-days: 1
       - name: Save PR ID
         if: always()


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Corrected the Playwright report artifact upload path from './playwright-report' to './playwright/report'