### PR TITLE
feat: add color prop to Icon

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -29,6 +29,7 @@ export interface IconProps extends QAProps {
     size?: number | string;
     fill?: string;
     stroke?: string;
+    color?: string;
     className?: string;
 }
 
@@ -36,7 +37,7 @@ const b = block('icon');
 
 export const Icon: React.ForwardRefExoticComponent<IconProps & React.RefAttributes<SVGSVGElement>> &
     IconComposition = React.forwardRef<SVGSVGElement, IconProps>(
-    ({data, width, height, size, className, fill = 'currentColor', stroke = 'none', qa}, ref) => {
+    ({data, width, height, size, className, fill = 'currentColor', stroke = 'none', color, qa}, ref) => {
         // This component supports four different ways to load and use icons:
         // - svg-react-loader
         // - svg-sprite-loader
@@ -98,6 +99,7 @@ export const Icon: React.ForwardRefExoticComponent<IconProps & React.RefAttribut
             fill,
             stroke,
             'data-qa': qa,
+            ...(color && { style: { color } }),
             ...a11yHiddenSvgProps,
         };
 

--- a/src/components/Icon/README-ru.md
+++ b/src/components/Icon/README-ru.md
@@ -59,4 +59,5 @@ import CheckIcon from './check.svg';
 | size      | Атрибуты `width` и `height` для SVG.           | `number` `string` |                       |
 | fill      | Атрибут `fill` для SVG.                        |     `string`      |   `"currentColor"`    |
 | stroke    | Атрибут `stroke` для SVG.                      |     `string`      |       `"none"`        |
+| color     | Цвет иконки (любое валидное CSS-значение цвета) |     `string`      |                       |
 | className | Пользовательский CSS-класс корневого элемента. |     `string`      |                       |

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -59,4 +59,5 @@ import CheckIcon from './check.svg';
 | size      | Both `width` and `height` SVG attributes | `number` `string` |                  |
 | fill      | `fill` SVG attribute                     |     `string`      | `"currentColor"` |
 | stroke    | `stroke` SVG attribute                   |     `string`      |     `"none"`     |
+| color     | Icon color (any valid CSS color value)  |     `string`      |                  |
 | className | Custom CSS class for the root element    |     `string`      |                  |

--- a/src/components/Icon/__stories__/Icon.stories.tsx
+++ b/src/components/Icon/__stories__/Icon.stories.tsx
@@ -49,3 +49,40 @@ export const Size: Story = {
         </Showcase>
     ),
 };
+
+export const Color: Story = {
+    render: (args) => (
+        <Showcase>
+            <div style={{display: 'flex', gap: '16px', alignItems: 'center', flexWrap: 'wrap'}}>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <Icon {...args} size={32} color="#ff0000" />
+                    <span style={{fontSize: '12px', color: '#666'}}>Hex: #ff0000</span>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <Icon {...args} size={32} color="blue" />
+                    <span style={{fontSize: '12px', color: '#666'}}>Named: blue</span>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <Icon {...args} size={32} color="rgb(255, 165, 0)" />
+                    <span style={{fontSize: '12px', color: '#666'}}>RGB: rgb(255, 165, 0)</span>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <Icon {...args} size={32} />
+                    <span style={{fontSize: '12px', color: '#666'}}>Default (currentColor)</span>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <div style={{color: 'red'}}>
+                        <Icon {...args} size={32} />
+                    </div>
+                    <span style={{fontSize: '12px', color: '#666'}}>Parent color: red</span>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px'}}>
+                    <div style={{color: 'red'}}>
+                        <Icon {...args} size={32} color="green" />
+                    </div>
+                    <span style={{fontSize: '12px', color: '#666'}}>Override parent</span>
+                </div>
+            </div>
+        </Showcase>
+    ),
+};


### PR DESCRIPTION
Added new color props.

Fixes gravity-ui/uikit#2335

## Summary by Sourcery

Introduce a color prop to the Icon component for flexible CSS-based coloring and update Storybook and documentation to showcase the new capability

New Features:
- Add a `color` prop to the Icon component to allow any valid CSS color value

Enhancements:
- Add a `Color` story in Storybook to demonstrate various color usages and overrides

Documentation:
- Document the new `color` prop in both English and Russian READMEs