### PR TITLE
fix(ThemeProvider): do not set direction in case of null body

### DIFF
--- a/src/components/theme/dom-helpers.ts
+++ b/src/components/theme/dom-helpers.ts
@@ -55,6 +55,11 @@ export function updateBodyClassName({
 export function updateBodyDirection(direction: Direction) {
     const bodyEl = document.body;
 
+    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-body-dev
+    if (!bodyEl) {
+        return;
+    }
+
     if (direction === DEFAULT_DIRECTION) {
         bodyEl.removeAttribute('dir');
     } else {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5f1a7638-0e65-4c50-a284-14c8eb4d0738)

## Summary by Sourcery

Bug Fixes:
- Add null check in updateBodyDirection to skip setting dir attribute if document.body is not available