### PR TITLE
fix(Accordion): issues #2399 and #2400 by adding 'use client' directives

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import {AccordionProvider} from './AccordionContext';

--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import {useUniqId} from '../../../hooks';

--- a/src/components/Accordion/AccordionSummary/AccordionSummary.tsx
+++ b/src/components/Accordion/AccordionSummary/AccordionSummary.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import {KeyCode} from '../../../constants';

--- a/src/components/Disclosure/DisclosureSummary/DisclosureSummary.tsx
+++ b/src/components/Disclosure/DisclosureSummary/DisclosureSummary.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import {ArrowToggle} from '../../ArrowToggle';


### PR DESCRIPTION
Fixed issues #2399 and #2400 by adding a `'use client'` directive at the top of `AccordionItem.tsx`, `AccordionSummary.tsx`, `Accordion.tsx` and `DisclosureSummary.tsx`.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/en/?lang=en.