### PR TITLE
feat: selectively handle reduced motion setting

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -76,4 +76,10 @@ $modal-transform-transition: transform $modal-transition-duration ease-out;
     &[data-floating-ui-status='close'] #{$block}__content {
         transition: $modal-height-transition, $modal-transform-transition;
     }
+
+    @media (prefers-reduced-motion: reduce) {
+        &[data-floating-ui-status] #{$block}__content {
+            transition: none;
+        }
+    }
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -190,7 +190,7 @@ function ModalComponent({
 
     const {getFloatingProps} = useInteractions([dismiss, role]);
 
-    const {isMounted, status, handleTransitionEnd} = useFloatingTransition({
+    const {isMounted, status} = useFloatingTransition({
         context,
         duration: TRANSITION_DURATION,
         onTransitionIn,
@@ -271,7 +271,6 @@ function ModalComponent({
                                         )}
                                         ref={handleFloatingRef}
                                         {...getFloatingProps({
-                                            onTransitionEnd: handleTransitionEnd,
                                             onKeyDown: handleKeyDown,
                                         })}
                                     >

--- a/src/components/Popup/Popup.scss
+++ b/src/components/Popup/Popup.scss
@@ -76,6 +76,13 @@ $transition-distance: 10px;
         transform: translateX($transition-distance);
     }
 
+    @media (prefers-reduced-motion: reduce) {
+        @at-root [data-floating-ui-status][data-floating-ui-placement] > & {
+            transform: none;
+            transition-property: opacity;
+        }
+    }
+
     &__arrow {
         position: absolute;
     }

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -282,10 +282,9 @@ function PopupComponent({
 
     const {getFloatingProps} = useInteractions(floatingInteractions ?? [role, dismiss]);
 
-    const {isMounted, status, handleTransitionEnd} = useFloatingTransition({
-        enabled: !disableTransition,
+    const {isMounted, status} = useFloatingTransition({
         context,
-        duration: TRANSITION_DURATION,
+        duration: disableTransition ? 0 : TRANSITION_DURATION,
         onTransitionIn,
         onTransitionInComplete,
         onTransitionOut,
@@ -316,7 +315,7 @@ function PopupComponent({
                 <Portal container={container} disablePortal={disablePortal}>
                     <FloatingFocusManager
                         context={context}
-                        disabled={!isMounted || !isPositioned}
+                        disabled={!isPositioned}
                         modal={modal}
                         initialFocus={initialFocus}
                         returnFocus={returnFocus}
@@ -355,7 +354,6 @@ function PopupComponent({
                                 )}
                                 style={style}
                                 data-qa={qa}
-                                onTransitionEnd={handleTransitionEnd}
                                 {...filterDOMProps(restProps)}
                             >
                                 {hasArrow && (

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -241,6 +241,7 @@ function PopupComponent({
         middlewareData,
         context,
         update,
+        isPositioned,
     } = useFloating({
         rootContext: floatingContext,
         nodeId: floatingNodeId,
@@ -301,7 +302,7 @@ function PopupComponent({
     const handleFloatingRef = useForkRef<HTMLDivElement>(refs.setFloating, floatingRef);
 
     let initialFocus = initialFocusProp;
-    if (initialFocus === undefined) {
+    if (typeof initialFocus === 'undefined') {
         if (modal) {
             initialFocus = refs.floating;
         } else {
@@ -315,7 +316,7 @@ function PopupComponent({
                 <Portal container={container} disablePortal={disablePortal}>
                     <FloatingFocusManager
                         context={context}
-                        disabled={!isMounted}
+                        disabled={!isMounted || !isPositioned}
                         modal={modal}
                         initialFocus={initialFocus}
                         returnFocus={returnFocus}

--- a/src/components/Sheet/Sheet.scss
+++ b/src/components/Sheet/Sheet.scss
@@ -39,6 +39,14 @@ $block: '.#{variables.$ns}sheet';
         &_with-transition {
             transition: transform $transition-duration ease;
         }
+
+        @media (prefers-reduced-motion: reduce) {
+            opacity: 0;
+
+            &_with-transition {
+                transition: opacity $transition-duration ease;
+            }
+        }
     }
 
     &__sheet-swipe-area {
@@ -81,6 +89,10 @@ $block: '.#{variables.$ns}sheet';
 
         &_without-scroll {
             overflow: hidden;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            transition-duration: 1ms;
         }
     }
 

--- a/src/components/Sheet/SheetContent.tsx
+++ b/src/components/Sheet/SheetContent.tsx
@@ -568,7 +568,7 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
     }
 
     private get isPrefersReducedMotion() {
-        return Boolean(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+        return Boolean(window?.matchMedia('(prefers-reduced-motion: reduce)').matches);
     }
 }
 

--- a/src/components/Sheet/SheetContent.tsx
+++ b/src/components/Sheet/SheetContent.tsx
@@ -255,6 +255,11 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
         this.veilRef.current.style.opacity = String(opacity);
 
         this.sheetRef.current.style.transform = translate;
+
+        if (this.isPrefersReducedMotion) {
+            this.sheetRef.current.style.opacity = String(opacity);
+            this.sheetRef.current.style.transform = `translate3d(0, -${visibleHeight}px, 0)`;
+        }
     };
 
     private getAvailableContentHeight = (sheetHeight: number) => {
@@ -560,6 +565,10 @@ class SheetContent extends React.Component<SheetContentInnerProps, SheetContentS
             prevProps.location.hash !== location.hash &&
             location.hash !== `#${id}`
         );
+    }
+
+    private get isPrefersReducedMotion() {
+        return Boolean(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
     }
 }
 

--- a/src/components/Skeleton/Skeleton.scss
+++ b/src/components/Skeleton/Skeleton.scss
@@ -27,6 +27,10 @@ $block: '.#{variables.$ns}skeleton';
                 var(--g-color-base-generic)
             );
             animation: #{variables.$ns}skeleton 1.2s ease-out infinite;
+
+            @media (prefers-reduced-motion: reduce) {
+                animation: none;
+            }
         }
     }
 

--- a/src/components/Spin/Spin.scss
+++ b/src/components/Spin/Spin.scss
@@ -44,6 +44,10 @@ $block: '.#{variables.$ns}spin';
             height: 36px;
         }
     }
+
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+    }
 }
 
 @keyframes #{variables.$ns}spin {

--- a/src/components/Spin/Spin.scss
+++ b/src/components/Spin/Spin.scss
@@ -7,6 +7,10 @@ $block: '.#{variables.$ns}spin';
     backface-visibility: hidden;
     animation: #{variables.$ns}spin 1s linear infinite;
 
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+    }
+
     &__inner {
         box-sizing: border-box;
         height: 100%;
@@ -43,10 +47,6 @@ $block: '.#{variables.$ns}spin';
             width: 36px;
             height: 36px;
         }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        animation: none;
     }
 }
 

--- a/src/components/Toaster/ToastList/ToastAnimation.scss
+++ b/src/components/Toaster/ToastList/ToastAnimation.scss
@@ -16,7 +16,6 @@ $animation-duration: 0.6s;
 }
 
 @mixin hidden-toast-move($platform) {
-    opacity: 0;
     @if ($platform == 'mobile') {
         transform: translateY($transition-distance);
     } @else {
@@ -25,8 +24,15 @@ $animation-duration: 0.6s;
 }
 
 @mixin visible-toast-move {
-    opacity: 1;
     transform: translateX(0);
+}
+
+@mixin hidden-toast-opacity {
+    opacity: 0;
+}
+
+@mixin visible-toast-opacity {
+    opacity: 1;
 }
 
 @each $platform in ('mobile', 'desktop') {
@@ -42,24 +48,35 @@ $animation-duration: 0.6s;
                 ease-out
                 forwards;
             position: relative;
+
+            @media (prefers-reduced-motion: reduce) {
+                animation-name: #{variables.$ns}toast-enter-reduced-motion;
+            }
         }
 
         &_exit_active {
             animation: #{variables.$ns}toast-exit-#{$platform} $animation-duration ease-in forwards;
+
+            @media (prefers-reduced-motion: reduce) {
+                animation-name: #{variables.$ns}toast-exit-reduced-motion;
+            }
         }
     }
 
     @keyframes #{variables.$ns}toast-enter-#{$platform} {
         0% {
             @include hidden-toast-height;
+            @include hidden-toast-opacity;
             @include hidden-toast-move($platform);
         }
         50% {
             @include visible-toast-height;
+            @include hidden-toast-opacity;
             @include hidden-toast-move($platform);
         }
         100% {
             @include visible-toast-height;
+            @include visible-toast-opacity;
             @include visible-toast-move;
         }
     }
@@ -67,15 +84,36 @@ $animation-duration: 0.6s;
     @keyframes #{variables.$ns}toast-exit-#{$platform} {
         0% {
             @include visible-toast-height;
+            @include visible-toast-opacity;
             @include visible-toast-move;
         }
         50% {
             @include visible-toast-height;
+            @include hidden-toast-opacity;
             @include hidden-toast-move($platform);
         }
         100% {
             @include hidden-toast-height;
+            @include hidden-toast-opacity;
             @include hidden-toast-move($platform);
+        }
+    }
+
+    @keyframes #{variables.$ns}toast-enter-reduced-motion {
+        0% {
+            @include hidden-toast-opacity;
+        }
+        100% {
+            @include visible-toast-opacity;
+        }
+    }
+
+    @keyframes #{variables.$ns}toast-exit-reduced-motion {
+        0% {
+            @include visible-toast-opacity;
+        }
+        100% {
+            @include hidden-toast-opacity;
         }
     }
 }

--- a/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
+++ b/src/hooks/private/useAnimateHeight/useAnimateHeight.ts
@@ -2,14 +2,17 @@ import * as React from 'react';
 
 import {useResizeObserver} from '../../useResizeObserver';
 import type {ResizeInfo} from '../../useResizeObserver/useResizeObserver';
+import {useMatchMedia} from '../useMatchMedia';
 
 export function useAnimateHeight({
     ref,
-    enabled,
+    enabled: enabledProp,
 }: {
     ref?: React.RefObject<HTMLElement | null | undefined>;
     enabled: boolean;
 }): void {
+    const isPrefersReducedMotion = useMatchMedia({media: '(prefers-reduced-motion: reduce)'});
+    const enabled = enabledProp && !isPrefersReducedMotion;
     const previousHeight = React.useRef<number | null>(null);
     const isTransitioningHeight = React.useRef(false);
     const overflowY = React.useRef<string>('');

--- a/src/hooks/private/useFloatingTransition/README.md
+++ b/src/hooks/private/useFloatingTransition/README.md
@@ -6,10 +6,10 @@ The `useFloatingTransition` hook consolidates logic for transition in Floating U
 
 | Name                    | Description                                         |       Type        |    Default    |
 | :---------------------- | :-------------------------------------------------- | :---------------: | :-----------: |
-| enabled                 | Whether or not the hook is active                   |     `boolean`     |    `true`     |
 | context                 | The Floating UI context from the `useFloating` hook | `FloatingContext` |               |
 | duration                | The duration of transition                          |     `number`      |               |
-| transitionProperty      | The CSS property that is being transitioned         |     `string`      | `"transform"` |
+| cssTransitionEnabled    | Whether the CSS transition is enabled               |     `boolean`     |    `true`     |
+| cssTransitionProperty   | The CSS property that is being transitioned         |     `string`      | `"transform"` |
 | onTransitionIn          | The callback fired on transition "in" start         |    `Function`     |               |
 | onTransitionInComplete  | The callback fired on transition "in" complete      |    `Function`     |               |
 | onTransitionOut         | The callback fired on transition "out" start        |    `Function`     |               |

--- a/src/hooks/private/useFloatingTransition/useFloatingTransition.ts
+++ b/src/hooks/private/useFloatingTransition/useFloatingTransition.ts
@@ -6,10 +6,8 @@ import type {FloatingContext, UseTransitionStatusProps} from '@floating-ui/react
 import {usePrevious} from '../usePrevious';
 
 export interface UseFloatingTransitionProps {
-    enabled?: boolean;
     context: FloatingContext;
     duration: NonNullable<UseTransitionStatusProps['duration']>;
-    transitionProperty?: string;
     onTransitionIn?: () => void;
     onTransitionInComplete?: () => void;
     onTransitionOut?: () => void;
@@ -19,65 +17,62 @@ export interface UseFloatingTransitionProps {
 export interface UseFloatingTransitionResult {
     isMounted: boolean;
     status: 'unmounted' | 'initial' | 'open' | 'close';
-    handleTransitionEnd: (event: React.TransitionEvent) => void;
 }
 
 export function useFloatingTransition({
-    enabled = true,
     context,
     duration,
-    transitionProperty = 'transform',
     onTransitionIn,
     onTransitionInComplete,
     onTransitionOut,
     onTransitionOutComplete,
 }: UseFloatingTransitionProps): UseFloatingTransitionResult {
     const {isMounted, status} = useTransitionStatus(context, {
-        duration: enabled ? duration : 0,
+        duration,
     });
     const previousStatus = usePrevious(status);
+    const openDuration = (typeof duration === 'number' ? duration : duration.open) ?? 0;
+    const timerIdRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const handleTransitionEnd = React.useCallback(
-        (event: React.TransitionEvent) => {
-            if (!enabled) {
-                return;
-            }
-
-            // If there are several simultaneous transitions running at the same time
-            // use specific property to only notify once
-            if (status === 'open' && event.propertyName === transitionProperty) {
-                onTransitionInComplete?.();
-            }
-        },
-        [enabled, status, transitionProperty, onTransitionInComplete],
-    );
-
-    // Cannot use transitionend event for these callbacks due to unmounting from the DOM
     React.useEffect(() => {
         if (status === 'open' && previousStatus === 'initial') {
             onTransitionIn?.();
 
-            if (!enabled) {
-                requestAnimationFrame(() => {
-                    onTransitionInComplete?.();
-                });
-            }
+            timerIdRef.current = setTimeout(() => {
+                onTransitionInComplete?.();
+                timerIdRef.current = null;
+            }, openDuration);
         }
         if (status === 'close' && previousStatus === 'open') {
+            if (timerIdRef.current) {
+                clearTimeout(timerIdRef.current);
+                timerIdRef.current = null;
+            }
+
             onTransitionOut?.();
         }
         if (status === 'unmounted' && previousStatus === 'close') {
             onTransitionOutComplete?.();
         }
     }, [
-        enabled,
         status,
         previousStatus,
+        openDuration,
         onTransitionIn,
         onTransitionInComplete,
         onTransitionOut,
         onTransitionOutComplete,
     ]);
 
-    return {isMounted, status, handleTransitionEnd};
+    React.useEffect(
+        () => () => {
+            if (timerIdRef.current) {
+                clearTimeout(timerIdRef.current);
+                timerIdRef.current = null;
+            }
+        },
+        [],
+    );
+
+    return {isMounted, status};
 }

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -328,6 +328,10 @@
 
     // stylelint-disable-next-line no-unknown-animations
     animation: g-loading-animation 0.5s linear infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+    }
 }
 
 @mixin scrollbar() {

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -41,20 +41,3 @@
 :root:has(body.g-root_theme_dark-hc) {
     color-scheme: dark;
 }
-
-// TODO BREAKING CHANGE: We should only disable "motion" animations and transitions but no all
-
-@media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-        /* stylelint-disable-next-line declaration-no-important */
-        scroll-behavior: auto !important;
-        /* stylelint-disable-next-line declaration-no-important */
-        transition-duration: 1ms !important;
-        /* stylelint-disable-next-line declaration-no-important */
-        animation-duration: 1ms !important;
-        /* stylelint-disable-next-line declaration-no-important */
-        animation-iteration-count: 1 !important;
-    }
-}


### PR DESCRIPTION
Instead of applying very short transitions and animations for all elements, we selectively tweak the styles and code to remove the "motion" animations. The `transition-duration: 1s` was especially problematic because it enabled transitions of all properties for all elements. This caused scroll jumps for floating elements when focusing.

## Summary by Sourcery

Respect users' prefers-reduced-motion setting by selectively disabling or simplifying animations and transitions across hooks and components, and refactor the useFloatingTransition hook to handle transition callbacks internally without relying on CSS events.

New Features:
- Add media queries to disable or simplify animations in Toast, Sheet, Popup, Modal, Skeleton, Spin, and global mixins when prefers-reduced-motion is enabled
- Enable useAnimateHeight hook to respect the reduced-motion preference

Enhancements:
- Refactor useFloatingTransition to remove external transition event handlers and matchMedia dependency, using internal timers and cleanup for transition callbacks
- Update Popup and Modal components to remove onTransitionEnd props and use the updated transition status and isPositioned flag
- Add reduced-motion-specific keyframes and mixins for toast animations

Documentation:
- Update useFloatingTransition README to reflect the renamed CSS transition props