### PR TITLE
feat(Tabs): allow scroll

### DIFF
--- a/src/components/legacy/Tabs/Tabs.scss
+++ b/src/components/legacy/Tabs/Tabs.scss
@@ -150,6 +150,11 @@ $block: '.#{variables.$ns}tabs-legacy';
         }
     }
 
+    &_with-scroll {
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
     &_direction_vertical {
         display: flex;
         flex-direction: column;

--- a/src/components/legacy/Tabs/Tabs.tsx
+++ b/src/components/legacy/Tabs/Tabs.tsx
@@ -48,6 +48,9 @@ export interface TabsProps extends AriaLabelingProps, QAProps {
      * Ignored when tabs rendered via `children`
      */
     wrapTo?(item: TabsItemProps, node: React.ReactNode, index: number): React.ReactNode;
+
+    /** Allow tab items to overflow container and enables scroll: auto for horizontal direction  */
+    allowScroll?: boolean;
 }
 
 const getActiveTabId = (
@@ -81,6 +84,7 @@ const TabsComponent = React.forwardRef<HTMLDivElement, TabsProps>(
             onSelectTab,
             wrapTo,
             qa,
+            allowScroll,
             ...restProps
         },
         ref,
@@ -111,7 +115,7 @@ const TabsComponent = React.forwardRef<HTMLDivElement, TabsProps>(
             <div
                 {...filterDOMProps(restProps, {labelable: true})}
                 role="tablist"
-                className={b({direction, size}, className)}
+                className={b({direction, size, 'with-scroll': allowScroll}, className)}
                 data-qa={qa}
                 ref={ref}
             >

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -166,6 +166,7 @@ LANDING_BLOCK-->
 | activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately |         `boolean`         | `false` |
 | size            | Element size                                                                         |    `"m"` `"l"` `"xl"`     |  `"m"`  |
 | qa              | HTML `data-qa` attribute, used in tests                                              |         `string`          |         |
+| allowScroll     | Allows content to overflow container with scroll instead of wrap to next line        |         `string`          |         |
 
 ## Tab
 

--- a/src/components/tabs/TabList.scss
+++ b/src/components/tabs/TabList.scss
@@ -46,6 +46,11 @@ $tabBlock: '.#{variables.$ns}tab';
         }
     }
 
+    &_with-scroll {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+    }
+
     #{$tabBlock}:not(:last-child) {
         margin-inline-end: var(--g-tabs-item-gap, var(--_--item-gap));
     }

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -126,7 +126,10 @@ export function useTabList(
         role: 'tablist',
         'aria-orientation': 'horizontal' as const,
         onKeyDown,
-        className: bTabList({size: tabListProps.size ?? 'm'}, tabListProps.className),
+        className: bTabList(
+            {size: tabListProps.size ?? 'm', 'with-scroll': tabListProps.allowScroll},
+            tabListProps.className,
+        ),
         'data-qa': tabListProps.qa,
     };
 }

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -21,6 +21,7 @@ export interface TabListProps
     // contentOverflow?: 'wrap';
     activateOnFocus?: boolean;
     children?: React.ReactNode;
+    allowScroll?: boolean;
 }
 
 interface TabCommonProps extends QAProps, DOMProps {


### PR DESCRIPTION
Now Tabs component always wrap items to next line if they are overflow container. And it's very bad ux in mobile layout
It forces to re-write component's styles by adding `flex: nowrap + overflow-x: auto`.

We should enable ability to do it by using prop