### PR TITLE
fix(Button): raised button has incorrect background color apperance

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -184,9 +184,8 @@ $block: '.#{variables.$ns}button';
         }
 
         &_raised {
+            --_--background-color: var(--g-color-base-float);
             --_--background-color-hover: var(--g-color-base-float-hover);
-
-            background: var(--g-color-base-float);
 
             &::before {
                 box-shadow: 0 3px 5px var(--g-color-sfx-shadow);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set the raised button’s background color via its CSS variable rather than the direct background property