### PR TITLE
fix(Select): aria-invalid attribute passing

### DIFF
--- a/src/components/Select/__tests__/Select.error.test.tsx
+++ b/src/components/Select/__tests__/Select.error.test.tsx
@@ -5,6 +5,20 @@ import {Select} from '../Select';
 import {SELECT_CONTROL_BUTTON_ERROR_CLASS, TEST_QA, setup} from './utils';
 
 describe('Select error', () => {
+    test('sets aria-invalid on the combobox when validationState is invalid', () => {
+        const {getByTestId} = setup({validationState: 'invalid'});
+        const selectControl = getByTestId(TEST_QA);
+
+        expect(selectControl).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    test('does not set aria-invalid when validationState is not invalid', () => {
+        const {getByTestId} = setup({});
+        const selectControl = getByTestId(TEST_QA);
+
+        expect(selectControl).not.toHaveAttribute('aria-invalid');
+    });
+
     test('render error appearance with invalid state and without errorMessage', () => {
         const {getByTestId} = setup({validationState: 'invalid'});
         const selectControl = getByTestId(TEST_QA);

--- a/src/components/Select/components/SelectControl/SelectControl.tsx
+++ b/src/components/Select/components/SelectControl/SelectControl.tsx
@@ -164,6 +164,7 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
         'aria-controls': open ? popupId : undefined,
         'aria-haspopup': 'listbox',
         'aria-expanded': open,
+        'aria-invalid': isErrorVisible || undefined,
         'aria-activedescendant':
             activeIndex === undefined ? undefined : `${popupId}-item-${activeIndex}`,
         onClick: handleControlClick,

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -20,6 +20,7 @@ export type SelectRenderTriggerProps = AriaLabelingProps &
         | 'aria-controls'
         | 'aria-haspopup'
         | 'aria-expanded'
+        | 'aria-invalid'
         | 'aria-activedescendant'
         | 'onClick'
         | 'onKeyDown'


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Expose the Select error state via the aria-invalid attribute on the trigger element so assistive technologies can detect invalid input.