### PR TITLE
fix(build): treeshaking

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,10 @@ async function compileTs(modules = false) {
             .pipe(
                 utils.addVirtualFile({
                     fileName: 'package.json',
-                    text: JSON.stringify({type: modules ? 'module' : 'commonjs'}),
+                    text: JSON.stringify({
+                        type: modules ? 'module' : 'commonjs',
+                        sideEffects: ['*.css', '*.scss'],
+                    }),
                 }),
             )
             .pipe(dest(path.resolve(BUILD_DIR, modules ? 'esm' : 'cjs')))


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Include a sideEffects array for '*.css' and '*.scss' in the virtual package.json generated by the Gulp build task