### PR TITLE
feat(TabList): add customization for "More" button

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -143,6 +143,7 @@ SANDBOX-->
 | activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately   |            `boolean`             | `false`  |
 | size            | Element size                                                                           |        `"m"` `"l"` `"xl"`        |  `"m"`   |
 | contentOverflow | How to deal with items that do not fit horizontally (wrap, scroll, or a **More** menu) | `"wrap"` `"scroll"` `"collapse"` | `"wrap"` |
+| moreLabel       | Label for the collapse overflow trigger when the active tab is visible in the list     |        `React.ReactNode`         | `"More"` |
 | qa              | HTML `data-qa` attribute, used in tests                                                |             `string`             |          |
 
 ## Tab

--- a/src/components/tabs/TabList.tsx
+++ b/src/components/tabs/TabList.tsx
@@ -58,6 +58,7 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, re
                         <TabListCollapseItem
                             ref={collapsedChildrenResults.collapseItemRef}
                             triggerChild={collapsedChildrenResults.triggerChild}
+                            moreLabel={props.moreLabel}
                             size={props.size}
                         >
                             {collapsedChildrenResults.collapsedChildren}

--- a/src/components/tabs/TabListCollapseItem/TabListCollapseItem.tsx
+++ b/src/components/tabs/TabListCollapseItem/TabListCollapseItem.tsx
@@ -22,7 +22,7 @@ const CHEVRON_SIZE: Record<NonNullable<TabListCollapseItemProps['size']>, number
 
 export const TabListCollapseItem = React.forwardRef<HTMLButtonElement, TabListCollapseItemProps>(
     (
-        {children, triggerChild, size = 'm'}: TabListCollapseItemProps,
+        {children, triggerChild, moreLabel = 'More', size = 'm'}: TabListCollapseItemProps,
         ref: React.ForwardedRef<HTMLButtonElement>,
     ) => {
         const childrenCount = React.Children.count(children);
@@ -52,7 +52,7 @@ export const TabListCollapseItem = React.forwardRef<HTMLButtonElement, TabListCo
                     <TabContent {...triggerChildTabProps} />
                 ) : (
                     <Text variant="inherit" className={bTabListCollapseItem('text')}>
-                        More
+                        {moreLabel}
                     </Text>
                 )}
                 <Text variant="inherit" className={bTabListCollapseItem('count')}>

--- a/src/components/tabs/__tests__/TabList.test.tsx
+++ b/src/components/tabs/__tests__/TabList.test.tsx
@@ -340,6 +340,34 @@ test('contentOverflow collapse: shows More button when some tabs overflow', () =
     spy.mockRestore();
 });
 
+test('contentOverflow collapse: supports custom moreLabel', () => {
+    const spy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+        this: Element,
+    ) {
+        if (this.classList.contains('g-tab-list')) return makeDOMRect(280);
+        if (this.classList.contains('g-tab-list-collapse-item')) return makeDOMRect(80);
+        return makeDOMRect(100);
+    });
+
+    render(
+        <TabList contentOverflow="collapse" value={tab1.value} moreLabel="Ещё">
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    expect(screen.getByRole('button', {name: /ещё/i})).toBeInTheDocument();
+
+    spy.mockRestore();
+});
+
 test('contentOverflow collapse: with narrow container shows selected tab as trigger', () => {
     const spy = mockNarrowContainer();
 

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -119,6 +119,7 @@ export function useTabList(
         activateOnFocus: _activateOnFocus,
         qa: _qa,
         contentOverflow,
+        moreLabel: _moreLabel,
         ...htmlProps
     } = tabListProps;
 

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -19,6 +19,8 @@ export interface TabListProps
     value?: string;
     size?: TabSize;
     contentOverflow?: 'wrap' | 'scroll' | 'collapse';
+    /** Label for the collapse overflow trigger when the active tab is visible in the list */
+    moreLabel?: React.ReactNode;
     activateOnFocus?: boolean;
     children?: React.ReactNode;
 }
@@ -75,5 +77,6 @@ export interface TabPanelProps
 export interface TabListCollapseItemProps {
     children: React.ReactNode;
     triggerChild?: React.ReactNode;
+    moreLabel?: React.ReactNode;
     size?: TabSize;
 }


### PR DESCRIPTION
Adds a moreLabel prop to TabList so the collapse overflow trigger text can be customized (for example, for localization).

## Summary by Sourcery

Add support for customizing the label of the collapsed overflow "More" button in TabList when using the collapse overflow mode.

New Features:
- Allow TabList consumers to specify a custom moreLabel for the collapse overflow trigger.
- Propagate the moreLabel prop to TabListCollapseItem with a default of "More".

Documentation:
- Document the new moreLabel prop for TabList in the tabs component README.

Tests:
- Add a test to verify that a custom moreLabel is rendered for the collapse overflow trigger.