### PR TITLE
fix(Breadcrumbs): render endContent only once to prevent duplicate events

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -190,11 +190,6 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
                     {items.map((child, index) =>
                         renderChild(child, index, index === items.length - 1, false),
                     )}
-                    {props.endContent && (
-                        <li key="end-content" className={b('item')}>
-                            {props.endContent}
-                        </li>
-                    )}
                 </ol>
             </div>
         </ol>

--- a/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -279,6 +279,18 @@ it('should support links', async function () {
     expect(items[1]).toHaveAttribute('href', 'https://example.com/foo');
 });
 
+it('renders endContent only once in the DOM', () => {
+    render(
+        <Breadcrumbs endContent={<button>Action</button>}>
+            <Breadcrumbs.Item>Folder 1</Breadcrumbs.Item>
+            <Breadcrumbs.Item>Folder 2</Breadcrumbs.Item>
+        </Breadcrumbs>,
+    );
+
+    const buttons = screen.getAllByRole('button', {name: 'Action'});
+    expect(buttons).toHaveLength(1);
+});
+
 it('should support custom item component', async () => {
     const navigate = jest.fn();
     function RouterLink({


### PR DESCRIPTION
## Summary

Fixes #2617 — `endContent` is rendered twice in the DOM (once in the visible list, once in the hidden measurer container), causing interactive elements to fire events twice and duplicating `data-qa` attributes.

**Root cause:** The measurer `<div aria-hidden="true" inert>` renders a full copy of `endContent` for width calculation. Even though the container is hidden, React still mounts the component tree and attaches event handlers.

**Fix:** Remove `endContent` from the measurer. It is already tracked via `preservedRefs` in the visible list (line 58), so `useCollapseChildren` correctly accounts for its width during collapse calculation.

## Test plan

- [x] Added test: `renders endContent only once in the DOM` — verifies only one button is found by role
- [x] All 15 existing Breadcrumbs tests pass
- [x] ESLint + pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)