### PR TITLE
docs(Divider): add orientation info to --g-divider-size CSS token

### DIFF
--- a/src/components/Divider/README-ru.md
+++ b/src/components/Divider/README-ru.md
@@ -193,4 +193,4 @@ import {Divider, Flex, Container} from '@gravity-ui/uikit';
 | Имя                 | Описание            |
 | :------------------ | :------------------ |
 | `--g-divider-color` | Цвет разделителя.   |
-| `--g-divider-size`  | Размер разделителя. |
+| `--g-divider-size`  | Размер разделителя. Для горизонтальной ориентации — `height`, для вертикальной — `width`. |

--- a/src/components/Divider/README.md
+++ b/src/components/Divider/README.md
@@ -193,4 +193,4 @@ import {Divider, Flex, Container} from '@gravity-ui/uikit';
 | Name                | Description   |
 | :------------------ | :------------ |
 | `--g-divider-color` | Divider color |
-| `--g-divider-size`  | Divider size  |
+| `--g-divider-size`  | Divider size. For horizontal orientation — `height`, for vertical orientation — `width`. |


### PR DESCRIPTION
## Summary
Fixes #2415 — adds additional description for the `--g-divider-size` CSS custom property in both English and Russian documentation.

## Change
- EN: `Divider size` → `Divider size. For horizontal orientation — height, for vertical orientation — width.`
- RU: `Размер разделителя.` → `Размер разделителя. Для горизонтальной ориентации — height, для вертикальной — width.`

## Type of Change
- [x] Documentation

## Summary by Sourcery

Clarify the Divider CSS custom property documentation for orientation-specific sizing in both English and Russian guides.

Documentation:
- Explain that `--g-divider-size` maps to `height` for horizontal and `width` for vertical Divider orientation in the English documentation.
- Add the same orientation-specific explanation for `--g-divider-size` to the Russian Divider documentation.