### PR TITLE
chore(eslint): add import/no-useless-path-segments rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig([
             'jsx-a11y/no-autofocus': 'off',
             'import/no-extraneous-dependencies': 'off',
             'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+            'import/no-useless-path-segments': 'error',
             complexity: 'off',
         },
     },

--- a/src/components/Accordion/AccordionContext.tsx
+++ b/src/components/Accordion/AccordionContext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {useControlledState} from '../../../src/hooks';
+import {useControlledState} from '../../hooks';
 
 import type {AccordionProps, AccordionValue} from './types';
 

--- a/src/components/ActionsPanel/__stories__/ActionsPanel.stories.tsx
+++ b/src/components/ActionsPanel/__stories__/ActionsPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react-webpack5';
 
-import {ActionsPanel} from '../../ActionsPanel';
+import {ActionsPanel} from '..';
 
 import {actions, actionsGroups, actionsSubmenu, actionsWithIcons, actionsWithNote} from './actions';
 

--- a/src/components/ActionsPanel/__stories__/actions.tsx
+++ b/src/components/ActionsPanel/__stories__/actions.tsx
@@ -1,6 +1,6 @@
 import {ChevronDown, Files, PencilToSquare, TrashBin} from '@gravity-ui/icons';
 
-import type {ActionsPanelProps} from '../../ActionsPanel';
+import type {ActionsPanelProps} from '..';
 import {Icon} from '../../Icon';
 import {Flex} from '../../layout';
 

--- a/src/components/Dialog/__stories__/DialogShowcase.tsx
+++ b/src/components/Dialog/__stories__/DialogShowcase.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import {Button} from '../../../components/Button';
-import {Dialog} from '../../../components/Dialog/Dialog';
-import {Loader} from '../../../components/Loader';
-import {Select} from '../../../components/Select';
+import {Button} from '../../Button';
+import {Loader} from '../../Loader';
+import {Select} from '../../Select';
 import {TextInput} from '../../controls';
 import {Flex} from '../../layout/Flex/Flex';
+import {Dialog} from '../Dialog';
 
 const darthVader = String.raw`
                        .-.

--- a/src/components/Link/__stories__/Link.stories.tsx
+++ b/src/components/Link/__stories__/Link.stories.tsx
@@ -2,7 +2,8 @@ import type {Meta, StoryObj} from '@storybook/react-webpack5';
 
 import {Showcase as ShowcaseComponent} from '../../../demo/Showcase';
 import {Link} from '../Link';
-import {LinkShowcase} from '../__stories__/LinkShowcase';
+
+import {LinkShowcase} from './LinkShowcase';
 
 export default {
     title: 'Components/Navigation/Link',

--- a/src/components/Pagination/__stories__/Pagination.stories.tsx
+++ b/src/components/Pagination/__stories__/Pagination.stories.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import type {Meta, StoryFn} from '@storybook/react-webpack5';
 
-import {Pagination} from '../../Pagination';
-import type {PaginationProps} from '../../Pagination';
+import {Pagination} from '..';
+import type {PaginationProps} from '..';
 
 const useState = (args: PaginationProps) => {
     const [state, setState] = React.useState({...args});

--- a/src/components/SegmentedRadioGroup/__tests__/SegmentedRadioGroup.test.tsx
+++ b/src/components/SegmentedRadioGroup/__tests__/SegmentedRadioGroup.test.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 
 import userEvent from '@testing-library/user-event';
 
-import {SegmentedRadioGroup} from '../';
+import {SegmentedRadioGroup} from '..';
 import type {
     SegmentedRadioGroupOptionProps,
     SegmentedRadioGroupProps,
     SegmentedRadioGroupSize,
     SegmentedRadioGroupWidth,
-} from '../';
+} from '..';
 import {render, screen, within} from '../../../../test-utils/utils';
-import {block} from '../../../components/utils/cn';
+import {block} from '../../utils/cn';
 
 const qaId = 'segmented-radio-group-component';
 const b = block('segmented-radio-group');

--- a/src/components/Select/__tests__/Select.filter.test.tsx
+++ b/src/components/Select/__tests__/Select.filter.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import {fireEvent, render, screen} from '../../../../test-utils/utils';
-import {SheetQa} from '../../../components/Sheet/constants';
+import {SheetQa} from '../../Sheet/constants';
 import {TextInput} from '../../controls';
 import {MobileProvider} from '../../mobile';
 import {Select} from '../Select';

--- a/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.stories.tsx
+++ b/src/components/Sheet/__stories__/DefaultShowcase/DefaultShowcase.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type {Meta, StoryFn} from '@storybook/react-webpack5';
 
-import {Button, Checkbox, TextInput} from '../../../';
+import {Button, Checkbox, TextInput} from '../../..';
 import {cn} from '../../../utils/cn';
 import {Sheet} from '../../Sheet';
 import type {SheetProps} from '../../Sheet';

--- a/src/components/Sheet/__stories__/WithMenuShowcase/WithMenuShowcase.stories.tsx
+++ b/src/components/Sheet/__stories__/WithMenuShowcase/WithMenuShowcase.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type {Meta, StoryFn} from '@storybook/react-webpack5';
 
-import {Button, Menu} from '../../../';
+import {Button, Menu} from '../../..';
 import {cn} from '../../../utils/cn';
 import {Sheet} from '../../Sheet';
 import type {SheetProps} from '../../Sheet';

--- a/src/components/Toaster/__tests__/ToasterProvider.test.tsx
+++ b/src/components/Toaster/__tests__/ToasterProvider.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {act, fireEvent, render, screen, within} from '../../../../test-utils/utils';
-import {Modal} from '../../../components/Modal/Modal';
+import {Modal} from '../../Modal/Modal';
 import {ToasterProvider} from '../Provider/ToasterProvider';
 import {ToasterComponent} from '../ToasterComponent/ToasterComponent';
 import {fireAnimationEndEvent} from '../__mocks__/fireAnimationEndEvent';

--- a/src/components/lab/FileDropZone/__stories__/FileDropZone.stories.tsx
+++ b/src/components/lab/FileDropZone/__stories__/FileDropZone.stories.tsx
@@ -1,7 +1,7 @@
 import {DatabaseFill, FolderOpenFill, HeartCrack} from '@gravity-ui/icons';
 import type {Meta, StoryFn} from '@storybook/react-webpack5';
 
-import {Text} from '../../../';
+import {Text} from '../../..';
 import {FileDropZone} from '../FileDropZone';
 import type {FileDropZoneProps} from '../FileDropZone';
 

--- a/src/components/lab/FileDropZone/parts/FileDropZone.Button.tsx
+++ b/src/components/lab/FileDropZone/parts/FileDropZone.Button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Button} from '../../../../';
+import {Button} from '../../../..';
 import {useFileZoneContext} from '../FileDropZone.Provider';
 import {cnFileDropZone} from '../FileDropZone.classname';
 import i18n from '../i18n';

--- a/src/components/lab/FileDropZone/parts/FileDropZone.Description.tsx
+++ b/src/components/lab/FileDropZone/parts/FileDropZone.Description.tsx
@@ -1,4 +1,4 @@
-import {Text} from '../../../';
+import {Text} from '../../..';
 import {useFileZoneContext} from '../FileDropZone.Provider';
 
 type FileDropZoneDescriptionProps = {

--- a/src/components/lab/FileDropZone/parts/FileDropZone.Icon.tsx
+++ b/src/components/lab/FileDropZone/parts/FileDropZone.Icon.tsx
@@ -5,7 +5,7 @@ import {
     CloudArrowUpIn as DefaultIcon,
 } from '@gravity-ui/icons';
 
-import {Icon} from '../../../';
+import {Icon} from '../../..';
 import {useFileZoneContext} from '../FileDropZone.Provider';
 import {cnFileDropZone} from '../FileDropZone.classname';
 

--- a/src/components/lab/FileDropZone/parts/FileDropZone.Title.tsx
+++ b/src/components/lab/FileDropZone/parts/FileDropZone.Title.tsx
@@ -1,4 +1,4 @@
-import {Text} from '../../../';
+import {Text} from '../../..';
 import {useFileZoneContext} from '../FileDropZone.Provider';
 import i18n from '../i18n';
 

--- a/src/components/lab/Virtualizer/useLoadMore.tsx
+++ b/src/components/lab/Virtualizer/useLoadMore.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {useLayoutEffect} from '../../../hooks/';
+import {useLayoutEffect} from '../../../hooks';
 
 export interface Loadable {
     /** Whether the items are currently loading. */

--- a/src/components/layout/demo/LayoutPresenter/LayoutPresenter.tsx
+++ b/src/components/layout/demo/LayoutPresenter/LayoutPresenter.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 
+import type {LayoutTheme} from '../..';
 import {Text} from '../../../Text';
-import type {LayoutTheme} from '../../../layout';
 import {ThemeProvider} from '../../../theme';
 import {Flex} from '../../Flex/Flex';
 import {useLayoutContext} from '../../hooks/useLayoutContext';

--- a/src/components/legacy/Popover/__stories__/Popover.stories.tsx
+++ b/src/components/legacy/Popover/__stories__/Popover.stories.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import type {Meta, StoryFn} from '@storybook/react-webpack5';
 
-import {Popover, PopoverBehavior} from '../';
-import type {PopoverProps} from '../';
+import {Popover, PopoverBehavior} from '..';
+import type {PopoverProps} from '..';
 import {Button} from '../../../Button';
 
 import {cnPopoverDemo} from './PopoverDemo.classname';

--- a/src/components/legacy/Popover/__stories__/examples/WithCustomAnchor/WithCustomAnchor.tsx
+++ b/src/components/legacy/Popover/__stories__/examples/WithCustomAnchor/WithCustomAnchor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Popover} from '../../../';
+import {Popover} from '../../..';
 import {Button} from '../../../../../Button';
 import {Loader} from '../../../../../Loader';
 import type {PopoverInstanceProps} from '../../../types';

--- a/src/components/tabs/__tests__/Tab.test.tsx
+++ b/src/components/tabs/__tests__/Tab.test.tsx
@@ -1,6 +1,6 @@
 import {Flame} from '@gravity-ui/icons';
 
-import {Tab, TabList} from '../';
+import {Tab, TabList} from '..';
 import {render, screen} from '../../../../test-utils/utils';
 
 import {tab1} from './constants';

--- a/src/components/tabs/__tests__/TabList.test.tsx
+++ b/src/components/tabs/__tests__/TabList.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
-import {Tab, TabList} from '../';
+import {Tab, TabList} from '..';
 import {act, render, screen} from '../../../../test-utils/utils';
 import {KeyCode} from '../../../constants';
 import type {TabSize} from '../types';

--- a/src/components/tabs/__tests__/TabPanel.test.tsx
+++ b/src/components/tabs/__tests__/TabPanel.test.tsx
@@ -1,4 +1,4 @@
-import {TabPanel, TabProvider} from '../';
+import {TabPanel, TabProvider} from '..';
 import {render, screen} from '../../../../test-utils/utils';
 
 import {tab1} from './constants';

--- a/src/components/tabs/__tests__/TabProvider.test.tsx
+++ b/src/components/tabs/__tests__/TabProvider.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
-import {Tab, TabList, TabPanel, TabProvider} from '../';
+import {Tab, TabList, TabPanel, TabProvider} from '..';
 import {render, screen} from '../../../../test-utils/utils';
 
 import {panel1qa, panel2qa, tab1, tab2} from './constants';

--- a/src/components/useList/components/ListItemView/__stories__/ListItemView.stories.tsx
+++ b/src/components/useList/components/ListItemView/__stories__/ListItemView.stories.tsx
@@ -7,7 +7,7 @@ import {Button} from '../../../../Button';
 import {DropdownMenu} from '../../../../DropdownMenu';
 import {Text} from '../../../../Text';
 import {Flex, sp} from '../../../../layout';
-import type {ListItemId} from '../../../../useList/types';
+import type {ListItemId} from '../../../types';
 import {ListItemExpandIcon} from '../../ListItemExpandIcon';
 import {ListItemView as ListItemViewComponent} from '../ListItemView';
 import type {ListItemViewProps} from '../ListItemView';

--- a/src/components/useList/utils/flattenItems.test.ts
+++ b/src/components/useList/utils/flattenItems.test.ts
@@ -1,4 +1,5 @@
-import type {ParsedFlattenState} from './../types';
+import type {ParsedFlattenState} from '../types';
+
 import {flattenItems} from './flattenItems';
 
 const data = [

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,4 +1,4 @@
-import type {StringWithSuggest} from '../utils/types';
+import type {StringWithSuggest} from './types';
 
 export enum Lang {
     Ru = 'ru',


### PR DESCRIPTION
## Summary by Sourcery

Enforce eslint import/no-useless-path-segments and update import paths across the codebase to remove redundant or inconsistent relative segments.

Enhancements:
- Normalize internal import paths in components, stories, tests, and utilities to use cleaner relative references.

Build:
- Enable the eslint import/no-useless-path-segments rule in the shared lint configuration to prevent redundant relative import segments in the future.

Tests:
- Adjust test imports to comply with the new import path linting rule without altering test behavior.

Chores:
- Tidy up Storybook story and component imports, including some re-pointed relative paths, to align with the new linting constraint.