### PR TITLE
feat(useFocusWithin): with focus on parent document

### DIFF
--- a/src/hooks/useFocusWithin/useFocusWithin.test.tsx
+++ b/src/hooks/useFocusWithin/useFocusWithin.test.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import userEvent from '@testing-library/user-event';
 import ReactDom from 'react-dom';
 
@@ -244,5 +246,189 @@ describe('useFocusWithin', () => {
         });
 
         expect(events).toEqual([]);
+    });
+
+    describe('when rendered inside an iframe (window !== window.parent)', () => {
+        let parentFocusInListeners: Array<(e: FocusEvent) => void>;
+
+        const triggerParentFocusIn = () => {
+            parentFocusInListeners.forEach((fn) => fn(new FocusEvent('focusin')));
+        };
+
+        // In a real browser, when focus crosses document boundaries (iframe → parent window),
+        // the iframe's activeElement becomes body BEFORE focusout fires with relatedTarget=null.
+        // JSDOM doesn't implement cross-document focus, so we simulate it manually.
+        const simulateCrossDocumentBlur = (element: HTMLElement) => {
+            const spy = jest.spyOn(document, 'activeElement', 'get').mockReturnValue(document.body);
+            element.dispatchEvent(new FocusEvent('focusout', {relatedTarget: null, bubbles: true}));
+            spy.mockRestore();
+        };
+
+        beforeEach(() => {
+            parentFocusInListeners = [];
+            const mockParent = {
+                addEventListener: (_type: string, fn: EventListenerOrEventListenerObject) => {
+                    parentFocusInListeners.push(fn as (e: FocusEvent) => void);
+                },
+                removeEventListener: (_type: string, fn: EventListenerOrEventListenerObject) => {
+                    const idx = parentFocusInListeners.indexOf(fn as (e: FocusEvent) => void);
+                    if (idx >= 0) parentFocusInListeners.splice(idx, 1);
+                },
+            };
+            Object.defineProperty(window, 'parent', {
+                configurable: true,
+                get: () => mockParent,
+            });
+        });
+
+        afterEach(() => {
+            Object.defineProperty(window, 'parent', {
+                configurable: true,
+                get: () => window,
+            });
+        });
+
+        it('should handle focus and blur events normally when focus stays in same window', async () => {
+            const user = userEvent.setup();
+            const events: any[] = [];
+            const Component = () => {
+                const {focusWithinProps} = useFocusWithin({
+                    onFocusWithin: (e) => events.push({type: e.type, target: e.target}),
+                    onBlurWithin: (e) => events.push({type: e.type, target: e.target}),
+                    onFocusWithinChange: (isFocused) =>
+                        events.push({type: 'focuschange', isFocused}),
+                });
+                return <button {...focusWithinProps} />;
+            };
+
+            render(<Component />);
+            const button = screen.getByRole('button');
+
+            await user.tab();
+            expect(button).toHaveFocus();
+            await user.tab();
+            expect(button).not.toHaveFocus();
+
+            expect(events).toEqual([
+                {type: 'focus', target: button},
+                {type: 'focuschange', isFocused: true},
+                {type: 'blur', target: button},
+                {type: 'focuschange', isFocused: false},
+            ]);
+        });
+
+        it('should defer onBlurWithin when focus moves cross-document to a parent-window portal', () => {
+            jest.useFakeTimers();
+            const onBlurWithin = jest.fn();
+
+            // Represents the popup container rendered in the parent window (e.g. document.body of
+            // the parent frame), as if useFocusWithin is used inside an iframe and the popup is
+            // portalled to the parent document.
+            const parentWindowContainer = document.createElement('div');
+            document.body.appendChild(parentWindowContainer);
+
+            const Component = () => {
+                const [open, setOpen] = React.useState(false);
+                const {focusWithinProps} = useFocusWithin({onBlurWithin});
+                return (
+                    <div {...focusWithinProps}>
+                        <button data-qa="trigger" onClick={() => setOpen(true)} />
+                        {open &&
+                            ReactDom.createPortal(
+                                <input data-qa="popup-input" />,
+                                parentWindowContainer,
+                            )}
+                    </div>
+                );
+            };
+
+            render(<Component />);
+            const trigger = screen.getByTestId('trigger');
+
+            act(() => {
+                trigger.focus();
+            });
+            act(() => {
+                trigger.click(); // open popup in "parent window"
+            });
+
+            // Moving focus cross-document fires focusout with relatedTarget=null on the
+            // iframe element; activeElement switches to body before the event fires.
+            act(() => {
+                simulateCrossDocumentBlur(trigger);
+            });
+
+            // Not fired yet — deferred until the setTimeout resolves
+            expect(onBlurWithin).not.toHaveBeenCalled();
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            expect(onBlurWithin).toHaveBeenCalledTimes(1);
+
+            document.body.removeChild(parentWindowContainer);
+            jest.useRealTimers();
+        });
+
+        it('should cancel deferred blur and fire exactly once when parent-window focusin fires', () => {
+            jest.useFakeTimers();
+            const onBlurWithin = jest.fn();
+
+            const parentWindowContainer = document.createElement('div');
+            document.body.appendChild(parentWindowContainer);
+
+            const Component = () => {
+                const [open, setOpen] = React.useState(false);
+                const {focusWithinProps} = useFocusWithin({onBlurWithin});
+                return (
+                    <div {...focusWithinProps}>
+                        <button data-qa="trigger" onClick={() => setOpen(true)} />
+                        {open &&
+                            ReactDom.createPortal(
+                                <input data-qa="popup-input" />,
+                                parentWindowContainer,
+                            )}
+                    </div>
+                );
+            };
+
+            render(<Component />);
+            const trigger = screen.getByTestId('trigger');
+
+            act(() => {
+                trigger.focus();
+            });
+            act(() => {
+                trigger.click();
+            });
+
+            // Cross-document focusout starts the deferred blur
+            act(() => {
+                trigger.dispatchEvent(
+                    new FocusEvent('focusout', {relatedTarget: null, bubbles: true}),
+                );
+            });
+
+            expect(onBlurWithin).not.toHaveBeenCalled();
+
+            // The popup input in the parent window gets focus → window.parent fires focusin
+            act(() => {
+                triggerParentFocusIn();
+            });
+
+            // Deferred timer was cancelled; blur fires once via handleParentFocusIn
+            expect(onBlurWithin).toHaveBeenCalledTimes(1);
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            // No second call from the cancelled timer
+            expect(onBlurWithin).toHaveBeenCalledTimes(1);
+
+            document.body.removeChild(parentWindowContainer);
+            jest.useRealTimers();
+        });
     });
 });

--- a/src/hooks/useFocusWithin/useFocusWithin.ts
+++ b/src/hooks/useFocusWithin/useFocusWithin.ts
@@ -137,6 +137,7 @@ function useFocusEvents<T extends Element = Element>({
 }) {
     const capturedRef = React.useRef(false);
     const targetRef = React.useRef<EventTarget | null>(null);
+    const pendingBlurRef = React.useRef<{cancel: () => void} | null>(null);
 
     React.useEffect(() => {
         if (isDisabled) {
@@ -170,9 +171,42 @@ function useFocusEvents<T extends Element = Element>({
         // implementations fire focusin events after focus event
         window.addEventListener('focusin', handleFocusIn);
 
+        // When portals are rendered in window.parent.document, listen to focusin there
+        // to distinguish "focus moved to our portal" from "focus left the component".
+        let cleanupParentListener: (() => void) | undefined;
+        if (window !== window.parent) {
+            try {
+                const parentWindow = window.parent;
+                const handleParentFocusIn = (_event: FocusEvent) => {
+                    if (!targetRef.current) {
+                        return;
+                    }
+                    // Always cancel the deferred blur
+                    pendingBlurRef.current?.cancel();
+                    pendingBlurRef.current = null;
+
+                    // Focus landed outside our portals → fire blur now.
+                    const nativeBlur = new FocusEvent('blur', {bubbles: false, cancelable: false});
+                    onBlur(
+                        new SyntheticFocusEvent('blur', nativeBlur, {
+                            target: targetRef.current,
+                            currentTarget: targetRef.current,
+                        }),
+                    );
+                    targetRef.current = null;
+                };
+                parentWindow.addEventListener('focusin', handleParentFocusIn);
+                cleanupParentListener = () =>
+                    parentWindow.removeEventListener('focusin', handleParentFocusIn);
+            } catch {
+                // Cross-origin parent — cross-document portal scenario is not supported.
+            }
+        }
+
         return () => {
             window.removeEventListener('focus', handleFocus, {capture: true});
             window.removeEventListener('focusin', handleFocusIn);
+            cleanupParentListener?.();
         };
     }, [isDisabled, onBlur]);
 
@@ -184,6 +218,27 @@ function useFocusEvents<T extends Element = Element>({
                     event.relatedTarget === document.body ||
                     event.relatedTarget === (document as EventTarget))
             ) {
+                // When relatedTarget is null and we have parent-window portals, the blur may be
+                // caused by focus moving into one of those portals. Defer the call so that the
+                // window.parent focusin listener fires first and can cancel it if needed.
+                if (event.relatedTarget === null && window !== window.parent) {
+                    const savedTarget = targetRef.current;
+                    let cancelled = false;
+                    const timerId = setTimeout(() => {
+                        if (!cancelled && savedTarget) {
+                            onBlur(event);
+                            targetRef.current = null;
+                        }
+                    }, 0);
+                    pendingBlurRef.current = {
+                        cancel: () => {
+                            cancelled = true;
+                            clearTimeout(timerId);
+                        },
+                    };
+                    return;
+                }
+
                 onBlur(event);
                 targetRef.current = null;
             }


### PR DESCRIPTION
**Problem**
When useFocusWithin is used inside an iframe and popups are portalled into window.parent.document, clicking inside such a portal fires blur on the iframe element with relatedTarget === null (cross-document focus transitions always produce null). The hook treated this as "focus left the component" and fired onBlurWithin immediately, causing dropdowns and popups to close on the first interaction.

**Solution**
When relatedTarget === null and window !== window.parent, the blur is deferred via setTimeout(0). A focusin listener on window.parent then fires before the timeout: it cancels the deferred blur and fires it immediately with the correct synthetic target. If the parent is cross-origin, the error is swallowed and the deferred timeout fires as a fallback.

**Where**
1. Daterange if popup render on parent document
2. Select if popup render on parent document

Issue: https://github.com/gravity-ui/uikit/issues/2653