### PR TITLE
fix(Sheet): fix height of scroll container when top bar is hidden

### DIFF
--- a/src/components/Sheet/Sheet.scss
+++ b/src/components/Sheet/Sheet.scss
@@ -10,8 +10,12 @@ $block: '.#{variables.$ns}sheet';
     height: 100%;
     z-index: 100000;
 
-    $top-height: 20px;
+    --_--top-height: 20px;
     $transition-duration: 0.3s;
+
+    &_without-top-bar {
+        --_--top-height: 0;
+    }
 
     &__veil {
         position: absolute;
@@ -66,7 +70,7 @@ $block: '.#{variables.$ns}sheet';
 
     &__sheet-top {
         position: relative;
-        height: $top-height;
+        height: var(--_--top-height);
     }
 
     &__sheet-top-resizer {
@@ -83,7 +87,7 @@ $block: '.#{variables.$ns}sheet';
 
     &__sheet-scroll-container {
         box-sizing: border-box;
-        max-height: calc(100% - #{$top-height});
+        max-height: calc(100% - var(--_--top-height));
         overflow: hidden auto;
         overscroll-behavior-y: contain;
 

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -81,7 +81,7 @@ export const Sheet = ({
         <Portal container={container} disablePortal={disablePortal}>
             <FloatingOverlay
                 data-qa={qa}
-                className={sheetBlock(null, className)}
+                className={sheetBlock({'without-top-bar': hideTopBar}, className)}
                 lockScroll={open}
                 style={{overflow: undefined}}
             >


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect scroll container height in Sheet when the top bar is hidden by applying a dedicated modifier class and associated styles.