### PR TITLE
feat(Label): allow ReactNode as value

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -47,7 +47,7 @@ export interface LabelProps extends QAProps {
     /** Display hover */
     interactive?: boolean;
     /** Label value (shows as "children : value") */
-    value?: string;
+    value?: React.ReactNode;
     /** Label color */
     theme?: 'normal' | 'info' | 'danger' | 'warning' | 'success' | 'utility' | 'unknown' | 'clear';
     /** Label type (plain, with copy text button, with close button, or with info icon) */

--- a/src/components/Label/README-ru.md
+++ b/src/components/Label/README-ru.md
@@ -272,6 +272,6 @@ LANDING_BLOCK-->
 | size             | Размер лейбла.                                         |           `"xs"` `"s"` `"m"`            |         `"s"`         |
 | theme            | Тема лейбла.                                           |                `string`                 |      `"normal"`       |
 | type             | Тип лейбла.                                            | `"default"` `"copy"` `"close"` `"info"` |      `"default"`      |
-| value            | Значение лейбла (в виде `"children : value"`).         |                `string`                 |                       |
+| value            | Значение лейбла (в виде `"children : value"`).         |            `React.ReactNode`            |                       |
 | title            | HTML-атрибут `title`.                                  |                `string`                 |                       |
 | qa               | HTML-атрибут `data-qa`, используется для тестирования. |                `string`                 |                       |

--- a/src/components/Label/README.md
+++ b/src/components/Label/README.md
@@ -272,6 +272,6 @@ LANDING_BLOCK-->
 | size             | Label size                                      |           `"xs"` `"s"` `"m"`            |    `"s"`    |
 | theme            | Label theme                                     |                `string`                 | `"normal"`  |
 | type             | Label type                                      | `"default"` `"copy"` `"close"` `"info"` | `"default"` |
-| value            | Label value (displayed as `"children : value"`) |                `string`                 |             |
+| value            | Label value (displayed as `"children : value"`) |            `React.ReactNode`            |             |
 | title            | `title` HTML attribute                          |                `string`                 |             |
 | qa               | `data-qa` HTML attribute, used for testing      |                `string`                 |             |


### PR DESCRIPTION
## Summary by Sourcery

Allow ReactNode as the Label component’s value prop and update documentation accordingly

Enhancements:
- Allow Label.value prop to accept React.ReactNode instead of string

Documentation:
- Update English and Russian READMEs to reflect React.ReactNode type for value prop