### PR TITLE
feat(Select): add fixed top zone on mobile

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,6 +65,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
         renderSelectedOption,
         renderEmptyOptions,
         renderPopup = DEFAULT_RENDER_POPUP,
+        renderTop,
         getOptionHeight,
         getOptionGroupHeight,
         filterOption,
@@ -311,6 +312,18 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
         return <EmptyOptions filter={filter} renderEmptyOptions={renderEmptyOptions} />;
     };
 
+    const _renderPopupFilter = () => {
+        if (renderTop && mobile) {
+            return () => null;
+        }
+
+        if (renderTop) {
+            return () => renderTop({renderFilter: _renderFilter});
+        }
+
+        return _renderFilter;
+    };
+
     return (
         <div
             ref={controlWrapRef}
@@ -372,8 +385,12 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function 
                           }
                         : undefined
                 }
+                topContent={renderTop?.({renderFilter: _renderFilter})}
             >
-                {renderPopup({renderFilter: _renderFilter, renderList: _renderList})}
+                {renderPopup({
+                    renderFilter: _renderPopupFilter(),
+                    renderList: _renderList,
+                })}
             </SelectPopup>
             <OuterAdditionalContent
                 errorMessage={isErrorMsgVisible ? errorMessage : null}

--- a/src/components/Select/__stories__/Select.stories.tsx
+++ b/src/components/Select/__stories__/Select.stories.tsx
@@ -383,6 +383,89 @@ export const WithVirtualizedList: Story = {
     },
 };
 
+export const WithVirtualizedListAndCustomPopup: Story = {
+    tags: ['!dev'],
+    decorators: [WithTitle],
+    args: {
+        ...showcaseArgs,
+        filterable: true,
+    },
+    render: (args) => {
+        const [{value}, setArgs] = useArgs<typeof args>();
+
+        return (
+            <Select
+                {...args}
+                value={value}
+                onUpdate={(values) => setArgs({value: values})}
+                popupWidth={args.multiple ? 120 : undefined}
+                renderPopup={({renderFilter, renderList}) => {
+                    return (
+                        <React.Fragment>
+                            <div>{'---- Before Filter ----'}</div>
+                            {renderFilter()}
+                            <div>{'---- After Filter, Before List ----'}</div>
+                            {renderList()}
+                            <div>{'---- After List ----'}</div>
+                        </React.Fragment>
+                    );
+                }}
+            >
+                {Array.from(new Array(100)).map((_, index) => (
+                    <Select.Option key={index} value={`val${index + 1}`}>
+                        Value {index + 1}
+                    </Select.Option>
+                ))}
+            </Select>
+        );
+    },
+};
+
+export const WithTopContent: Story = {
+    tags: ['!dev'],
+    decorators: [WithTitle],
+    args: {
+        ...showcaseArgs,
+        filterable: true,
+    },
+    render: (args) => {
+        const [{value}, setArgs] = useArgs<typeof args>();
+
+        return (
+            <Select
+                {...args}
+                value={value}
+                onUpdate={(values) => setArgs({value: values})}
+                popupWidth={args.multiple ? 120 : undefined}
+                renderTop={({renderFilter}) => {
+                    return (
+                        <React.Fragment>
+                            <div>{'---- Before Filter ----'}</div>
+                            {renderFilter()}
+                        </React.Fragment>
+                    );
+                }}
+                renderPopup={({renderFilter, renderList}) => {
+                    return (
+                        <React.Fragment>
+                            {renderFilter()}
+                            <div>{'---- After Filter, Before List ----'}</div>
+                            {renderList()}
+                            <div>{'---- After List ----'}</div>
+                        </React.Fragment>
+                    );
+                }}
+            >
+                {Array.from(new Array(100)).map((_, index) => (
+                    <Select.Option key={index} value={`val${index + 1}`}>
+                        Value {index + 1}
+                    </Select.Option>
+                ))}
+            </Select>
+        );
+    },
+};
+
 export const WithCustomRendererAndTooltipAtDisabledItem: Story = {
     tags: ['!dev'],
     decorators: [WithTitle],

--- a/src/components/Select/__stories__/Showcase.mdx
+++ b/src/components/Select/__stories__/Showcase.mdx
@@ -14,6 +14,8 @@ import * as Stories from './Select.stories';
 <Canvas of={Stories.WithCustomRendererAndTooltipAtDisabledItem} />
 <Canvas of={Stories.WithCustomFilterSection} />
 <Canvas of={Stories.WithCustomPopup} />
+<Canvas of={Stories.WithVirtualizedListAndCustomPopup} />
+<Canvas of={Stories.WithTopContent} />
 
 ## With errors
 

--- a/src/components/Select/components/SelectPopup/SelectPopup.tsx
+++ b/src/components/Select/components/SelectPopup/SelectPopup.tsx
@@ -33,6 +33,7 @@ export const SelectPopup = React.forwardRef<HTMLDivElement, SelectPopupProps>(
             virtualized,
             mobile,
             id,
+            topContent,
         },
         ref,
     ) =>
@@ -42,6 +43,7 @@ export const SelectPopup = React.forwardRef<HTMLDivElement, SelectPopupProps>(
                 className={className}
                 visible={Boolean(open)}
                 onClose={handleClose}
+                topContent={topContent}
             >
                 {children}
             </Sheet>

--- a/src/components/Select/components/SelectPopup/types.ts
+++ b/src/components/Select/components/SelectPopup/types.ts
@@ -11,6 +11,7 @@ export type SelectPopupProps = {
     placement?: PopupPlacement;
     controlRef?: React.RefObject<HTMLElement>;
     children?: React.ReactNode;
+    topContent?: React.ReactNode;
     className?: string;
     disablePortal?: boolean;
     virtualized?: boolean;

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -63,6 +63,10 @@ export type SelectRenderPopup = (popupItems: {
     renderList: () => React.JSX.Element;
 }) => React.ReactElement;
 
+export type SelectRenderTop = (popupItems: {
+    renderFilter: () => React.JSX.Element | null;
+}) => React.ReactElement;
+
 export type SelectFilterInputProps = {value: string} & Pick<
     React.InputHTMLAttributes<HTMLInputElement>,
     | 'placeholder'
@@ -103,6 +107,7 @@ export type SelectProps<T = any> = AriaLabelingProps &
         renderSelectedOption?: (option: SelectOption<T>, index: number) => React.ReactElement;
         renderEmptyOptions?: ({filter}: {filter: string}) => React.ReactElement;
         renderPopup?: SelectRenderPopup;
+        renderTop?: SelectRenderTop;
         renderCounter?: SelectRenderCounter;
         getOptionHeight?: (option: SelectOption<T>, index: number) => number;
         getOptionGroupHeight?: (option: SelectOptionGroup<T>, index: number) => number;

--- a/src/components/Sheet/Sheet.scss
+++ b/src/components/Sheet/Sheet.scss
@@ -70,6 +70,11 @@ $block: '.#{variables.$ns}sheet';
         background-color: var(--g-color-line-generic);
     }
 
+    &__sheet-top-container {
+        background-color: var(--g-sheet-background-color, var(--g-color-base-float));
+        padding: var(--g-sheet-content-padding, 0 10px);
+    }
+
     &__sheet-scroll-container {
         box-sizing: border-box;
         max-height: calc(100% - #{$top-height});

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -16,6 +16,8 @@ import './Sheet.scss';
 export interface SheetProps extends Pick<PortalProps, 'container' | 'disablePortal'>, QAProps {
     children?: React.ReactNode;
     onClose?: () => void;
+    /** Сontent fixed at the top of sheet */
+    topContent?: React.ReactNode;
     /** Show/hide sheet */
     visible: boolean;
     /** ID of the sheet, used as hash in URL. It's important to specify different `id` values if there can be more than one sheet on the page */
@@ -40,6 +42,7 @@ export interface SheetProps extends Pick<PortalProps, 'container' | 'disablePort
 
 export const Sheet = ({
     children,
+    topContent,
     onClose,
     visible,
     id,
@@ -87,6 +90,7 @@ export const Sheet = ({
             >
                 <SheetContentContainer
                     id={id}
+                    topContent={topContent}
                     content={children}
                     contentClassName={contentClassName}
                     swipeAreaClassName={swipeAreaClassName}

--- a/src/components/Sheet/SheetContent.tsx
+++ b/src/components/Sheet/SheetContent.tsx
@@ -39,6 +39,7 @@ interface SheetContentBaseProps {
     hideTopBar?: boolean;
     maxContentHeightCoefficient?: number;
     alwaysFullHeight?: boolean;
+    topContent?: React.ReactNode;
 }
 
 interface SheetContentDefaultProps {
@@ -81,6 +82,7 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
     sheetTopRef = React.createRef<HTMLDivElement>();
     sheetMarginBoxRef = React.createRef<HTMLDivElement>();
     sheetScrollContainerRef = React.createRef<HTMLDivElement>();
+    sheetTopContainerRef = React.createRef<HTMLDivElement>();
     velocityTracker = new VelocityTracker();
     observer: ResizeObserver | null = null;
     resizeWindowTimer: number | null = null;
@@ -131,7 +133,8 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
     }
 
     render() {
-        const {content, contentClassName, swipeAreaClassName, hideTopBar, title} = this.props;
+        const {content, contentClassName, swipeAreaClassName, hideTopBar, title, topContent} =
+            this.props;
 
         const {deltaY, swipeAreaTouched, contentTouched, veilTouched} = this.state;
 
@@ -180,6 +183,13 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
                         onTouchMove={this.onSwipeAriaTouchMove}
                         onTouchEnd={this.onSwipeAriaTouchEnd}
                     />
+                    <div
+                        ref={this.sheetTopContainerRef}
+                        className={sheetBlock('sheet-top-container')}
+                    >
+                        {title && <div className={sheetBlock('sheet-content-title')}>{title}</div>}
+                        <div className={sheetBlock('sheet-top-content')}>{topContent}</div>
+                    </div>
                     {/* TODO: extract to external component ContentArea */}
                     <div
                         ref={this.sheetScrollContainerRef}
@@ -195,11 +205,6 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
                         >
                             <div className={sheetBlock('sheet-margin-box-border-compensation')}>
                                 <div className={sheetBlock('sheet-content', contentClassName)}>
-                                    {title && (
-                                        <div className={sheetBlock('sheet-content-title')}>
-                                            {title}
-                                        </div>
-                                    )}
                                     {content}
                                 </div>
                             </div>
@@ -224,6 +229,10 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
 
     private get sheetScrollTop() {
         return this.sheetScrollContainerRef.current?.scrollTop || 0;
+    }
+
+    private get sheetTopContentHeight() {
+        return this.sheetTopContainerRef.current?.getBoundingClientRect().height || 0;
     }
 
     private get sheetContentHeight() {

--- a/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.scss
+++ b/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.scss
@@ -8,7 +8,7 @@
         inset-block-start: 0;
         display: flex;
         justify-content: center;
-        margin-block-end: 20px;
+        padding-block-end: 20px;
         background-color: var(--g-color-base-background);
         z-index: 1;
     }
@@ -27,10 +27,10 @@
     }
 
     &__content-item {
-        margin-block-end: 15px;
+        padding-block-end: 15px;
 
         &:last-child {
-            margin-block-end: 25px;
+            padding-block-end: 25px;
         }
     }
 }

--- a/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.stories.tsx
+++ b/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.stories.tsx
@@ -83,10 +83,12 @@ export const Default: StoryFn<SheetProps> = ({
                 onClose={() => setVisible(false)}
                 title={withTitle ? 'Sheet title' : undefined}
                 qa={DEFAULT_SHEET_QA}
+                topContent={
+                    <div className={b('content-item')}>
+                        <TextInput />
+                    </div>
+                }
             >
-                <div className={b('content-item')}>
-                    <TextInput />
-                </div>
                 <div className={b('content-item', b('checkbox'))}>
                     <Checkbox
                         content="Extra content"


### PR DESCRIPTION
**Before:**

https://github.com/user-attachments/assets/e24860fc-7309-4c1c-98ee-f0c16a4d4b15



**After:**

https://github.com/user-attachments/assets/490f8d9a-d520-4927-98df-51aeb9d89c2f


If you customize the renderPopup for the mobile version, the following drawbacks arise:
- High class nesting (deep hierarchy) requiring display properties to be overridden
- Breaks the swipe-on-scroll behavior

## Summary by Sourcery

Introduce a fixed top zone on mobile for both Sheet and Select components by adding dedicated props and separating top content from scrollable areas.

New Features:
- Add `topContent` prop to `Sheet` and `SheetContent` to render non-scrolling header content.
- Add `renderTop` prop to `Select` and `SelectPopup` to enable a customizable fixed top section above the filter.
- Introduce new Storybook stories (`WithVirtualizedListAndCustomPopup`, `WithTopContent`) and update `DefaultShowcase` to demonstrate the fixed top zone.

Enhancements:
- Refactor sheet layout to isolate a top container and compute its height for proper scroll area adjustment.
- Replace bottom margins with padding in Sheet story styles to maintain consistent spacing.
- Adjust Select popup rendering logic to integrate `renderTop` and preserve swipe-on-scroll behavior on mobile.

Documentation:
- Update Storybook MDX to include the new top content stories