### PR TITLE
fix: replace barrel imports for useLayoutEffect

### DIFF
--- a/src/hooks/useListNavigation/useListNavigation.ts
+++ b/src/hooks/useListNavigation/useListNavigation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import {useLayoutEffect} from '../..';
 import {KeyCode} from '../../constants';
+import {useLayoutEffect} from '../useLayoutEffect';
 
 import {moveBack} from './moveBack';
 import {moveForward} from './moveForward';


### PR DESCRIPTION
## Summary

  Fixed `TypeError: useLayoutEffect is not a function` error that occurs when `@gravity-ui/uikit` is used with Next.js `optimizePackageImports` option.

  ## Problem

Error found when updating packages in `gravity-ui/landing` ([PR](https://github.com/gravity-ui/landing/pull/547)).

<img src="https://github.com/user-attachments/assets/48259d2e-8bba-4eae-8a4c-f17f932de610" alt="screenshot" width="640" width="480">


When Next.js is configured with:
```js
experimental: {
  optimizePackageImports: ['@gravity-ui/uikit'],
}
```
the barrel imports (`import { useLayoutEffect } from '../..'`) in hooks are not correctly resolved, causing `useLayoutEffect` to be undefined at runtime.

This breaks components like `DropdownMenu`, `Select`, and others that use `useListNavigation` internally.