### PR TITLE
fix: [SegmentedRadioGroup] Horizontal alignment breaks if you specify…

### DIFF
--- a/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
+++ b/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
@@ -239,7 +239,12 @@ $block: '.#{variables.$ns}segmented-radio-group';
             overflow: hidden;
 
             &-text {
-                display: block;
+                display: inline-flex;
+                min-width: 0;
+            }
+
+            &-text > span {
+                min-width: 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
             }


### PR DESCRIPTION
Closes https://github.com/gravity-ui/uikit/issues/2133