### PR TITLE
fix(ClipboardButton): correct types

### DIFF
--- a/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/src/components/ClipboardButton/ClipboardButton.tsx
@@ -22,7 +22,7 @@ const b = block('clipboard-button');
 
 export interface ClipboardButtonProps
     extends Omit<CopyToClipboardProps, 'children'>,
-        Omit<ClipboardButtonComponentProps, 'status' | 'closeDelay' | 'onClick'> {}
+        Omit<ClipboardButtonComponentProps, 'status' | 'closeDelay'> {}
 
 interface ClipboardButtonComponentProps extends Omit<ButtonButtonProps, 'onCopy'> {
     status: CopyToClipboardStatus;
@@ -58,8 +58,6 @@ const ClipboardButtonComponent = (props: ClipboardButtonComponentProps) => {
         children,
         iconPosition = 'start',
         closeDelay,
-        onMouseEnter,
-        onFocus,
         ...rest
     } = props;
 
@@ -75,14 +73,7 @@ const ClipboardButtonComponent = (props: ClipboardButtonComponentProps) => {
             disabled={!hasTooltip}
             closeDelay={closeDelay}
         >
-            <Button
-                view={view}
-                size={size}
-                onMouseEnter={onMouseEnter}
-                onFocus={onFocus}
-                aria-label={tooltipInitialText}
-                {...rest}
-            >
+            <Button view={view} size={size} aria-label={tooltipInitialText} {...rest}>
                 {iconPosition === 'start' ? buttonIcon : null}
                 {children}
                 {iconPosition === 'end' ? buttonIcon : null}


### PR DESCRIPTION
## Summary by Sourcery

Fix ClipboardButtonProps typing to include onClick and ensure event handlers are forwarded to the underlying Button component.

Bug Fixes:
- Restore onClick in ClipboardButtonProps to correctly type click handlers.
- Forward onMouseEnter and onFocus events to the underlying Button by removing explicit destructuring.

Enhancements:
- Simplify Button JSX to pass all remaining props directly.