### PR TITLE
fix(Table): add missing class to menu popup

### DIFF
--- a/src/components/Table/hoc/withTableActions/withTableActions.tsx
+++ b/src/components/Table/hoc/withTableActions/withTableActions.tsx
@@ -175,6 +175,7 @@ const DefaultRowActions = <I extends TableDataItem>({
                 placement={DEFAULT_PLACEMENT}
                 onOutsideClick={closePopup}
                 id={rowId}
+                className={bPopup()}
                 qa={tableQa && `${tableQa}-actions-popup`}
             >
                 <Menu className={menuCn} size={rowActionsSize}>


### PR DESCRIPTION
Some styles were introduced in #2612. But this class was never attached to any element