### PR TITLE
ci: use github app token for actions

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -14,9 +14,15 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GRAVITY_UI_APP_ID }}
+          private-key: ${{ secrets.GRAVITY_UI_APP_PRIVATE_KEY }}
       - uses: gravity-ui/preview-deploy-action@v2
         with:
           project: uikit
-          github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           s3-key-id: ${{ secrets.STORYBOOK_S3_KEY_ID }}
           s3-secret-key: ${{ secrets.STORYBOOK_S3_SECRET_KEY }}

--- a/.github/workflows/pr-visual-tests-report.yml
+++ b/.github/workflows/pr-visual-tests-report.yml
@@ -12,10 +12,16 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GRAVITY_UI_APP_ID }}
+          private-key: ${{ secrets.GRAVITY_UI_APP_PRIVATE_KEY }}
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Extract PR Number
         id: pr
@@ -37,7 +43,7 @@ jobs:
       - name: Create Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           number: ${{ steps.pr.outputs.id }}
           header: visual tests report
           message: '[Visual Tests Report](https://storage.yandexcloud.net/playwright-reports/uikit/pulls/${{ steps.pr.outputs.id }}/index.html) is ready.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GRAVITY_UI_APP_ID }}
+          private-key: ${{ secrets.GRAVITY_UI_APP_PRIVATE_KEY }}
       - name: Release from ${{ github.ref_name }}
         uses: gravity-ui/release-action@v1
         with:
-          github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
           node-version: 20
           default-branch: ${{ github.ref_name != 'main' && github.ref_name || null }}


### PR DESCRIPTION
## Summary by Sourcery

Migrate CI workflows to use a GitHub App token instead of the GRAVITY_UI_BOT_GITHUB_TOKEN secret

CI:
- Add a step to generate a GitHub App token in the pr-visual-tests-report workflow
- Switch artifact download and PR comment actions to use the generated token
- Remove direct github-token inputs from pr-preview-deploy and release workflows