### PR TITLE
fix(SegmentedRadioGroup): ignore non-option siblings

### DIFF
--- a/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
+++ b/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
@@ -144,8 +144,8 @@ $block: '.#{variables.$ns}segmented-radio-group';
             }
         }
 
-        &_checked ~ & {
-            &:not(&_checked ~ #{$block}__option ~ #{$block}__option)::before {
+        #{$block}__option_checked ~ & {
+            &:not(#{$block}__option_checked ~ #{$block}__option ~ #{$block}__option)::before {
                 background-color: transparent;
             }
         }

--- a/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
+++ b/src/components/SegmentedRadioGroup/SegmentedRadioGroup.scss
@@ -46,15 +46,17 @@ $block: '.#{variables.$ns}segmented-radio-group';
                 border-color var(--_--transition-time) linear;
         }
 
-        &:not(:first-child):not(&_checked)::after {
-            border-inline-start-width: 0;
+        #{$block}__option ~ & {
+            &:not(&_checked)::after {
+                border-inline-start-width: 0;
+            }
         }
 
-        &:not(:last-child):not(&_checked):after {
+        &:has(~ #{$block}__option):not(&_checked)::after {
             border-inline-end-width: 0;
         }
 
-        &:first-child {
+        &:not(#{$block}__option ~ #{$block}__option) {
             border-start-start-radius: var(--_--border-radius);
             border-end-start-radius: var(--_--border-radius);
 
@@ -68,7 +70,7 @@ $block: '.#{variables.$ns}segmented-radio-group';
             }
         }
 
-        &:last-child {
+        &:not(:has(~ #{$block}__option)) {
             border-start-end-radius: var(--_--border-radius);
             border-end-end-radius: var(--_--border-radius);
 
@@ -138,6 +140,12 @@ $block: '.#{variables.$ns}segmented-radio-group';
 
             &::before,
             & + #{$block}__option::before {
+                background-color: transparent;
+            }
+        }
+
+        &_checked ~ & {
+            &:not(&_checked ~ #{$block}__option ~ #{$block}__option)::before {
                 background-color: transparent;
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Adjust segmented radio group styling to only treat actual option elements as segmented siblings, preventing layout artifacts when other elements are present.

Bug Fixes:
- Ensure segmented radio group borders and corner radii are computed only among option elements, ignoring non-option siblings.
- Prevent checked-state background styling from leaking across non-option siblings within the segmented radio group.