### PR TITLE
fix: use sort icon as draggable handler in List

### DIFF
--- a/src/components/List/components/ListItem.tsx
+++ b/src/components/List/components/ListItem.tsx
@@ -75,7 +75,6 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
                     itemClassName,
                 )}
                 {...this.props.provided?.draggableProps}
-                {...this.props.provided?.dragHandleProps}
                 style={getStyle(this.props.provided, fixedStyle)}
                 onClick={item.disabled ? undefined : this.onClick}
                 onClickCapture={item.disabled ? undefined : this.onClickCapture}
@@ -99,7 +98,7 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
     private renderSortIcon() {
         const {sortable} = this.props;
         return sortable ? (
-            <div className={b('item-sort-icon')}>
+            <div {...this.props.provided?.dragHandleProps} className={b('item-sort-icon')}>
                 <Icon data={Grip} size={12} />
             </div>
         ) : null;


### PR DESCRIPTION
Previously, dragHandleProps were applied to the entire list item, making the whole item draggable. This caused:
- Accidental drags when clicking to select an item
- Conflicts between click and drag interactions.

Also I tried to implement 2 levels List with root and sub items and current logic doesn't allow to sort items correctly.

That's why I enabled dragging only through sort icon.