### PR TITLE
docs(Accordion): fix README.md

### DIFF
--- a/src/components/Accordion/README.md
+++ b/src/components/Accordion/README.md
@@ -464,7 +464,7 @@ LANDING_BLOCK-->
 | view          | Accordion appearance                               |    `"solid"` `"top-bottom"`     | `"solid"` |
 | multiple      | Allow multiple items to be expanded simultaneously |            `boolean`            |  `false`  |
 | arrowPosition | Arrow indicator position                           |        `"start"` `"end"`        |  `"end"`  |
-| defaultValue  | Default value for uncontrolled state               | `string` `string[]` `undefined` |           |
+| defaultValue  | Default value for uncontrolled state               | `string` `string[]` `null`      |           |
 | value         | Current value for controlled state                 | `string` `string[]` `undefined` |           |
 | onUpdate      | Callback function called when state changes        |           `Function`            |           |
 | ariaLevel     | Heading level for accessibility                    |            `number`             |    `3`    |


### PR DESCRIPTION
fixed "multiple" type from "undefined" to "null" in doc (readme.md) #2411 