### PR TITLE
fix(Menu): fix role for MenuItem

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -121,11 +121,7 @@ export const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(function Me
     }
 
     return (
-        <li
-            ref={ref as React.ForwardedRef<HTMLLIElement>}
-            className={b('list-item')}
-            role="none"
-        >
+        <li ref={ref as React.ForwardedRef<HTMLLIElement>} className={b('list-item')} role="none">
             {item}
         </li>
     );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link].

The component currently renders links () with the role menuitem inside <li> elements.
According to the WAI-ARIA specification, menuitem elements should be direct children of an element with the role menu or menubar, without additional structural elements in between.

WAI-ARIA reference:
https://www.w3.org/WAI/ARIA/apg/patterns/menubar/#wai-ariaroles,states,andproperties

Having ```<li>``` between menu and menuitem violates the ARIA hierarchy and may cause incorrect behavior in screen readers.

I suggest adding:

```<li role="presentation">```

This follows the MDN recommendation for cases where li should not participate in the accessibility tree:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitem_role