### PR TITLE
fix(Breadcrumbs): сollapsing crumbs for the react 17

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -118,8 +118,8 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     };
 
     const handleResize = React.useCallback(() => {
-        setCalculated(false);
         setVisibleItemsCount(items.length);
+        setCalculated(false);
     }, [items.length]);
     useResizeObserver({
         ref: listRef,
@@ -134,8 +134,8 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     React.useLayoutEffect(() => {
         if (calculated && props.children !== lastChildren.current) {
             lastChildren.current = props.children;
-            setCalculated(false);
             setVisibleItemsCount(items.length);
+            setCalculated(false);
         }
     }, [calculated, items.length, props.children]);
 


### PR DESCRIPTION
## Summary by Sourcery

Fix breadcrumb collapsing under React 17 by adjusting the order of state updates during resize and children changes

Bug Fixes:
- Swap state update order (setVisibleItemsCount before setCalculated) in handleResize to ensure correct recalculation of visible crumbs
- Swap state update order in the layout effect to prevent incorrect collapsing when children change under React 17