### PR TITLE
feat(NumberInput): add decimalScale prop

### DIFF
--- a/src/components/NumberInput/__tests__/utils.test.ts
+++ b/src/components/NumberInput/__tests__/utils.test.ts
@@ -200,6 +200,14 @@ describe('NumberInput utils', () => {
             expect(truncateExtraDecimalNumbers('1.1', 8)).toBe('1.1');
         });
 
+        it('returns original value when decimalScale is negative', () => {
+            expect(truncateExtraDecimalNumbers('1.11', -1)).toBe('1.11');
+        });
+
+        it('returns integer part only when decimalScale is 0', () => {
+            expect(truncateExtraDecimalNumbers('1.11', 0)).toBe('1');
+        });
+
         it('returns original value', () => {
             expect(truncateExtraDecimalNumbers('1.1')).toBe('1.1');
         });
@@ -207,6 +215,7 @@ describe('NumberInput utils', () => {
         it('truncates extra decimal places', () => {
             expect(truncateExtraDecimalNumbers('1.1111', 1)).toBe('1.1');
             expect(truncateExtraDecimalNumbers('1.1111', 2)).toBe('1.11');
+            expect(truncateExtraDecimalNumbers('1.100', 2)).toBe('1.10');
         });
 
         it('not rounds', () => {

--- a/src/components/NumberInput/__tests__/utils.test.ts
+++ b/src/components/NumberInput/__tests__/utils.test.ts
@@ -1,4 +1,9 @@
-import {clampToNearestStepValue, getParsedValue, getPossibleNumberSubstring} from '../utils';
+import {
+    clampToNearestStepValue,
+    getParsedValue,
+    getPossibleNumberSubstring,
+    truncateExtraDecimalNumbers,
+} from '../utils';
 
 describe('NumberInput utils', () => {
     describe('getPossibleNumberSubstring', () => {
@@ -187,6 +192,25 @@ describe('NumberInput utils', () => {
             expect(
                 clampToNearestStepValue({value: 1.25, step: 8.25, min: -1, max: undefined}),
             ).toBe(1.25);
+        });
+    });
+    describe('truncateExtraDecimalNumbers', () => {
+        it('no adds missing decimal places', () => {
+            expect(truncateExtraDecimalNumbers('1.1', 2)).toBe('1.1');
+            expect(truncateExtraDecimalNumbers('1.1', 8)).toBe('1.1');
+        });
+
+        it('returns original value', () => {
+            expect(truncateExtraDecimalNumbers('1.1')).toBe('1.1');
+        });
+
+        it('truncates extra decimal places', () => {
+            expect(truncateExtraDecimalNumbers('1.1111', 1)).toBe('1.1');
+            expect(truncateExtraDecimalNumbers('1.1111', 2)).toBe('1.11');
+        });
+
+        it('not rounds', () => {
+            expect(truncateExtraDecimalNumbers('1.18', 1)).toBe('1.1');
         });
     });
 });

--- a/src/components/NumberInput/utils.ts
+++ b/src/components/NumberInput/utils.ts
@@ -138,7 +138,7 @@ function normalizeDecimalScale(decimalScale: number) {
 }
 
 export function truncateExtraDecimalNumbers(value: string, decimalScale?: number) {
-    if (!isNumber(decimalScale)) {
+    if (!isNumber(decimalScale) || decimalScale < 0) {
         return value;
     }
 
@@ -147,13 +147,11 @@ export function truncateExtraDecimalNumbers(value: string, decimalScale?: number
         return value;
     }
 
-    const currentDecimalScale = value.slice(dotIndex + 1);
-    if (currentDecimalScale.length > decimalScale) {
-        const multiplier = Math.pow(10, decimalScale);
-        return String(Math.trunc(parseFloat(value) * multiplier) / multiplier);
+    if (decimalScale === 0) {
+        return value.substring(0, dotIndex);
     }
 
-    return value;
+    return value.substring(0, dotIndex + decimalScale + 1);
 }
 
 export function clampToNearestStepValue({

--- a/src/components/NumberInput/utils.ts
+++ b/src/components/NumberInput/utils.ts
@@ -1,3 +1,6 @@
+import isFinite from 'lodash/isFinite';
+import isNumber from 'lodash/isNumber';
+
 export const INCREMENT_BUTTON_QA = 'increment-button-qa';
 export const DECREMENT_BUTTON_QA = 'decrement-button-qa';
 export const CONTROL_BUTTONS_QA = 'control-buttons-qa';
@@ -52,8 +55,16 @@ export function getParsedValue(value: string | undefined): {valid: boolean; valu
     return {valid: isValidValue, value: parsedValue};
 }
 
-function roundIfNecessary(value: number, allowDecimal: boolean) {
-    return allowDecimal ? value : Math.floor(value);
+function roundIfNecessary(value: number, allowDecimal: boolean, decimalScale?: number) {
+    if (!allowDecimal) {
+        return Math.floor(value);
+    }
+
+    if (allowDecimal && isNumber(decimalScale)) {
+        return parseFloat(value.toFixed(decimalScale));
+    }
+
+    return value;
 }
 
 interface VariablesProps {
@@ -64,6 +75,7 @@ interface VariablesProps {
     value: number | null | undefined;
     defaultValue: number | null | undefined;
     allowDecimal: boolean;
+    decimalScale?: number;
 }
 export function getInternalState(props: VariablesProps): {
     min: number | undefined;
@@ -72,6 +84,7 @@ export function getInternalState(props: VariablesProps): {
     shiftMultiplier: number;
     value: number | null | undefined;
     defaultValue: number | null | undefined;
+    decimalScale: number | undefined;
 } {
     const {
         min: externalMin,
@@ -80,6 +93,7 @@ export function getInternalState(props: VariablesProps): {
         shiftMultiplier: externalShiftMultiplier,
         value: externalValue,
         allowDecimal,
+        decimalScale: externalDecimalScale,
         defaultValue: externalDefaultValue,
     } = props;
 
@@ -96,14 +110,50 @@ export function getInternalState(props: VariablesProps): {
     const max =
         rangedMax !== undefined && rangedMax <= Number.MAX_SAFE_INTEGER ? rangedMax : undefined;
 
-    const step = roundIfNecessary(Math.abs(externalStep), allowDecimal) || 1;
-    const shiftMultiplier = roundIfNecessary(externalShiftMultiplier, allowDecimal) || 10;
-    const value = externalValue ? roundIfNecessary(externalValue, allowDecimal) : externalValue;
+    const decimalScale =
+        allowDecimal && typeof externalDecimalScale === 'number'
+            ? normalizeDecimalScale(externalDecimalScale)
+            : undefined;
+
+    const step = roundIfNecessary(Math.abs(externalStep), allowDecimal, decimalScale) || 1;
+    const shiftMultiplier =
+        roundIfNecessary(externalShiftMultiplier, allowDecimal, decimalScale) || 10;
+
+    const value = externalValue
+        ? roundIfNecessary(externalValue, allowDecimal, decimalScale)
+        : externalValue;
     const defaultValue = externalDefaultValue
-        ? roundIfNecessary(externalDefaultValue, allowDecimal)
+        ? roundIfNecessary(externalDefaultValue, allowDecimal, decimalScale)
         : externalDefaultValue;
 
-    return {min, max, step, shiftMultiplier, value, defaultValue};
+    return {min, max, step, shiftMultiplier, value, defaultValue, decimalScale};
+}
+
+function normalizeDecimalScale(decimalScale: number) {
+    if (!isFinite(decimalScale) || !isNumber(decimalScale)) {
+        return 0;
+    }
+
+    return decimalScale > 0 ? decimalScale : 0;
+}
+
+export function truncateExtraDecimalNumbers(value: string, decimalScale?: number) {
+    if (!isNumber(decimalScale)) {
+        return value;
+    }
+
+    const dotIndex = value.indexOf('.');
+    if (dotIndex < 0) {
+        return value;
+    }
+
+    const currentDecimalScale = value.slice(dotIndex + 1);
+    if (currentDecimalScale.length > decimalScale) {
+        const multiplier = Math.pow(10, decimalScale);
+        return String(Math.trunc(parseFloat(value) * multiplier) / multiplier);
+    }
+
+    return value;
 }
 
 export function clampToNearestStepValue({
@@ -121,7 +171,7 @@ export function clampToNearestStepValue({
 }) {
     const base = originalMin || 0;
     const min = originalMin ?? Number.MIN_SAFE_INTEGER;
-    let clampedValue = toFixedNumber(value, step);
+    let clampedValue = value;
 
     if (clampedValue > max) {
         clampedValue = max;
@@ -154,7 +204,7 @@ export function clampToNearestStepValue({
         }
     }
 
-    return toFixedNumber(clampedValue, step);
+    return clampedValue;
 }
 
 export function updateCursorPosition(
@@ -204,9 +254,4 @@ export function areStringRepresentationOfNumbersEqual(v1: string, v2: string) {
         return true;
     }
     return false;
-}
-
-function toFixedNumber(value: number, baseStep: number): number {
-    const stepDecimalDigits = baseStep.toString().split('.')[1]?.length || 0;
-    return parseFloat(value.toFixed(stepDecimalDigits));
 }


### PR DESCRIPTION
close #2321 

I'd like to highlight several important points regarding the current implementation:
1. When value is a number that has more decimal places than the `decimalScale` allows, rounding to the nearest integer occurs. For example: `<NumberInput ... value={1.28} decimalScale={1} /> => value === 1.3` Is this the expected behavior? 
2. When `allowDecimal = false` and attempting to insert a floating-point value, the current behavior rounds down (floor) rather than to the nearest integer. This behavior was already present in the library. I've added a test case for this scenario with name `"rounds float number down if not allowDecimal prop"`. For example: `<NumberInput value={1.8}/> => value === 1`. Is this the expected behavior, or should it round to the nearest integer in this case?
3. How should we handle situations where `step` contains more decimal places than allowed by `decimalScale`? Currently, I've implemented behavior where `step` gets rounded to match the number of decimal places specified in `decimalScale`. For example: `<NumberInput step={0.08} decimalScale={1} /> => step === 0.1`. Check: `rounds up step value` and `rounds down step value` tests. However, would it be more appropriate to throw an error for an invalid `step` configuration?