### PR TITLE
chore: fix relative type impots

### DIFF
--- a/src/components/Avatar/__tests__/helpersPlaywright.tsx
+++ b/src/components/Avatar/__tests__/helpersPlaywright.tsx
@@ -1,7 +1,6 @@
 import {FaceRobot} from '@gravity-ui/icons';
 
-import type {DistributiveOmit} from 'src/utils/types';
-
+import type {DistributiveOmit} from '../../../utils/types';
 import {Avatar} from '../Avatar';
 import type {AvatarProps} from '../types/main';
 

--- a/src/components/Drawer/components/Drawer.tsx
+++ b/src/components/Drawer/components/Drawer.tsx
@@ -11,10 +11,9 @@ import {
     useRole,
 } from '@floating-ui/react';
 
-import type {ModalProps} from 'src/components/Modal';
-
 import {useForkRef} from '../../../hooks';
 import {useFloatingTransition} from '../../../hooks/private/useFloatingTransition';
+import type {ModalProps} from '../../Modal';
 import {Portal} from '../../Portal';
 import {block} from '../../utils/cn';
 import {filterDOMProps} from '../../utils/filterDOMProps';

--- a/src/components/Drawer/components/DrawerItem.tsx
+++ b/src/components/Drawer/components/DrawerItem.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import type {AriaLabelingProps} from 'src/components/types';
-
+import type {AriaLabelingProps} from '../../types';
 import {block} from '../../utils/cn';
 import {useResizableDrawerItem} from '../hooks/useResizableDrawerItem';
 import type {DrawerPlacement, OnResizeHandler} from '../hooks/useResizeHandlers';

--- a/src/components/lab/FileDropZone/FileDropZone.tsx
+++ b/src/components/lab/FileDropZone/FileDropZone.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
-import type {BaseInputControlProps} from 'src/components/controls/types';
-import type {UseDropZoneAccept} from 'src/hooks/lab/useDropZone';
-
 import type {IconData} from '../..';
+import type {UseDropZoneAccept} from '../../../hooks/lab/useDropZone';
+import type {BaseInputControlProps} from '../../controls/types';
 
 import {FileDropZoneProvider, useFileZoneContext} from './FileDropZone.Provider';
 import {cnFileDropZone} from './FileDropZone.classname';

--- a/src/hooks/useColorGenerator/types.ts
+++ b/src/hooks/useColorGenerator/types.ts
@@ -1,4 +1,4 @@
-import type {ThemeType} from 'src/components';
+import type {ThemeType} from '../../components';
 
 export type ColorOptions = {
     lightness: [number, number];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,12 @@
         "module": "esnext",
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "baseUrl": ".",
         "resolveJsonModule": true,
         "importHelpers": true,
         "verbatimModuleSyntax": true,
         "paths": {
             "~playwright/*": [
-                "playwright/*"
+                "./playwright/*"
             ]
         }
     },


### PR DESCRIPTION
## Summary by Sourcery

Align TypeScript configuration and component imports with correct relative paths.

Enhancements:
- Update ThemeType import in the color generator hook to use a relative components path instead of a root alias.

Build:
- Adjust TypeScript path alias for Playwright to use a relative path and remove the baseUrl setting.