### PR TITLE
feat: add max-width to popup table action

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -18,6 +18,7 @@ export interface MenuItemProps extends DOMProps, QAProps {
     selected?: boolean;
     href?: string;
     target?: string;
+    classNameContent?: string;
     rel?: string;
     onClick?: React.MouseEventHandler<HTMLDivElement | HTMLAnchorElement>;
     theme?: 'normal' | 'danger';
@@ -41,6 +42,7 @@ export const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(function Me
         onClick,
         style,
         className,
+        classNameContent,
         theme,
         extraProps,
         children,
@@ -82,7 +84,7 @@ export const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(function Me
                 {iconStart}
             </div>
         ),
-        <div key="content" className={b('item-content')}>
+        <div key="content" className={b('item-content', classNameContent)}>
             {children}
         </div>,
         iconEnd && (

--- a/src/components/Menu/README-ru.md
+++ b/src/components/Menu/README-ru.md
@@ -265,24 +265,25 @@ LANDING_BLOCK-->
 
 ### Свойства
 
-| Имя        | Описание                                                 |            Тип            | Значение по умолчанию |
-| :--------- | :------------------------------------------------------- | :-----------------------: | :-------------------: |
-| iconStart  | Иконка меню перед текстом элемента.                      |        `ReactNode`        |                       |
-| iconEnd    | Иконка меню после текста элемента.                       |        `ReactNode`        |                       |
-| selected   | Флаг выбранного элемента меню.                           |         `boolean`         |        `false`        |
-| disabled   | Флаг отключенного элемента меню.                         |         `boolean`         |        `false`        |
-| active     | Флаг активного элемента меню.                            |         `boolean`         |        `false`        |
-| href       | URL-адрес.                                               |         `string`          |                       |
-| title      | Атрибут заголовка.                                       |         `string`          |                       |
-| target     | Атрибут целевого ресурса.                                |         `string`          |                       |
-| rel        | Атрибут `rel`.                                           |         `string`          |                       |
-| onClick    | Обработчик события клика.                                | `React.MouseEventHandler` |                       |
-| theme      | Тема элемента меню.                                      |   `"normal"` `"danger"`   |      `"normal"`       |
-| children   | Дочерний элемент.                                        |     `React.ReactNode`     |                       |
-| className  | HTML-атрибут `class`.                                    |         `string`          |                       |
-| style      | HTML-атрибут `style`.                                    |   `React.CSSProperties`   |                       |
-| qa         | Атрибут `data-qa` в HTML, используется для тестирования. |         `string`          |                       |
-| extraProps | Дополнительные HTML-атрибуты.                            |         `Record`          |                       |
+| Имя              | Описание                                                 |            Тип            | Значение по умолчанию |
+| :--------------- | :------------------------------------------------------- | :-----------------------: | :-------------------: |
+| iconStart        | Иконка меню перед текстом элемента.                      |        `ReactNode`        |                       |
+| iconEnd          | Иконка меню после текста элемента.                       |        `ReactNode`        |                       |
+| selected         | Флаг выбранного элемента меню.                           |         `boolean`         |        `false`        |
+| disabled         | Флаг отключенного элемента меню.                         |         `boolean`         |        `false`        |
+| active           | Флаг активного элемента меню.                            |         `boolean`         |        `false`        |
+| href             | URL-адрес.                                               |         `string`          |                       |
+| title            | Атрибут заголовка.                                       |         `string`          |                       |
+| target           | Атрибут целевого ресурса.                                |         `string`          |                       |
+| rel              | Атрибут `rel`.                                           |         `string`          |                       |
+| onClick          | Обработчик события клика.                                | `React.MouseEventHandler` |                       |
+| theme            | Тема элемента меню.                                      |   `"normal"` `"danger"`   |      `"normal"`       |
+| children         | Дочерний элемент.                                        |     `React.ReactNode`     |                       |
+| className        | HTML-атрибут `class`.                                    |         `string`          |                       |
+| classNameContent | HTML-атрибут `class`.                                    |         `string`          |                       |
+| style            | HTML-атрибут `style`.                                    |   `React.CSSProperties`   |                       |
+| qa               | Атрибут `data-qa` в HTML, используется для тестирования. |         `string`          |                       |
+| extraProps       | Дополнительные HTML-атрибуты.                            |         `Record`          |                       |
 
 ## Menu.Group
 

--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -265,24 +265,25 @@ LANDING_BLOCK-->
 
 ### Properties
 
-| Name       | Description                                |           Type            |  Default   |
-| :--------- | :----------------------------------------- | :-----------------------: | :--------: |
-| iconStart  | Menu icon before item text                 |        `ReactNode`        |            |
-| iconEnd    | Menu icon after item text                  |        `ReactNode`        |            |
-| selected   | Menu item selected flag                    |         `boolean`         |  `false`   |
-| disabled   | Menu item disabled flag                    |         `boolean`         |  `false`   |
-| active     | Menu item active flag                      |         `boolean`         |  `false`   |
-| href       | URL                                        |         `string`          |            |
-| title      | Title attribute                            |         `string`          |            |
-| target     | Target attribute                           |         `string`          |            |
-| rel        | Rel attribute                              |         `string`          |            |
-| onClick    | Handler for onclick event                  | `React.MouseEventHandler` |            |
-| theme      | Menu item theme                            |   `"normal"` `"danger"`   | `"normal"` |
-| children   | Child element                              |     `React.ReactNode`     |            |
-| className  | `class` HTML attribute                     |         `string`          |            |
-| style      | `style` HTML attribute                     |   `React.CSSProperties`   |            |
-| qa         | `data-qa` HTML attribute, used for testing |         `string`          |            |
-| extraProps | Additional HTML attributes                 |         `Record`          |            |
+| Name             | Description                                |           Type            |  Default   |
+| :--------------- | :----------------------------------------- | :-----------------------: | :--------: |
+| iconStart        | Menu icon before item text                 |        `ReactNode`        |            |
+| iconEnd          | Menu icon after item text                  |        `ReactNode`        |            |
+| selected         | Menu item selected flag                    |         `boolean`         |  `false`   |
+| disabled         | Menu item disabled flag                    |         `boolean`         |  `false`   |
+| active           | Menu item active flag                      |         `boolean`         |  `false`   |
+| href             | URL                                        |         `string`          |            |
+| title            | Title attribute                            |         `string`          |            |
+| target           | Target attribute                           |         `string`          |            |
+| rel              | Rel attribute                              |         `string`          |            |
+| onClick          | Handler for onclick event                  | `React.MouseEventHandler` |            |
+| theme            | Menu item theme                            |   `"normal"` `"danger"`   | `"normal"` |
+| children         | Child element                              |     `React.ReactNode`     |            |
+| className        | `class` HTML attribute                     |         `string`          |            |
+| classNameContent | `class` HTML attribute                     |         `string`          |            |
+| style            | `style` HTML attribute                     |   `React.CSSProperties`   |            |
+| qa               | `data-qa` HTML attribute, used for testing |         `string`          |            |
+| extraProps       | Additional HTML attributes                 |         `Record`          |            |
 
 ## Menu.Group
 

--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -150,7 +150,7 @@ const DefaultRowActions = <I extends TableDataItem>({
                 }}
                 href={typeof href === 'function' ? href(item, index) : href}
                 iconStart={icon}
-                className={menuItemCn}
+                classNameContent={menuItemCn}
                 {...restProps}
             >
                 {text}


### PR DESCRIPTION
### What was done

There was an issue where the text of actions in the table did not apply the 'ellipsis' property
<img width="516" alt="Снимок экрана 2025-06-21 в 15 56 04" src="https://github.com/user-attachments/assets/feee13ad-d481-4d16-bd4d-ffb96c3c26df" />

I resolved it by adding a class specifically to the content so that the ellipsis worked correctly.

<img width="837" alt="Снимок экрана 2025-06-21 в 15 48 11" src="https://github.com/user-attachments/assets/857102db-e93b-485a-b857-16070cafe424" />

Issue #2255 

