### PR TITLE
fix(ColorPicker): accept default value not only at hex format

### DIFF
--- a/src/components/lab/ColorPicker/ColorPicker.tsx
+++ b/src/components/lab/ColorPicker/ColorPicker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import type {HsvaColor} from '@uiw/react-color';
-import {Alpha, Hue, Saturation, hsvaToHex, hsvaToHexa, validHex} from '@uiw/react-color';
+import {Alpha, Hue, Saturation, hsvaToHex, hsvaToHexa} from '@uiw/react-color';
 
 import {useControlledState} from '../../../hooks/useControlledState';
 import {Popup} from '../../Popup';
@@ -11,7 +11,12 @@ import {Select} from '../../Select';
 import {ColorDisplay, ColorPointer, HexInput, RgbInputs} from './components';
 import {DEFAULT_COLOR, b} from './constants';
 import {Modes} from './types';
-import {convertSelectedModeColorToHsva, getTextValueByMode, isValidHsva} from './utils';
+import {
+    getTextValueByMode,
+    isValidHsva,
+    normalizeInputColorForMode,
+    parseColorToHsva,
+} from './utils';
 
 export interface ColorPickerProps {
     /*
@@ -72,6 +77,8 @@ const MODE_OPTIONS = Object.values(Modes).map((val) => ({
 
 const COLOR_POINTER_TRANSLATE = 'translate(-50%, -50%)';
 const SLIDERS_TRANSLATE = 'translate(-50%, -25%)';
+const isSameHsva = (a: HsvaColor, b: HsvaColor) =>
+    a.h === b.h && a.s === b.s && a.v === b.v && a.a === b.a;
 
 export const ColorPicker = ({
     size,
@@ -90,12 +97,21 @@ export const ColorPicker = ({
 
     const [color, setColor] = useControlledState(value, defaultValue, onUpdate);
 
+    const [isOpen, setIsOpen] = useControlledState(open, defaultOpen, onOpenChange);
+
     const isInternalUpdateRef = React.useRef(false);
 
     const effectiveColor = color?.trim() || DEFAULT_COLOR;
 
-    const [hsva, setHsva] = React.useState<HsvaColor>(() =>
-        convertSelectedModeColorToHsva(effectiveColor, Modes.Hex, withAlpha),
+    const initialColor = (value ?? defaultValue)?.trim() || DEFAULT_COLOR;
+
+    const [hsva, setHsva] = React.useState<HsvaColor>(() => {
+        const parsed = parseColorToHsva(initialColor, withAlpha);
+        return parsed.isValid ? parsed.hsva : parseColorToHsva(DEFAULT_COLOR, withAlpha).hsva;
+    });
+
+    const [inputValue, setInputValue] = React.useState(() =>
+        getTextValueByMode(hsva, modeState, withAlpha),
     );
 
     React.useEffect(() => {
@@ -103,91 +119,94 @@ export const ColorPicker = ({
             isInternalUpdateRef.current = false;
             return;
         }
-        setHsva(convertSelectedModeColorToHsva(effectiveColor, Modes.Hex, withAlpha));
-    }, [color, withAlpha]);
 
-    const [isOpen, setIsOpen] = useControlledState(open, defaultOpen, onOpenChange);
+        const parsed = parseColorToHsva(effectiveColor, withAlpha);
 
-    const [inputValue, setInputValue] = React.useState(() =>
-        getTextValueByMode(hsva, modeState, withAlpha),
-    );
+        if (parsed.isValid) {
+            setHsva((prev) => (isSameHsva(prev, parsed.hsva) ? prev : parsed.hsva));
+        }
+    }, [effectiveColor, withAlpha]);
 
     React.useEffect(() => {
-        setInputValue(getTextValueByMode(hsva, modeState, withAlpha));
+        const nextValue = getTextValueByMode(hsva, modeState, withAlpha);
+        setInputValue((prev) => (prev === nextValue ? prev : nextValue));
     }, [hsva, modeState, withAlpha]);
 
-    const updateHsva = React.useCallback(
-        (updates: Partial<HsvaColor>) => {
-            setHsva((prevHsva) => {
-                const newHsva = {...prevHsva, ...updates};
+    const updateHsva = React.useCallback((updates: Partial<HsvaColor>) => {
+        setHsva((prevHsva) => {
+            const nextHsva = {...prevHsva, ...updates};
 
-                if (!isValidHsva(newHsva)) return prevHsva;
+            if (!isValidHsva(nextHsva)) {
+                return prevHsva;
+            }
 
-                if (
-                    newHsva.h === prevHsva.h &&
-                    newHsva.s === prevHsva.s &&
-                    newHsva.v === prevHsva.v &&
-                    newHsva.a === prevHsva.a
-                ) {
-                    return prevHsva;
-                }
+            if (
+                nextHsva.h === prevHsva.h &&
+                nextHsva.s === prevHsva.s &&
+                nextHsva.v === prevHsva.v &&
+                nextHsva.a === prevHsva.a
+            ) {
+                return prevHsva;
+            }
 
-                const newHexValue = withAlpha ? hsvaToHexa(newHsva) : hsvaToHex(newHsva);
+            return nextHsva;
+        });
+    }, []);
 
-                isInternalUpdateRef.current = true;
-                setColor(newHexValue);
+    React.useEffect(() => {
+        const nextHexValue = withAlpha ? hsvaToHexa(hsva) : hsvaToHex(hsva);
 
-                return newHsva;
-            });
-        },
-        [setColor, withAlpha],
-    );
+        if (nextHexValue !== color) {
+            isInternalUpdateRef.current = true;
+            setColor(nextHexValue);
+        }
+    }, [hsva, withAlpha, color, setColor]);
 
-    const handleModeChange = (newMode: Modes) => {
-        setModeState(newMode);
-    };
+    const handleModeChange = (newMode: Modes) => setModeState(newMode);
 
     const handleInputChange = (val: string) => {
         setInputValue(val);
     };
 
+    const resetInputValue = React.useCallback(() => {
+        setInputValue(getTextValueByMode(hsva, modeState, withAlpha));
+    }, [hsva, modeState, withAlpha]);
+
     const applyInputValue = React.useCallback(() => {
         const raw = inputValue.trim();
 
         if (!raw) {
-            setInputValue(color);
+            resetInputValue();
             return;
         }
 
-        if (modeState === Modes.Hex && !validHex(raw)) {
-            setInputValue(color);
-            return;
-        }
-        const newHsva = convertSelectedModeColorToHsva(raw, modeState, withAlpha);
+        const normalized = normalizeInputColorForMode(raw, modeState, withAlpha);
 
-        if (!isValidHsva(newHsva)) {
-            setInputValue(color);
+        if (!normalized.isValid) {
+            resetInputValue();
             return;
         }
 
-        const newHexValue = withAlpha ? hsvaToHexa(newHsva) : hsvaToHex(newHsva);
-
-        if (!validHex(newHexValue)) {
-            setInputValue(color);
-            return;
-        }
+        const nextHsva = normalized.hsva;
+        const nextHexValue = withAlpha ? hsvaToHexa(nextHsva) : hsvaToHex(nextHsva);
 
         isInternalUpdateRef.current = true;
-        setHsva(newHsva);
-        setColor(newHexValue);
-    }, [inputValue, modeState, withAlpha, setColor, color]);
+        setHsva(nextHsva);
+        setColor(nextHexValue);
+        setInputValue(normalized.formattedValue);
+    }, [inputValue, modeState, withAlpha, resetInputValue, setColor]);
+    const selectValue = React.useMemo(() => [modeState], [modeState]);
 
     return (
         <React.Fragment>
             <ColorDisplay
                 hsva={hsva}
                 withAlpha={withAlpha}
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={() => {
+                    if (!disabled) {
+                        setIsOpen(!isOpen);
+                    }
+                }}
                 onColorChange={updateHsva}
                 ref={setAnchor}
                 size={size}
@@ -256,8 +275,13 @@ export const ColorPicker = ({
                         <Select
                             options={MODE_OPTIONS}
                             multiple={false}
-                            value={[modeState]}
-                            onUpdate={(val) => handleModeChange(val[0] as Modes)}
+                            value={selectValue}
+                            onUpdate={(val) => {
+                                const nextMode = val[0];
+                                if (nextMode && nextMode !== modeState) {
+                                    handleModeChange(nextMode as Modes);
+                                }
+                            }}
                         />
 
                         {modeState === Modes.Hex && (

--- a/src/components/lab/ColorPicker/__stories__/ColorPicker.stories.tsx
+++ b/src/components/lab/ColorPicker/__stories__/ColorPicker.stories.tsx
@@ -28,7 +28,8 @@ const parameters = {
 };
 export const Default = {
     args: {
-        value: '#000000',
+        value: undefined,
+        defaultValue: 'rgb(100,10,20)',
         onUpdate: (color) => console.log('Color changed:', color),
     },
     parameters,

--- a/src/components/lab/ColorPicker/components/ColorDisplay/ColorDisplay.tsx
+++ b/src/components/lab/ColorPicker/components/ColorDisplay/ColorDisplay.tsx
@@ -6,7 +6,7 @@ import type {HsvaColor} from '@uiw/react-color';
 import {TextInput} from '../../../../controls';
 import {b} from '../../constants';
 import {Modes} from '../../types';
-import {convertSelectedModeColorToHsva, getTextValueByMode} from '../../utils';
+import {getTextValueByMode, normalizeInputColorForMode} from '../../utils';
 
 type ColorDisplayProps = {
     hsva: HsvaColor;
@@ -29,7 +29,7 @@ export const ColorDisplay = React.forwardRef<HTMLDivElement, ColorDisplayProps>(
 
         const handleInputBlur = React.useCallback(() => {
             try {
-                const newHsva = convertSelectedModeColorToHsva(inputValue, Modes.Hex, withAlpha);
+                const newHsva = normalizeInputColorForMode(inputValue, Modes.Hex, withAlpha).hsva;
 
                 onColorChange?.(newHsva);
             } catch {

--- a/src/components/lab/ColorPicker/utils.ts
+++ b/src/components/lab/ColorPicker/utils.ts
@@ -1,78 +1,166 @@
 import {
     hexToHsva,
+    hslaStringToHsva,
+    hsvaStringToHsva,
     hsvaToHex,
     hsvaToHexa,
     hsvaToRgbString,
-    hsvaToRgba,
-    rgbStringToHsva,
+    hsvaToRgbaString,
     rgbaStringToHsva,
+    validHex,
 } from '@uiw/react-color';
 import type {HsvaColor, RgbaColor} from '@uiw/react-color';
 
 import {Modes} from './types';
 
-/**
- * Validates if an HsvaColor object has valid values (no NaN)
- */
-export const isValidHsva = (hsva: HsvaColor): boolean => {
+const DEFAULT_HSVA: HsvaColor = {h: 0, s: 0, v: 0, a: 1};
+
+const POSSIBLE_HEX_RE = /^(?:#)?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+const normalizePossibleHexInput = (value: string): string => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return trimmed;
+    }
+
+    if (POSSIBLE_HEX_RE.test(trimmed) && !trimmed.startsWith('#')) {
+        return `#${trimmed}`;
+    }
+
+    return trimmed;
+};
+
+const normalizeAlpha = (hsva: HsvaColor, withAlpha: boolean): HsvaColor => {
+    return withAlpha ? hsva : {...hsva, a: 1};
+};
+
+const getInvalidResult = () => ({
+    hsva: {...DEFAULT_HSVA},
+    formattedValue: '',
+    isValid: false,
+});
+
+export const isValidHsva = (value: HsvaColor): boolean => {
     return (
-        !Number.isNaN(hsva.h) &&
-        !Number.isNaN(hsva.s) &&
-        !Number.isNaN(hsva.v) &&
-        !Number.isNaN(hsva.a) &&
-        Number.isFinite(hsva.h) &&
-        Number.isFinite(hsva.s) &&
-        Number.isFinite(hsva.v) &&
-        Number.isFinite(hsva.a)
+        Number.isFinite(value.h) &&
+        Number.isFinite(value.s) &&
+        Number.isFinite(value.v) &&
+        Number.isFinite(value.a) &&
+        value.h >= 0 &&
+        value.h <= 360 &&
+        value.s >= 0 &&
+        value.s <= 100 &&
+        value.v >= 0 &&
+        value.v <= 100 &&
+        value.a >= 0 &&
+        value.a <= 1
     );
 };
 
-const DEFAULT_HSVA: HsvaColor = {h: 0, s: 0, v: 0, a: 1};
+const parseStringToHsva = (value: string): HsvaColor | null => {
+    const trimmed = value.trim();
 
-export const convertSelectedModeColorToHsva = (value: string, mode: Modes, alpha: boolean) => {
-    if (!value || value.trim() === '') {
-        return {...DEFAULT_HSVA};
+    if (!trimmed) {
+        return null;
     }
 
+    const normalizedHex = normalizePossibleHexInput(trimmed);
+
+    if (validHex(normalizedHex)) {
+        const hsva = hexToHsva(normalizedHex);
+        return isValidHsva(hsva) ? hsva : null;
+    }
+
+    if (/^rgba?\(/i.test(trimmed)) {
+        const hsva = rgbaStringToHsva(trimmed);
+        return isValidHsva(hsva) ? hsva : null;
+    }
+
+    if (/^hsla?\(/i.test(trimmed)) {
+        const hsva = hslaStringToHsva(trimmed);
+        return isValidHsva(hsva) ? hsva : null;
+    }
+
+    if (/^hsva?\(/i.test(trimmed)) {
+        const hsva = hsvaStringToHsva(trimmed);
+        return isValidHsva(hsva) ? hsva : null;
+    }
+
+    return null;
+};
+
+export const getTextValueByMode = (hsva: HsvaColor, mode: Modes, withAlpha: boolean): string => {
+    const normalizedHsva = normalizeAlpha(hsva, withAlpha);
+
     switch (mode) {
-        case Modes.Hex: {
-            // If alpha is disabled, strip alpha channel from hex value
-            if (!alpha && value.length === 9) {
-                value = value.substring(0, 7); // Keep only #RRGGBB
-            }
+        case Modes.Hex:
+            return withAlpha ? hsvaToHexa(normalizedHsva) : hsvaToHex(normalizedHsva);
 
-            const hsva = hexToHsva(value);
+        case Modes.Rgb:
+            return withAlpha ? hsvaToRgbaString(normalizedHsva) : hsvaToRgbString(normalizedHsva);
 
-            // If alpha is disabled, ensure alpha is set to 1
-            if (!alpha) {
-                hsva.a = 1;
-            }
-
-            return hsva;
-        }
-        case Modes.Rgb: {
-            return alpha ? rgbaStringToHsva(value) : rgbStringToHsva(value);
-        }
+        default:
+            return withAlpha ? hsvaToHexa(normalizedHsva) : hsvaToHex(normalizedHsva);
     }
 };
 
-export function formatRgbaString(hsvaResult: RgbaColor) {
-    const {r, g, b, a} = hsvaResult;
+export const parseColorToHsva = (
+    value: string,
+    withAlpha: boolean,
+): {
+    hsva: HsvaColor;
+    isValid: boolean;
+} => {
+    const parsed = parseStringToHsva(value);
 
+    if (!parsed) {
+        return {
+            hsva: {...DEFAULT_HSVA},
+            isValid: false,
+        };
+    }
+
+    const hsva = normalizeAlpha(parsed, withAlpha);
+
+    if (!isValidHsva(hsva)) {
+        return {
+            hsva: {...DEFAULT_HSVA},
+            isValid: false,
+        };
+    }
+
+    return {
+        hsva,
+        isValid: true,
+    };
+};
+
+export const normalizeInputColorForMode = (
+    value: string,
+    selectedMode: Modes,
+    withAlpha: boolean,
+): {
+    hsva: HsvaColor;
+    formattedValue: string;
+    isValid: boolean;
+} => {
+    const parsed = parseColorToHsva(value, withAlpha);
+
+    if (!parsed.isValid) {
+        return getInvalidResult();
+    }
+
+    return {
+        hsva: parsed.hsva,
+        formattedValue: getTextValueByMode(parsed.hsva, selectedMode, withAlpha),
+        isValid: true,
+    };
+};
+
+export function formatRgbaString(rgba: RgbaColor) {
+    const {r, g, b, a} = rgba;
     const roundedA = Math.round(a * 100) / 100;
 
     return `rgba(${r},${g},${b},${roundedA})`;
 }
-
-export const getTextValueByMode = (hsva: HsvaColor, mode: Modes, alpha: boolean) => {
-    switch (mode) {
-        case Modes.Rgb: {
-            return alpha ? formatRgbaString(hsvaToRgba(hsva)) : hsvaToRgbString(hsva);
-        }
-        case Modes.Hex: {
-            const hexValue = alpha ? hsvaToHexa(hsva) : hsvaToHex(hsva);
-
-            return hexValue;
-        }
-    }
-};


### PR DESCRIPTION
ColorPicker defaultValue could not be set as rgb by default and made input transparent. I've made the improvement that helps normalize any incoming color value and adapt it to hex as default.