### PR TITLE
fix(unstable_Menu): tweak paddings and offsets

### DIFF
--- a/src/components/lab/Menu/Menu.tsx
+++ b/src/components/lab/Menu/Menu.tsx
@@ -148,7 +148,14 @@ export function Menu({
         onNavigate: setActiveIndex,
         rtl: isRTL,
     });
-    const middlewares = [offset({mainAxis: 4, alignmentAxis: isNested ? -4 : 0}), flip(), shift()];
+    const detectOverflowOptions = {
+        padding: 4,
+    };
+    const middlewares = [
+        offset({mainAxis: isNested ? 3 : 4, alignmentAxis: isNested ? -4 : 0}),
+        flip({...detectOverflowOptions}),
+        shift({...detectOverflowOptions}),
+    ];
     const interactions = [hover, click, dismiss, role, listNavigation];
     const {getReferenceProps, getItemProps} = useInteractions(interactions);
 


### PR DESCRIPTION
## Summary by Sourcery

Tweak paddings and offsets in the Menu component to ensure consistent spacing and overflow handling, particularly for nested menus.

Enhancements:
- Introduce a shared detectOverflowOptions object to apply a consistent 4px padding for flip and shift middlewares
- Adjust the offset middleware’s mainAxis value to 3px for nested menus (4px otherwise)