### PR TITLE
fix(Dialog): remove Dialog.Body content node

### DIFF
--- a/src/components/Dialog/DialogBody/DialogBody.scss
+++ b/src/components/Dialog/DialogBody/DialogBody.scss
@@ -6,13 +6,10 @@ $block: '.#{variables.$ns}dialog-body';
     padding: 10px var(--_--side-padding);
     flex: 1 1 auto;
     overflow-y: auto;
+    transition: height 0.35s ease-in-out;
 
     &_has-borders {
         border-block-start: 1px solid var(--g-color-line-generic);
         border-block-end: 1px solid var(--g-color-line-generic);
-    }
-
-    &__content {
-        transition: height 0.35s ease-in-out;
     }
 }

--- a/src/components/Dialog/DialogBody/DialogBody.tsx
+++ b/src/components/Dialog/DialogBody/DialogBody.tsx
@@ -24,10 +24,8 @@ export function DialogBody(props: DialogBodyProps) {
     });
 
     return (
-        <div className={b({'has-borders': hasBorders})}>
-            <div ref={contentRef} className={b('content', className)}>
-                {props.children}
-            </div>
+        <div ref={contentRef} className={b({'has-borders': hasBorders}, className)}>
+            {props.children}
         </div>
     );
 }

--- a/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
+++ b/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
@@ -107,10 +107,8 @@ function calculateNodeHeight(node: HTMLElement) {
         return node.clientHeight;
     }
 
-    const paddingTop = Number(computedStyle.getPropertyValue('padding-top').replace('px', ''));
-    const paddingBottom = Number(
-        computedStyle.getPropertyValue('padding-bottom').replace('px', ''),
-    );
+    const paddingTop = parseFloat(computedStyle.getPropertyValue('padding-top'));
+    const paddingBottom = parseFloat(computedStyle.getPropertyValue('padding-bottom'));
 
     return node.clientHeight - paddingTop - paddingBottom;
 }

--- a/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
+++ b/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
@@ -25,7 +25,7 @@ export function useAnimateHeight({
                 if (!mutations.length || !isTransitioningHeight.current) return;
 
                 // If node content changes mid animation, we reset height to immediately animate towards the new height
-                previousHeight.current = node.clientHeight;
+                previousHeight.current = calculateNodeHeight(node);
                 isTransitioningHeight.current = false;
                 node.style.height = '';
                 node.style.overflowY = overflowY.current;
@@ -57,7 +57,7 @@ export function useAnimateHeight({
                 return;
             }
 
-            const contentHeight = node.clientHeight;
+            const contentHeight = calculateNodeHeight(node);
             if (!previousHeight.current && !overflowY.current) {
                 previousHeight.current = contentHeight;
                 overflowY.current = node.style.overflowY;
@@ -99,4 +99,18 @@ export function useAnimateHeight({
     );
 
     useResizeObserver({ref: enabled ? ref : undefined, onResize: handleResize});
+}
+
+function calculateNodeHeight(node: HTMLElement) {
+    const computedStyle = window.getComputedStyle(node, null);
+    if (computedStyle.getPropertyValue('box-sizing') === 'border-box') {
+        return node.clientHeight;
+    }
+
+    const paddingTop = Number(computedStyle.getPropertyValue('padding-top').replace('px', ''));
+    const paddingBottom = Number(
+        computedStyle.getPropertyValue('padding-bottom').replace('px', ''),
+    );
+
+    return node.clientHeight - paddingTop - paddingBottom;
 }


### PR DESCRIPTION
## Summary by Sourcery

Fix height animation for Dialog content and simplify DialogBody structure

Bug Fixes:
- Use a calculateNodeHeight helper to account for padding and box-sizing when animating height.

Enhancements:
- Extract calculateNodeHeight and replace direct clientHeight references in useAnimateHeight.
- Simplify DialogBody markup by removing the nested content wrapper, merging classes, and moving the height transition style to the root element.