### PR TITLE
feat(Hotkey): remove mac esc icon

### DIFF
--- a/src/components/Hotkey/definitions.ts
+++ b/src/components/Hotkey/definitions.ts
@@ -101,7 +101,7 @@ const MacDisplayName: Record<MacKeys, string> = {
     down: '▼',
     left: '◀',
     right: '▶',
-    escape: '⎋',
+    escape: 'esc',
 
     plus: '＋',
     minus: '－',


### PR DESCRIPTION
Changed mac `⎋` hotkey character to `esc` key name, which seems to be more convenient