### PR TITLE
Custom icon with table actions

### DIFF
--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -7,6 +7,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 
 import type {TableAction, TableSettingsData} from '..';
+import {CheckboxDashIcon} from '../../Checkbox/CheckboxDashIcon';
 import {Icon} from '../../Icon';
 import {TreeSelect} from '../../TreeSelect/TreeSelect';
 import {Table} from '../Table';
@@ -184,15 +185,22 @@ const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
                 }}
             />
             <br />
-            <h3>{'with rowActionsIcon property'}</h3>
+            <h3>{'with rowActionsIcon propert as a SVG sprite'}</h3>
             <TableWithAction
                 {...args}
                 getRowActions={getRowActions}
-                rowActionsIcon={CircleChevronDownFill}
+                rowActionsIcon={<CheckboxDashIcon />}
             />
             <br />
-            <h3>{'without rowActionsIcon property'}</h3>
-            <TableWithAction {...args} getRowActions={getRowActions} />
+            <h3>{'with rowActionsIcon property as a string'}</h3>
+            <TableWithAction {...args} getRowActions={getRowActions} rowActionsIcon="⭐" />
+
+            <h3>{'with rowActionsIcon property as a react component'}</h3>
+            <TableWithAction
+                {...args}
+                getRowActions={getRowActions}
+                rowActionsIcon={<Icon data={CircleChevronDownFill} size={12} />}
+            />
         </React.Fragment>
     );
 };

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -7,7 +7,6 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 
 import type {TableAction, TableSettingsData} from '..';
-import {CheckboxDashIcon} from '../../Checkbox/CheckboxDashIcon';
 import {Icon} from '../../Icon';
 import {TreeSelect} from '../../TreeSelect/TreeSelect';
 import {Table} from '../Table';
@@ -185,11 +184,21 @@ const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
                 }}
             />
             <br />
-            <h3>{'with rowActionsIcon propert as a SVG sprite'}</h3>
+            <h3>{'with rowActionsIcon propert as a SVG'}</h3>
             <TableWithAction
                 {...args}
                 getRowActions={getRowActions}
-                rowActionsIcon={<CheckboxDashIcon />}
+                rowActionsIcon={
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 17 17"
+                        width="16"
+                        height="16"
+                        fill="currentColor"
+                    >
+                        <path d="M4 7h9v3H4z" />
+                    </svg>
+                }
             />
             <br />
             <h3>{'with rowActionsIcon property as a string'}</h3>

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Pencil} from '@gravity-ui/icons';
+import {CircleChevronDownFill, Pencil} from '@gravity-ui/icons';
 import {action} from '@storybook/addon-actions';
 import type {Meta, StoryFn} from '@storybook/react';
 import _cloneDeep from 'lodash/cloneDeep';
@@ -183,6 +183,16 @@ const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
                     );
                 }}
             />
+            <br />
+            <h3>{'with rowActionsIcon property'}</h3>
+            <TableWithAction
+                {...args}
+                getRowActions={getRowActions}
+                rowActionsIcon={CircleChevronDownFill}
+            />
+            <br />
+            <h3>{'without rowActionsIcon property'}</h3>
+            <TableWithAction {...args} getRowActions={getRowActions} />
         </React.Fragment>
     );
 };

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -116,6 +116,20 @@ Adaptive.args = {
     data: data.slice(0, 2),
 };
 
+const svgIconTest = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 17 17"
+            width="16"
+            height="16"
+            fill="currentColor"
+        >
+            <path d="M4 7h9v3H4z" />
+        </svg>
+    );
+};
+
 // ---------------------------------
 const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
     const getRowActions = (item: DataItem, index: number): TableAction<DataItem>[] => [
@@ -188,17 +202,7 @@ const WithTableActionsTemplate: StoryFn<TableProps<DataItem>> = (args) => {
             <TableWithAction
                 {...args}
                 getRowActions={getRowActions}
-                rowActionsIcon={
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 17 17"
-                        width="16"
-                        height="16"
-                        fill="currentColor"
-                    >
-                        <path d="M4 7h9v3H4z" />
-                    </svg>
-                }
+                rowActionsIcon={svgIconTest()}
             />
             <br />
             <h3>{'with rowActionsIcon property as a string'}</h3>

--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -76,7 +76,7 @@ export interface WithTableActionsProps<I> {
     getRowActions?: (item: I, index: number) => TableActionConfig<I>[];
     renderRowActions?: (props: RenderRowActionsProps<I>) => React.ReactNode;
     rowActionsSize?: TableRowActionsSize;
-    rowActionsIcon?: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
+    rowActionsIcon?: React.ReactNode;
 }
 
 interface WithTableActionsState<I> {
@@ -192,7 +192,7 @@ const DefaultRowActions = <I extends TableDataItem>({
                 aria-expanded={isPopupOpen}
                 aria-controls={rowId}
             >
-                <Icon data={rowActionsIcon || Ellipsis} />
+                {rowActionsIcon || <Icon data={Ellipsis} />}
             </Button>
         </div>
     );

--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -76,6 +76,7 @@ export interface WithTableActionsProps<I> {
     getRowActions?: (item: I, index: number) => TableActionConfig<I>[];
     renderRowActions?: (props: RenderRowActionsProps<I>) => React.ReactNode;
     rowActionsSize?: TableRowActionsSize;
+    rowActionsIcon?: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
 }
 
 interface WithTableActionsState<I> {
@@ -101,7 +102,7 @@ const DEFAULT_PLACEMENT: PopupPlacement = ['bottom-end', 'top-end'];
 
 type DefaultRowActionsProps<I extends TableDataItem> = Pick<
     WithTableActionsProps<I>,
-    'getRowActions' | 'rowActionsSize'
+    'getRowActions' | 'rowActionsSize' | 'rowActionsIcon'
 > &
     Pick<TableProps<I>, 'isRowDisabled' | 'getRowDescriptor'> & {
         item: I;
@@ -115,6 +116,7 @@ const DefaultRowActions = <I extends TableDataItem>({
     getRowActions,
     getRowDescriptor,
     rowActionsSize,
+    rowActionsIcon,
     isRowDisabled,
     tableQa,
 }: DefaultRowActionsProps<I>) => {
@@ -190,7 +192,7 @@ const DefaultRowActions = <I extends TableDataItem>({
                 aria-expanded={isPopupOpen}
                 aria-controls={rowId}
             >
-                <Icon data={Ellipsis} />
+                <Icon data={rowActionsIcon || Ellipsis} />
             </Button>
         </div>
     );
@@ -235,6 +237,7 @@ export function withTableActions<I extends TableDataItem, E extends {} = {}>(
             const {
                 getRowActions,
                 rowActionsSize,
+                rowActionsIcon,
                 renderRowActions,
                 isRowDisabled,
                 getRowDescriptor,
@@ -251,6 +254,7 @@ export function withTableActions<I extends TableDataItem, E extends {} = {}>(
                     item={item}
                     getRowActions={getRowActions}
                     rowActionsSize={rowActionsSize}
+                    rowActionsIcon={rowActionsIcon}
                     getRowDescriptor={getRowDescriptor}
                     isRowDisabled={isRowDisabled}
                     tableQa={qa}


### PR DESCRIPTION
added `rowActionsIcon` prop to withTableActions to add a custom icon in place of the default `Ellipsis` icon.