### PR TITLE
fix(useColorGenerator): removed unused parameter from required

### DIFF
--- a/src/hooks/useColorGenerator/index.ts
+++ b/src/hooks/useColorGenerator/index.ts
@@ -1,3 +1,3 @@
 export {useColorGenerator} from './useColorGenerator';
 export {generateColor, generateCustomColor} from './color';
-export type {GenerateColorProps, ColorDetails} from './types';
+export type {GenerateColorProps, UseColorGeneratorProps, ColorDetails} from './types';

--- a/src/hooks/useColorGenerator/types.ts
+++ b/src/hooks/useColorGenerator/types.ts
@@ -10,6 +10,12 @@ export type GenerateColorProps = {
     theme: ThemeType;
 };
 
+export type UseColorGeneratorProps = {
+    seed: string;
+    /** @deprecated Theme is resolved automatically from context. This field has no effect. */
+    theme?: ThemeType;
+};
+
 export interface ColorDetails {
     hash: number;
     oklch: {

--- a/src/hooks/useColorGenerator/useColorGenerator.ts
+++ b/src/hooks/useColorGenerator/useColorGenerator.ts
@@ -3,11 +3,12 @@ import * as React from 'react';
 import {useThemeType} from '../../components/theme/useThemeType';
 
 import {generateColor} from './color';
-import type {ColorDetails, GenerateColorProps} from './types';
+import type {ColorDetails, UseColorGeneratorProps} from './types';
 
 /**
  * The `useColorGenerator` hook generates a unique (but consistent) background color based on some unique attribute (e.g., name, id, email).
  * The background color remains unchanged with each update.
+ * Theme is resolved automatically from context; passing `theme` in props has no effect.
  * @param {object} props
  * @param {string} props.seed - unique attribute of the entity (e.g., name, id, email).
  * @example
@@ -35,7 +36,7 @@ import type {ColorDetails, GenerateColorProps} from './types';
  * - rgb: object with red (r), green (g), and blue (b) values
  * - textColor: string - text color (dark or light), ensuring higher contrast on generated color
  */
-export function useColorGenerator({seed}: GenerateColorProps): ColorDetails {
+export function useColorGenerator({seed}: UseColorGeneratorProps): ColorDetails {
     const theme = useThemeType();
 
     const colorDetails = React.useMemo(() => {


### PR DESCRIPTION
## Summary by Sourcery

Align useColorGenerator hook props with context-based theming by introducing a dedicated props type and updating exports.

Enhancements:
- Introduce a UseColorGeneratorProps type that reflects automatic theme resolution while keeping the theme field deprecated and optional.
- Update useColorGenerator to consume the new props type and re-export it from the hook index for external use.