### PR TITLE
feat(Button): added aria-pressed attribute support

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -183,6 +183,11 @@ const _Button = React.forwardRef(function Button<T extends ButtonCustomElementTy
         );
     }
 
+    const ariaPressed =
+        extraProps && 'aria-pressed' in extraProps
+            ? (extraProps as React.ButtonHTMLAttributes<HTMLButtonElement>)['aria-pressed']
+            : selected;
+
     return (
         <button
             {...(rest as Pick<typeof props, keyof typeof rest>)}
@@ -191,7 +196,7 @@ const _Button = React.forwardRef(function Button<T extends ButtonCustomElementTy
             ref={ref as React.Ref<HTMLButtonElement>}
             type={props.type || 'button'}
             disabled={disabled || loading}
-            aria-pressed={selected}
+            aria-pressed={ariaPressed}
         >
             {prepareChildren(children)}
         </button>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [CLA](https://yandex.ru/legal/cla/ru/?lang=ru).

### `Button` does not allow to override `aria-pressed` using `extraProps`
`Button` sets `aria-pressed={selected}` after the `extraProps` spread on the native `<button>` element 
```
<button
    {...rest}
    {...extraProps}
    {...commonProps}
    ref={ref}
    type={props.type || 'button'}
    disabled={disabled || loading}
    aria-pressed={selected}
>
```
Since `aria-pressed={selected}` is set explicitly after `{...extraProps}`, any attempt to override or remove this attribute through `extraProps` (for example, '`aria-pressed': undefined`) is ignored — the value from selected always takes precedence.

---------
### Problem
When `Button` is used to implement controls with radio group semantics, the correct markup according to the specification requires `role="radio"` + `aria-checked`, not `aria-pressed`.

According to the WAI-ARIA specification:
- `aria-pressed` is not a valid attribute for `role="radio"` [(WAI-ARIA: radio role)](https://www.w3.org/TR/wai-aria-1.2/#radio).
- the valid state attribute for `role="radio"` is `aria-checked`.

As a result, the combination of `role="radio"` + `aria-pressed` (which cannot be removed) leads to an accessibility validation error: "ARIA attribute is not allowed: aria-pressed"

This violates the ARIA specification, breaks the behavior of screen readers, and fails automated accessibility checks (axe, Lighthouse, etc.).

--------
### Context of use
In our project, `Button` is used inside a component where the buttons are semantically radio buttons:
```
<Button
    selected={selected}
    extraProps={{
        name,
        role: 'radio',
        'aria-checked': selected,
        'aria-pressed': undefined, // ← does not work, it is being overwritten by the component
    }}
/>
```
**What we've tried doesn't work:**
- Passing `'aria-pressed': undefined` through `extraProps` is overwritten.
- Passing `aria-pressed` as a separate prop is overwritten.
- Removing the `selected` prop breaks the visual state (`g-button_selected` class), and we have to manually add the internal component class, which is fragile and will break when uikit is updated.

--------
### Expected behavior
`extraProps` (or a separate prop) should allow `aria-pressed` to be overridden or removed, so that consumers can use a `Button` with a `selected`-visual but with different ARIA semantics.

--------
### The proposed solution
Сalculate `aria-pressed` using `extraProps`:
```
const ariaPressed =
	extraProps && 'aria-pressed' in extraProps
    	? (extraProps as React.ButtonHTMLAttributes<HTMLButtonElement>)['aria-pressed']
    	: selected;
```
The solution is backward compatible: if the consumer does not pass `aria-pressed` in `extraProps`, the behavior remains the same.

--------
### Impact
- Accessibility (a11y): the current behavior results in invalid ARIA markup that cannot be fixed by the consumer without fragile hacks.
- Backwards compatibility: the proposed change does not break the existing behavior and only affects cases where `aria-pressed` is explicitly passed in `extraProps`.
- Flexibility: allows the use of `Button` with `selected`-visual for any ARIA roles (radio, option, tab, etc.) without manually adding internal library classes.

---------
### Success metric
- Accessibility validation (axe / Lighthouse) passes without errors when using `Button` with `role="radio"`.
-  Consumers can override `aria-pressed` through the native API of the component without hacks.

## Summary by Sourcery

New Features:
- Support overriding or removing the Button’s aria-pressed attribute through extraProps to customize ARIA semantics.