### PR TITLE
fix(List): ignore middle mouse button clicks

### DIFF
--- a/src/components/List/components/ListItem.tsx
+++ b/src/components/List/components/ListItem.tsx
@@ -78,6 +78,7 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
                 style={getStyle(this.props.provided, fixedStyle)}
                 onClick={item.disabled ? undefined : this.onClick}
                 onClickCapture={item.disabled ? undefined : this.onClickCapture}
+                onMouseDown={this.onMouseDown}
                 onMouseEnter={this.onMouseEnter}
                 ref={this.setRef}
                 id={`${this.props.listId}-item-${this.props.itemIndex}`}
@@ -122,7 +123,13 @@ export class ListItem<T = unknown> extends React.Component<ListItemProps<T>> {
             eventId: 'click',
         });
     };
-
+    private onMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {
+        if (event.button === 1) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+    };
     private onMouseEnter = () =>
         !this.props.item.disabled && this.props.onActivate(this.props.itemIndex);
 }


### PR DESCRIPTION
Changes:
- Added an `onMouseDown` handler for `ListItem`
- When clicking the middle mouse button inside the dropdown list, the event is prevented so that the page autoscroll is not triggered

Why: 
- In an open Select, clicking the middle mouse button inside the list area enabled the browser’s autoscroll, which caused the whole page to scroll with the dropdown open
- Many UI libraries disable middle‑click autoscroll inside dropdown lists, so it was decided to remove this behavior here as well

How to test :
1. Open a Select with a long list
2. Click the middle mouse button inside the list area
3. Verify that the page no longer starts autoscrolling and the dropdown remains open


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en