### PR TITLE
fix(NumberInput): fix input pattern in case of using allowDecimal

### DIFF
--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -242,7 +242,7 @@ export const NumberInput = React.forwardRef<HTMLSpanElement, NumberInputProps>(f
                 ...props.controlProps,
                 role: 'spinbutton',
                 inputMode: allowDecimal ? 'decimal' : 'numeric',
-                pattern: props.controlProps?.pattern ?? getInputPattern(allowDecimal, false),
+                pattern: props.controlProps?.pattern ?? getInputPattern(!allowDecimal, false),
                 'aria-valuemin': props.min,
                 'aria-valuemax': props.max,
                 'aria-valuenow': value === null ? undefined : value,

--- a/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -570,11 +570,11 @@ describe('NumberInput input', () => {
         });
 
         test('should submit decimal value', async () => {
+            let value;
             const handleSubmit = jest.fn((e) => {
                 e.preventDefault();
-                // Collect form data for assertion
-                const formData = new FormData(e.target);
-                handleSubmit.formData = formData;
+                const formData = new FormData(e.currentTarget);
+                value = [...formData.entries()];
             });
             render(
                 <form data-qa="form" onSubmit={handleSubmit}>
@@ -586,10 +586,7 @@ describe('NumberInput input', () => {
             );
             await userEvent.click(screen.getByTestId('submit'));
             expect(handleSubmit).toHaveBeenCalledTimes(1);
-
-            // Assert the submitted value
-            const submittedValue = handleSubmit.formData.get('numeric-field');
-            expect(submittedValue).toBe('123.45');
+            expect(value).toEqual([['numeric-field', '123.45']]);
         });
     });
 });

--- a/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -568,5 +568,19 @@ describe('NumberInput input', () => {
             await userEvent.click(button);
             expect(inputs[0]).toHaveValue('123');
         });
+
+        test('should submit decimal value', async () => {
+            const handleSubmit = jest.fn();
+            render(
+                <form data-qa="form" onSubmit={handleSubmit}>
+                    <NumberInput allowDecimal name="numeric-field" value={123.45} />
+                    <button type="submit" data-qa="submit">
+                        submit
+                    </button>
+                </form>,
+            );
+            await userEvent.click(screen.getByTestId('submit'));
+            expect(handleSubmit).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -570,7 +570,12 @@ describe('NumberInput input', () => {
         });
 
         test('should submit decimal value', async () => {
-            const handleSubmit = jest.fn();
+            const handleSubmit = jest.fn((e) => {
+                e.preventDefault();
+                // Collect form data for assertion
+                const formData = new FormData(e.target);
+                handleSubmit.formData = formData;
+            });
             render(
                 <form data-qa="form" onSubmit={handleSubmit}>
                     <NumberInput allowDecimal name="numeric-field" value={123.45} />
@@ -581,6 +586,10 @@ describe('NumberInput input', () => {
             );
             await userEvent.click(screen.getByTestId('submit'));
             expect(handleSubmit).toHaveBeenCalledTimes(1);
+
+            // Assert the submitted value
+            const submittedValue = handleSubmit.formData.get('numeric-field');
+            expect(submittedValue).toBe('123.45');
         });
     });
 });


### PR DESCRIPTION
Closes #2320

## Summary by Sourcery

Fix the input pattern logic in NumberInput to correctly allow decimal values when allowDecimal is true and add a test case to verify decimal submission.

Bug Fixes:
- Correct NumberInput input pattern to properly allow decimals when allowDecimal is enabled.

Tests:
- Add test to ensure NumberInput submits decimal values when allowDecimal is enabled.