### PR TITLE
feat(useFocusWithin): simplify detection of blur events

### DIFF
--- a/src/components/SegmentedRadioGroup/__tests__/SegmentedRadioGroup.test.tsx
+++ b/src/components/SegmentedRadioGroup/__tests__/SegmentedRadioGroup.test.tsx
@@ -160,18 +160,25 @@ describe('SegmentedRadioGroup', () => {
         });
 
         test('call onFocus/onBlur', async () => {
+            const user = userEvent.setup();
+
             const handleOnFocus = jest.fn();
             const handleOnBlur = jest.fn();
             renderSegmentedRadioGroup({onBlur: handleOnBlur, onFocus: handleOnFocus});
 
             const component = screen.getByTestId(qaId);
             const radios = within(component).getAllByRole('radio');
-            const secondRadio = radios[1];
 
-            secondRadio.focus();
+            await user.tab();
+            expect(radios[0]).toHaveFocus();
             expect(handleOnFocus).toHaveBeenCalledTimes(1);
 
-            secondRadio.blur();
+            await user.keyboard('{ArrowRight}');
+            expect(radios[1]).toHaveFocus();
+
+            await user.tab();
+
+            expect(handleOnFocus).toHaveBeenCalledTimes(1);
             expect(handleOnBlur).toHaveBeenCalledTimes(1);
         });
 

--- a/src/hooks/useFocusWithin/useFocusWithin.test.tsx
+++ b/src/hooks/useFocusWithin/useFocusWithin.test.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
+
 import userEvent from '@testing-library/user-event';
 import ReactDom from 'react-dom';
 
-import {act, render, screen, waitFor} from '../../../test-utils/utils';
+import {render, screen, waitFor} from '../../../test-utils/utils';
 
 import {useFocusWithin} from './useFocusWithin';
 
@@ -80,21 +82,21 @@ describe('useFocusWithin', () => {
 
             return (
                 <div>
-                    <button {...focusWithinProps} data-qa="btn-1" />
-                    <button data-qa="btn-2" />
+                    <button {...focusWithinProps}>first</button>
+                    <button>second</button>
                 </div>
             );
         };
 
         render(<Component />);
 
-        const button = screen.getByTestId('btn-1');
+        const button = screen.getByRole('button', {name: 'first'});
 
         await user.tab();
         expect(button).toHaveFocus();
 
         await user.tab();
-        expect(screen.getByTestId('btn-2')).toHaveFocus();
+        expect(screen.getByRole('button', {name: 'second'})).toHaveFocus();
 
         expect(events).toEqual([
             {type: 'focus', target: button},
@@ -105,81 +107,108 @@ describe('useFocusWithin', () => {
     });
 
     it('should handle focus events on children', async () => {
+        const user = userEvent.setup();
+
         const events: any[] = [];
         const Component = () => {
             const {focusWithinProps} = useFocusWithin({
-                onFocusWithin: (e) => events.push({type: e.type, target: e.target}),
-                onBlurWithin: (e) => events.push({type: e.type, target: e.target}),
+                onFocusWithin: (e) =>
+                    events.push({type: e.type, target: e.target, currentTarget: e.currentTarget}),
+                onBlurWithin: (e) => {
+                    events.push({type: e.type, target: e.target, currentTarget: e.currentTarget});
+                },
                 onFocusWithinChange: (isFocused) => events.push({type: 'focuschange', isFocused}),
             });
 
             return (
-                <div {...focusWithinProps} tabIndex={-1} data-qa="component">
-                    <button />
+                <div>
+                    <div {...focusWithinProps} data-qa="container">
+                        <button>first</button>
+                        <button>second</button>
+                    </div>
+                    <button>outside</button>
                 </div>
             );
         };
 
         render(<Component />);
 
-        const el = screen.getByTestId('component');
-        const child = screen.getByRole('button');
+        const container = screen.getByTestId('container');
+        const firstButton = screen.getByRole('button', {name: 'first'});
+        const secondButton = screen.getByRole('button', {name: 'second'});
+        const outsideButton = screen.getByRole('button', {name: 'outside'});
 
-        act(() => {
-            child.focus();
-        });
+        await user.tab();
+        expect(firstButton).toHaveFocus();
 
-        el.focus();
-        child.focus();
+        await user.tab();
+        expect(secondButton).toHaveFocus();
 
-        act(() => {
-            child.blur();
-        });
+        await user.tab();
+        expect(outsideButton).toHaveFocus();
 
         expect(events).toEqual([
-            {type: 'focus', target: child},
+            {type: 'focus', target: firstButton, currentTarget: container},
             {type: 'focuschange', isFocused: true},
-            {type: 'blur', target: child},
+            {type: 'blur', target: secondButton, currentTarget: container},
             {type: 'focuschange', isFocused: false},
         ]);
     });
 
     it('should handle focus events on children within portal', async () => {
+        const user = userEvent.setup();
         const events: any[] = [];
         const Component = () => {
             const {focusWithinProps} = useFocusWithin({
-                onFocusWithin: (e) => events.push({type: e.type, target: e.target}),
-                onBlurWithin: (e) => events.push({type: e.type, target: e.target}),
+                onFocusWithin: (e) =>
+                    events.push({type: e.type, target: e.target, currentTarget: e.currentTarget}),
+                onBlurWithin: (e) => {
+                    events.push({type: e.type, target: e.target, currentTarget: e.currentTarget});
+                },
                 onFocusWithinChange: (isFocused) => events.push({type: 'focuschange', isFocused}),
             });
 
+            const [portal, setPortal] = React.useState<HTMLDivElement | null>(null);
+
             return (
-                <div {...focusWithinProps} tabIndex={-1} data-qa="component">
-                    {ReactDom.createPortal(<button />, document.body)}
+                <div>
+                    <div ref={setPortal} />
+                    <div {...focusWithinProps} data-qa="container">
+                        {portal
+                            ? ReactDom.createPortal(
+                                  <div>
+                                      <button>first</button>
+                                      <button>second</button>
+                                  </div>,
+                                  portal,
+                              )
+                            : null}
+                    </div>
+                    <button>outside</button>
                 </div>
             );
         };
 
         render(<Component />);
 
-        const el = screen.getByTestId('component');
-        const child = screen.getByRole('button');
+        const container = screen.getByTestId('container');
+        const firstButton = screen.getByRole('button', {name: 'first'});
+        const secondButton = screen.getByRole('button', {name: 'second'});
+        const outsideButton = screen.getByRole('button', {name: 'outside'});
 
-        act(() => {
-            child.focus();
-        });
+        await user.tab();
+        expect(firstButton).toHaveFocus();
 
-        el.focus();
-        child.focus();
+        await user.tab();
+        expect(secondButton).toHaveFocus();
 
-        act(() => {
-            child.blur();
-        });
+        await user.tab();
+        expect(outsideButton).toHaveFocus();
 
         expect(events).toEqual([
-            {type: 'focus', target: child},
+            {type: 'focus', target: firstButton, currentTarget: container},
             {type: 'focuschange', isFocused: true},
-            {type: 'blur', target: child},
+            {type: 'blur', target: secondButton, currentTarget: container},
             {type: 'focuschange', isFocused: false},
         ]);
     });
@@ -196,8 +225,8 @@ describe('useFocusWithin', () => {
             });
             return (
                 <div {...focusWithinProps}>
-                    <button data-qa="btn-1" />
-                    <button disabled={props.disabled} data-qa="btn-2" />
+                    <button>first</button>
+                    <button disabled={props.disabled}>second</button>
                 </div>
             );
         }
@@ -205,9 +234,9 @@ describe('useFocusWithin', () => {
         const {rerender} = render(<Component />);
 
         await user.tab();
-        expect(screen.getByTestId('btn-1')).toHaveFocus();
+        expect(screen.getByRole('button', {name: 'first'})).toHaveFocus();
         await user.tab();
-        expect(screen.getByTestId('btn-2')).toHaveFocus();
+        expect(screen.getByRole('button', {name: 'second'})).toHaveFocus();
 
         expect(onFocus).toHaveBeenCalledTimes(1);
         expect(onBlur).not.toHaveBeenCalled();
@@ -218,7 +247,9 @@ describe('useFocusWithin', () => {
         expect(onFocus).toHaveBeenCalledTimes(1);
     });
 
-    it('should not handle focus events if disabled', () => {
+    it('should not handle focus events if disabled', async () => {
+        const user = userEvent.setup();
+
         const events: any[] = [];
         const Component = () => {
             const {focusWithinProps} = useFocusWithin({
@@ -235,13 +266,11 @@ describe('useFocusWithin', () => {
 
         const button = screen.getByRole('button');
 
-        act(() => {
-            button.focus();
-        });
+        await user.tab();
+        expect(button).toHaveFocus();
 
-        act(() => {
-            button.blur();
-        });
+        await user.tab();
+        expect(button).not.toHaveFocus();
 
         expect(events).toEqual([]);
     });

--- a/src/hooks/useFocusWithin/useFocusWithin.ts
+++ b/src/hooks/useFocusWithin/useFocusWithin.ts
@@ -106,7 +106,6 @@ export function useFocusWithin<T extends Element = Element>(
     const {onBlur: onBlurHandler, onFocus: onFocusHandler} = useFocusEvents<T>({
         onFocus,
         onBlur,
-        isDisabled,
     });
 
     if (isDisabled) {
@@ -129,81 +128,26 @@ export function useFocusWithin<T extends Element = Element>(
 function useFocusEvents<T extends Element = Element>({
     onFocus,
     onBlur,
-    isDisabled,
 }: {
     onFocus: (event: React.FocusEvent<T>) => void;
     onBlur: (event: React.FocusEvent<T>) => void;
-    isDisabled?: boolean;
 }) {
     const capturedRef = React.useRef(false);
-    const targetRef = React.useRef<EventTarget | null>(null);
-
-    React.useEffect(() => {
-        if (isDisabled) {
-            return undefined;
-        }
-
-        const handleFocus = function () {
-            capturedRef.current = false;
-        };
-
-        const handleFocusIn = function (event: FocusEvent) {
-            if (!capturedRef.current && targetRef.current) {
-                const blurEvent = new FocusEvent('blur', {
-                    ...event,
-                    relatedTarget: event.target,
-                    bubbles: false,
-                    cancelable: false,
-                });
-                onBlur(
-                    new SyntheticFocusEvent('blur', blurEvent, {
-                        target: targetRef.current,
-                        currentTarget: targetRef.current,
-                    }),
-                );
-                targetRef.current = null;
-            }
-        };
-
-        const controller = new AbortController();
-        window.addEventListener('focus', handleFocus, {capture: true, signal: controller.signal});
-        // use focusin because a focus event does not bubble and current browser
-        // implementations fire focusin events after focus event
-        window.addEventListener('focusin', handleFocusIn, {signal: controller.signal});
-        if (window.parent !== window) {
-            try {
-                window.parent.addEventListener('focus', handleFocus, {capture: true, signal: controller.signal});
-                window.parent.addEventListener('focusin', handleFocusIn, {signal: controller.signal});
-            } catch {
-                // cross-origin/parent-access is not supported.
-            }
-        }
-        return () => {
-            controller.abort();
-        };
-    }, [isDisabled, onBlur]);
 
     const onBlurHandler = React.useCallback(
         (event: React.FocusEvent<T>) => {
-            if (
-                document.activeElement !== event.target &&
-                (event.relatedTarget === null ||
-                    event.relatedTarget === document.body ||
-                    event.relatedTarget === (document as EventTarget))
-            ) {
-                if (event.relatedTarget === null && window.parent !== window) {
-                    capturedRef.current = false;
-                    setTimeout(() => {
-                        if (!capturedRef.current) {
-                            onBlur(event);
-                            targetRef.current = null;
-                        }
-                    }, 0);
-                } else {
-                    onBlur(event);
-                    targetRef.current = null;
-                }
+            if (event.currentTarget.contains(event.relatedTarget)) {
+                return;
             }
+            capturedRef.current = false;
+            const newEvent = new SyntheticFocusEvent<T>('blur', event.nativeEvent, {
+                currentTarget: event.currentTarget,
+            });
+            setTimeout(() => {
+                if (!capturedRef.current) {
+                    onBlur(newEvent);
+                }
+            }, 0);
         },
         [onBlur],
     );
@@ -213,7 +157,6 @@ function useFocusEvents<T extends Element = Element>({
     const onFocusHandler = React.useCallback(
         (event: React.FocusEvent<T>) => {
             capturedRef.current = true;
-            targetRef.current = event.target;
             onSyntheticFocus(event);
             onFocus(event);
         },

--- a/src/hooks/useFocusWithin/useFocusWithin.ts
+++ b/src/hooks/useFocusWithin/useFocusWithin.ts
@@ -165,14 +165,21 @@ function useFocusEvents<T extends Element = Element>({
             }
         };
 
-        window.addEventListener('focus', handleFocus, {capture: true});
+        const controller = new AbortController();
+        window.addEventListener('focus', handleFocus, {capture: true, signal: controller.signal});
         // use focusin because a focus event does not bubble and current browser
         // implementations fire focusin events after focus event
-        window.addEventListener('focusin', handleFocusIn);
-
+        window.addEventListener('focusin', handleFocusIn, {signal: controller.signal});
+        if (window.parent !== window) {
+            try {
+                window.parent.addEventListener('focus', handleFocus, {capture: true, signal: controller.signal});
+                window.parent.addEventListener('focusin', handleFocusIn, {signal: controller.signal});
+            } catch {
+                // cross-origin/parent-access is not supported.
+            }
+        }
         return () => {
-            window.removeEventListener('focus', handleFocus, {capture: true});
-            window.removeEventListener('focusin', handleFocusIn);
+            controller.abort();
         };
     }, [isDisabled, onBlur]);
 
@@ -184,8 +191,18 @@ function useFocusEvents<T extends Element = Element>({
                     event.relatedTarget === document.body ||
                     event.relatedTarget === (document as EventTarget))
             ) {
-                onBlur(event);
-                targetRef.current = null;
+                if (event.relatedTarget === null && window.parent !== window) {
+                    capturedRef.current = false;
+                    setTimeout(() => {
+                        if (!capturedRef.current) {
+                            onBlur(event);
+                            targetRef.current = null;
+                        }
+                    }, 0);
+                } else {
+                    onBlur(event);
+                    targetRef.current = null;
+                }
             }
         },
         [onBlur],


### PR DESCRIPTION
The use of document event handlers has been removed. This allows for the correct use of the hook within iframe.

## Summary by Sourcery

Simplify focus-within blur detection to rely on component-level focus events instead of global document handlers, improving behavior in nested and portal scenarios.

Bug Fixes:
- Fix incorrect blur handling when focus moves between children or across portals, ensuring focus-within change events reflect the actual focused container.

Enhancements:
- Refine useFocusWithin hook internals to avoid window-level focus listeners and use synthetic blur events guarded by capture state.
- Update focus-related tests, including SegmentedRadioGroup, to use keyboard navigation via userEvent and assert currentTarget on focus/blur callbacks.