### PR TITLE
feat(pagination): add last page button and lastPage prop

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -29,6 +29,7 @@ export const Pagination = ({
     pageSizeOptions,
     showPages = true,
     showInput = false,
+    lastPage,
     className,
     qa,
 }: PaginationProps) => {
@@ -48,6 +49,7 @@ export const Pagination = ({
         page: resultPage,
         pageSize,
         total: resultTotal,
+        lastPage,
         mobile,
     });
 
@@ -95,6 +97,7 @@ export const Pagination = ({
                             item={item}
                             page={resultPage}
                             pageSize={pageSize}
+                            numberOfPages={numberOfPages}
                             onUpdate={onUpdate}
                             compact={compact}
                             className={b('pagination-item')}
@@ -109,7 +112,7 @@ export const Pagination = ({
     return (
         <div className={b(null, className)} data-qa={qa}>
             {pagination}
-            {showInput && (
+            {showInput && total !== undefined && (
                 <PaginationInput
                     numberOfPages={numberOfPages}
                     pageSize={pageSize}

--- a/src/components/Pagination/__stories__/Pagination.stories.tsx
+++ b/src/components/Pagination/__stories__/Pagination.stories.tsx
@@ -47,6 +47,35 @@ TotalUnknown.args = {
     showInput: true,
     compact: false,
 };
+TotalUnknown.parameters = {
+    docs: {
+        description: {
+            story: 'When `total` is undefined, the page input is hidden even if `showInput` is true.',
+        },
+    },
+};
+
+const LastPageTemplate: StoryFn<PaginationProps> = (args) => {
+    const state = useState(args);
+    return <Pagination {...state} />;
+};
+
+export const LastPage = LastPageTemplate.bind({});
+LastPage.args = {
+    page: 10,
+    pageSize: 100,
+    total: 1000,
+    lastPage: true,
+    showInput: true,
+    compact: false,
+};
+LastPage.parameters = {
+    docs: {
+        description: {
+            story: 'When `lastPage` is true, the "next" and "last" buttons are disabled.',
+        },
+    },
+};
 
 const CompactTemplate: StoryFn<PaginationProps> = (args) => {
     const state = useState(args);

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -19,6 +19,9 @@ describe('Pagination component', () => {
 
         const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
         expect(nextButton).toBeDisabled();
+
+        const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+        expect(lastButton).toBeDisabled();
     });
 
     describe('Two pages', () => {
@@ -47,6 +50,9 @@ describe('Pagination component', () => {
 
             const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
             expect(nextButton).not.toBeDisabled();
+
+            const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+            expect(lastButton).not.toBeDisabled();
         });
 
         test('Second page is current', () => {
@@ -73,15 +79,40 @@ describe('Pagination component', () => {
 
             const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
             expect(nextButton).toBeDisabled();
+
+            const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+            expect(lastButton).toBeDisabled();
         });
     });
 
     test('Total property undefined', () => {
-        render(<Pagination pageSize={20} onUpdate={noop} page={0} total={undefined} />);
+        render(<Pagination pageSize={20} onUpdate={noop} page={1} total={undefined} showInput />);
 
         const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
-
         expect(nextButton).not.toBeDisabled();
+
+        const lastButton = screen.queryByTestId(PaginationQa.PaginationButtonLast);
+        expect(lastButton).not.toBeInTheDocument();
+
+        const input = screen.queryByTestId(PaginationQa.PaginationInput);
+        expect(input).not.toBeInTheDocument();
+    });
+
+    test('Last page property', () => {
+        render(<Pagination pageSize={20} onUpdate={noop} page={1} total={100} lastPage />);
+
+        const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
+        expect(nextButton).toBeDisabled();
+
+        const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+        expect(lastButton).toBeDisabled();
+    });
+
+    test('Last page property', () => {
+        render(<Pagination pageSize={20} onUpdate={noop} page={1} total={undefined} lastPage />);
+
+        const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
+        expect(nextButton).toBeDisabled();
     });
 
     test.each(new Array<PaginationSize | undefined>('m', 'l', undefined))(
@@ -100,6 +131,9 @@ describe('Pagination component', () => {
 
             const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
             expect(nextButton).toHaveClass(expectedClass);
+
+            const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+            expect(lastButton).toHaveClass(expectedClass);
         },
     );
 
@@ -123,6 +157,9 @@ describe('Pagination component', () => {
 
             const nextButton = screen.getByTestId(PaginationQa.PaginationButtonNext);
             expect(nextButton).toHaveClass(expectedClass);
+
+            const lastButton = screen.getByTestId(PaginationQa.PaginationButtonLast);
+            expect(lastButton).toHaveClass(expectedClass);
         },
     );
 });

--- a/src/components/Pagination/components/PaginationButton/PaginationButton.tsx
+++ b/src/components/Pagination/components/PaginationButton/PaginationButton.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from 'react';
 
-import {ChevronLeft, ChevronRight, ChevronsLeft} from '@gravity-ui/icons';
+import {ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight} from '@gravity-ui/icons';
 
 import {Button} from '../../../Button';
 import {Icon} from '../../../Icon';
@@ -15,6 +15,7 @@ type Props = {
     size: PaginationSize;
     page: NonNullable<PaginationProps['page']>;
     pageSize: NonNullable<PaginationProps['pageSize']>;
+    numberOfPages: number;
     onUpdate: NonNullable<PaginationProps['onUpdate']>;
     compact: NonNullable<PaginationProps['compact']>;
     className?: string;
@@ -26,6 +27,7 @@ export const PaginationButton = ({
     className,
     page,
     pageSize,
+    numberOfPages,
     onUpdate,
     compact,
 }: Props) => {
@@ -79,6 +81,22 @@ export const PaginationButton = ({
                 >
                     <Icon data={ChevronRight} size="16" />
                     {compact ? undefined : t('button_next')}
+                </Button>
+            );
+            break;
+        case 'last':
+            button = (
+                <Button
+                    size={size}
+                    view="outlined"
+                    className={className}
+                    onClick={() => onUpdate(numberOfPages, pageSize)}
+                    title={compact ? t('button_last') : undefined}
+                    disabled={disabled}
+                    qa={PaginationQa.PaginationButtonLast}
+                >
+                    <Icon data={ChevronsRight} size="16" />
+                    {compact ? undefined : t('button_last')}
                 </Button>
             );
             break;

--- a/src/components/Pagination/constants.ts
+++ b/src/components/Pagination/constants.ts
@@ -6,6 +6,7 @@ export const PaginationQa = {
     PaginationButtonFirst: 'pagination-button-first',
     PaginationButtonPrevious: 'pagination-button-previous',
     PaginationButtonNext: 'pagination-button-next',
+    PaginationButtonLast: 'pagination-button-last',
 };
 
 export const getPaginationPageQa = (pageNumber: number) => {

--- a/src/components/Pagination/hooks/usePagination.ts
+++ b/src/components/Pagination/hooks/usePagination.ts
@@ -1,7 +1,7 @@
 import type {PaginationItem, PaginationProps} from '../types';
 import {getNumberOfPages, getNumerationList} from '../utils';
 
-type UsePaginationArgs = Pick<PaginationProps, 'page' | 'pageSize' | 'total'> & {
+type UsePaginationArgs = Pick<PaginationProps, 'page' | 'pageSize' | 'total' | 'lastPage'> & {
     mobile: boolean;
 };
 
@@ -14,11 +14,12 @@ export function usePagination({
     page,
     pageSize,
     total,
+    lastPage,
     mobile,
 }: UsePaginationArgs): UsePaginationReturn {
     const numberOfPages = getNumberOfPages(pageSize, total);
-    const hasTotal = numberOfPages !== 0;
-    const isNextDisabled = (hasTotal && page === numberOfPages) || total === 0;
+    const hasTotal = total !== undefined;
+    const isNextDisabled = Boolean((hasTotal && page === numberOfPages) || total === 0 || lastPage);
 
     let items: PaginationItem[];
 
@@ -62,6 +63,14 @@ export function usePagination({
         action: 'next',
         disabled: isNextDisabled,
     });
+
+    if (hasTotal) {
+        items.push({
+            type: 'button',
+            action: 'last',
+            disabled: isNextDisabled,
+        });
+    }
 
     return {items, numberOfPages};
 }

--- a/src/components/Pagination/i18n/en.json
+++ b/src/components/Pagination/i18n/en.json
@@ -2,6 +2,7 @@
   "button_previous": "Previous",
   "button_next": "Next",
   "button_first": "First",
+  "button_last": "Last",
   "label_input-placeholder": "Page #",
   "label_page-of": "of",
   "label_select_size": "Select page size"

--- a/src/components/Pagination/i18n/ru.json
+++ b/src/components/Pagination/i18n/ru.json
@@ -2,6 +2,7 @@
   "button_previous": "Предыдущая",
   "button_next": "Следующая",
   "button_first": "Первая",
+  "button_last": "Последняя",
   "label_input-placeholder": "Стр.",
   "label_page-of": "из",
   "label_select_size": "Выбрать размер страницы"

--- a/src/components/Pagination/types.ts
+++ b/src/components/Pagination/types.ts
@@ -1,6 +1,6 @@
 import type {QAProps} from '../types';
 
-export type ActionName = 'previous' | 'next' | 'first';
+export type ActionName = 'previous' | 'next' | 'first' | 'last';
 
 export type PaginationSize = 's' | 'm' | 'l' | 'xl';
 
@@ -44,6 +44,11 @@ export type PaginationProps = {
      * Default true.
      */
     showPages?: boolean;
+    /**
+     * Whether the current page is the last one.
+     * If true, the "next" button will be disabled.
+     */
+    lastPage?: boolean;
     /**
      * ClassName of element
      */


### PR DESCRIPTION
- Added lastPage prop to PaginationProps to manually disable "next" and "last" buttons. 
- Implemented "Last" button to navigate to the final page (visible only when total is provided). 
- Hidden page input field when total is undefined, even if showInput is true. 
- Added button_last translations for en and ru locales. 
- Updated Pagination tests and stories to cover new functionality. 