### PR TITLE
fix(Modal): fix closing not nested parent Modals

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -140,6 +140,8 @@ function ModalComponent({
 }: ModalProps) {
     useLayer({open, type: 'modal'});
 
+    const overlayRef = React.useRef<HTMLDivElement>(null);
+
     const handleOpenChange = React.useCallback<NonNullable<UseFloatingOptions['onOpenChange']>>(
         (isOpen, event, reason) => {
             onOpenChange?.(isOpen, event, reason);
@@ -182,7 +184,18 @@ function ModalComponent({
 
     const dismiss = useDismiss(context, {
         enabled: !disableOutsideClick || !disableEscapeKeyDown,
-        outsidePress: !disableOutsideClick,
+        outsidePress: (event) => {
+            if (disableOutsideClick) {
+                return false;
+            }
+
+            // Prevent closing parent modals if they aren't nested in the React tree
+            if ((event.target as HTMLElement).closest(`.${b()}`) !== overlayRef.current) {
+                return false;
+            }
+
+            return true;
+        },
         escapeKey: !disableEscapeKeyDown,
     });
 
@@ -243,6 +256,7 @@ function ModalComponent({
             {isMounted || keepMounted ? (
                 <Portal container={container} disablePortal={disablePortal}>
                     <FloatingOverlay
+                        ref={overlayRef}
                         style={style}
                         className={b({open}, className)}
                         data-qa={qa}


### PR DESCRIPTION
## Summary by Sourcery

Prevent non-nested parent modals from being dismissed by clicks outside the current modal overlay.

Bug Fixes:
- Limit outside-click dismissal to the current modal overlay element to avoid closing parent modals not nested in the React tree.

Enhancements:
- Introduce overlayRef to track and reference the correct FloatingOverlay DOM node.