### PR TITLE
fix(Breadcrumbs): use hash instead of measurer element for recalculation

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -11,7 +11,7 @@ import {BreadcrumbsDropdownMenu} from './BreadcrumbsDropdownMenu';
 import {BreadcrumbsItem} from './BreadcrumbsItem';
 import type {BreadcrumbsItemInnerProps} from './BreadcrumbsItem';
 import {BreadcrumbsSeparator} from './BreadcrumbsSeparator';
-import {b} from './utils';
+import {b, getReactNodeHash} from './utils';
 
 import './Breadcrumbs.scss';
 
@@ -36,7 +36,6 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     const listRef = React.useRef<HTMLOListElement>(null);
     const containerRef = useForkRef(ref, listRef);
     const menuRef = React.useRef<HTMLLIElement>(null);
-    const measurerListRef = React.useRef<HTMLOListElement>(null);
     const endContentRef = React.useRef<HTMLLIElement>(null);
 
     const items: React.ReactElement<any>[] = [];
@@ -71,52 +70,16 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
     });
 
     useResizeObserver({
-        ref: measurerListRef,
+        ref: endContentRef,
         onResize: recalculate,
     });
 
-    const renderChild = (
-        child: React.ReactElement,
-        index: number,
-        isCurrent: boolean,
-        isCalculated: boolean,
-    ) => {
-        const key = child.key ?? index;
-
-        const {'data-breadcrumbs-menu-item': isMenu, ...childProps} = child.props;
-        let item: React.ReactNode;
-        if (isMenu) {
-            item = child;
-        } else {
-            const Component = props.itemComponent ?? BreadcrumbsItem;
-            const handleAction = () => {
-                if (typeof props.onAction === 'function') {
-                    props.onAction(key);
-                }
-            };
-            const innerProps: BreadcrumbsItemInnerProps = {
-                __current: isCurrent,
-                __disabled: props.disabled || childProps.disabled,
-                __onAction: handleAction,
-            };
-            item = (
-                <Component {...childProps} key={key} {...innerProps}>
-                    {childProps.children}
-                </Component>
-            );
-        }
-        return (
-            <li
-                ref={isMenu ? menuRef : undefined}
-                key={isMenu ? 'menu' : `item-${key}`}
-                className={b('item', {calculating: isCurrent && !isCalculated, current: isCurrent})}
-                data-current={isCurrent ? isCurrent : undefined}
-            >
-                {item}
-                {isCurrent ? null : <BreadcrumbsSeparator separator={props.separator} />}
-            </li>
-        );
-    };
+    const childrenHash = getReactNodeHash(props.children);
+    const separatorHash = getReactNodeHash(props.separator);
+    React.useEffect(() => {
+        recalculate();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [childrenHash, separatorHash, props.itemComponent]);
 
     let contents = items;
     if (items.length > visibleItemsCount) {
@@ -164,17 +127,6 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
         contents.push(...breadcrumbs.slice(-endItems));
     }
 
-    const lastIndex = contents.length - 1;
-    const breadcrumbsItems = contents.map((child, index) =>
-        renderChild(child, index, index === lastIndex, calculated),
-    );
-    if (props.endContent) {
-        breadcrumbsItems.push(
-            <li key="end-content" ref={endContentRef} className={b('item')}>
-                {props.endContent}
-            </li>,
-        );
-    }
     return (
         <ol
             ref={containerRef}
@@ -183,20 +135,52 @@ export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
             className={b(null, props.className)}
             style={props.style}
         >
-            {breadcrumbsItems}
-            {/* @ts-expect-error */}
-            <div className={b('measurer')} aria-hidden="true" inert="">
-                <ol ref={measurerListRef} className={b('list')} style={props.style}>
-                    {items.map((child, index) =>
-                        renderChild(child, index, index === items.length - 1, false),
-                    )}
-                    {props.endContent && (
-                        <li key="end-content" className={b('item')}>
-                            {props.endContent}
-                        </li>
-                    )}
-                </ol>
-            </div>
+            {contents.map((child, index) => {
+                const key = child.key ?? index;
+                const isCurrent = index === contents.length - 1;
+
+                const {'data-breadcrumbs-menu-item': isMenu, ...childProps} = child.props;
+                let item: React.ReactNode;
+                if (isMenu) {
+                    item = child;
+                } else {
+                    const Component = props.itemComponent ?? BreadcrumbsItem;
+                    const handleAction = () => {
+                        if (typeof props.onAction === 'function') {
+                            props.onAction(key);
+                        }
+                    };
+                    const innerProps: BreadcrumbsItemInnerProps = {
+                        __current: isCurrent,
+                        __disabled: props.disabled || childProps.disabled,
+                        __onAction: handleAction,
+                    };
+                    item = (
+                        <Component {...childProps} key={key} {...innerProps}>
+                            {childProps.children}
+                        </Component>
+                    );
+                }
+                return (
+                    <li
+                        ref={isMenu ? menuRef : undefined}
+                        key={isMenu ? 'menu' : `item-${key}`}
+                        className={b('item', {
+                            calculating: isCurrent && !calculated,
+                            current: isCurrent,
+                        })}
+                        data-current={isCurrent ? isCurrent : undefined}
+                    >
+                        {item}
+                        {isCurrent ? null : <BreadcrumbsSeparator separator={props.separator} />}
+                    </li>
+                );
+            })}
+            {props.endContent && (
+                <li ref={endContentRef} className={b('item')}>
+                    {props.endContent}
+                </li>
+            )}
         </ol>
     );
 }) as unknown as BreadcrumbsComponent;

--- a/src/components/Breadcrumbs/__tests__/getReactNodeHash.test.tsx
+++ b/src/components/Breadcrumbs/__tests__/getReactNodeHash.test.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react';
+
+import {getReactNodeHash} from '../utils';
+
+function Wrapper({children}: {children?: React.ReactNode}) {
+    return <div>{children}</div>;
+}
+Wrapper.displayName = 'Wrapper';
+
+it('returns empty string for null/undefined/boolean', () => {
+    expect(getReactNodeHash(null)).toBe('');
+    expect(getReactNodeHash(undefined)).toBe('');
+    expect(getReactNodeHash(true)).toBe('');
+    expect(getReactNodeHash(false)).toBe('');
+});
+
+it('returns string representation for primitives', () => {
+    expect(getReactNodeHash('hello')).toBe('hello');
+    expect(getReactNodeHash(42)).toBe('42');
+});
+
+it('includes element type name for intrinsic elements', () => {
+    const hash = getReactNodeHash(<span>text</span>);
+    expect(hash).toContain('span');
+});
+
+it('includes displayName for custom components', () => {
+    const hash = getReactNodeHash(<Wrapper>text</Wrapper>);
+    expect(hash).toContain('Wrapper');
+});
+
+it('includes element key', () => {
+    const hash = getReactNodeHash(<span key="my-key">text</span>);
+    expect(hash).toContain('my-key');
+});
+
+it('includes primitive props', () => {
+    const hash = getReactNodeHash(<a href="/home" title="Home" />);
+    expect(hash).toContain('href:/home');
+    expect(hash).toContain('title:Home');
+});
+
+it('includes boolean and number props', () => {
+    const hash = getReactNodeHash(<input disabled={true} tabIndex={-1} />);
+    expect(hash).toContain('disabled:true');
+    expect(hash).toContain('tabIndex:-1');
+});
+
+it('ignores function and object props', () => {
+    const onClick = () => {};
+    const style = {color: 'red'};
+    const hash = getReactNodeHash(<button onClick={onClick} style={style} />);
+    expect(hash).not.toContain('onClick');
+    expect(hash).not.toContain('style');
+});
+
+it('recurses into nested children', () => {
+    const hash = getReactNodeHash(
+        <div>
+            <span>nested text</span>
+        </div>,
+    );
+    expect(hash).toContain('span');
+    expect(hash).toContain('nested text');
+});
+
+it('handles deeply nested structures', () => {
+    const hash = getReactNodeHash(
+        <div>
+            <ul>
+                <li>
+                    <a href="/deep">deep link</a>
+                </li>
+            </ul>
+        </div>,
+    );
+    expect(hash).toContain('deep link');
+    expect(hash).toContain('href:/deep');
+});
+
+it('returns same hash for same structure', () => {
+    const tree = (
+        <div>
+            <span className="a">text</span>
+            <span className="b">other</span>
+        </div>
+    );
+    expect(getReactNodeHash(tree)).toBe(getReactNodeHash(tree));
+});
+
+it('returns different hash when text changes', () => {
+    const hash1 = getReactNodeHash(<span>text A</span>);
+    const hash2 = getReactNodeHash(<span>text B</span>);
+    expect(hash1).not.toBe(hash2);
+});
+
+it('returns different hash when props change', () => {
+    const hash1 = getReactNodeHash(<a href="/a">link</a>);
+    const hash2 = getReactNodeHash(<a href="/b">link</a>);
+    expect(hash1).not.toBe(hash2);
+});
+
+it('returns different hash when element type changes', () => {
+    const hash1 = getReactNodeHash(<span>text</span>);
+    const hash2 = getReactNodeHash(<div>text</div>);
+    expect(hash1).not.toBe(hash2);
+});
+
+it('returns different hash when children count changes', () => {
+    const hash1 = getReactNodeHash(
+        <React.Fragment>
+            <span>a</span>
+            <span>b</span>
+        </React.Fragment>,
+    );
+    const hash2 = getReactNodeHash(
+        <React.Fragment>
+            <span>a</span>
+            <span>b</span>
+            <span>c</span>
+        </React.Fragment>,
+    );
+    expect(hash1).not.toBe(hash2);
+});
+
+it('returns different hash when children order changes', () => {
+    const hash1 = getReactNodeHash(
+        <React.Fragment>
+            <span>a</span>
+            <span>b</span>
+        </React.Fragment>,
+    );
+    const hash2 = getReactNodeHash(
+        <React.Fragment>
+            <span>b</span>
+            <span>a</span>
+        </React.Fragment>,
+    );
+    expect(hash1).not.toBe(hash2);
+});
+
+it('handles multiple children at top level', () => {
+    const hash = getReactNodeHash(
+        <React.Fragment>
+            <span>first</span>
+            <span>second</span>
+        </React.Fragment>,
+    );
+    expect(hash).toContain('first');
+    expect(hash).toContain('second');
+});
+
+it('handles mixed children types', () => {
+    const hash = getReactNodeHash(
+        <div>
+            text node
+            <span>element</span>
+            {42}
+        </div>,
+    );
+    expect(hash).toContain('text node');
+    expect(hash).toContain('span');
+    expect(hash).toContain('element');
+    expect(hash).toContain('42');
+});
+
+it('returns different hash when nested prop changes', () => {
+    const hash1 = getReactNodeHash(
+        <div>
+            <a href="/old">link</a>
+        </div>,
+    );
+    const hash2 = getReactNodeHash(
+        <div>
+            <a href="/new">link</a>
+        </div>,
+    );
+    expect(hash1).not.toBe(hash2);
+});

--- a/src/components/Breadcrumbs/utils.ts
+++ b/src/components/Breadcrumbs/utils.ts
@@ -1,3 +1,53 @@
+import * as React from 'react';
+
 import {block} from '../utils/cn';
 
 export const b = block('breadcrumbs');
+
+/**
+ * This is not a full hash, but a stable string that will change when:
+ *  - the text changes at any level of nesting
+ *  - the component type changes
+ *  - primitive props change (className, title, href, etc.)
+ *  - elements are added, removed, or reordered
+ */
+export function getReactNodeHash(children: React.ReactNode): string {
+    const parts: string[] = [];
+
+    React.Children.forEach(children, (child) => {
+        if (child === null || child === undefined || typeof child === 'boolean') {
+            return;
+        }
+
+        if (typeof child === 'string' || typeof child === 'number') {
+            parts.push(String(child));
+            return;
+        }
+
+        if (React.isValidElement(child)) {
+            const type = child.type;
+            const typeName =
+                typeof type === 'string'
+                    ? type
+                    : (type as React.ComponentType)?.displayName ||
+                      (type as React.ComponentType)?.name ||
+                      '';
+            parts.push(typeName);
+
+            if (child.key !== null && child.key !== undefined) parts.push(String(child.key));
+
+            const {children: nested, ...rest} = child.props as Record<string, unknown>;
+            for (const [k, v] of Object.entries(rest)) {
+                if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+                    parts.push(`${k}:${v}`);
+                }
+            }
+
+            if (nested) {
+                parts.push(getReactNodeHash(nested as React.ReactNode));
+            }
+        }
+    });
+
+    return parts.join('|');
+}


### PR DESCRIPTION
## Summary by Sourcery

Use a hash of breadcrumb children to trigger recalculation instead of relying on a hidden measurer element, simplifying rendering and item handling.

Bug Fixes:
- Ensure breadcrumb layout recalculates when children change by hashing children and using it as a React effect dependency.

Enhancements:
- Inline breadcrumb item rendering in the main list and remove the separate hidden measurer list and associated render helper.
- Add a utility to compute a stable hash from breadcrumb children, including element types, keys, primitive props, and nested children.