### PR TITLE
fix: use variables for button and label components

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -87,7 +87,7 @@ $block: '.#{variables.$ns}button';
 
     &_size {
         &_xs {
-            --_--height: 20px;
+            --_--height: #{variables.$xs-height};
             --_--border-radius: var(--g-border-radius-xs);
             --_--padding: 6px;
             --_--icon-space: 12px;
@@ -95,7 +95,7 @@ $block: '.#{variables.$ns}button';
         }
 
         &_s {
-            --_--height: 24px;
+            --_--height: #{variables.$s-height};
             --_--border-radius: var(--g-border-radius-s);
             --_--padding: 8px;
             --_--icon-space: 16px;
@@ -103,7 +103,7 @@ $block: '.#{variables.$ns}button';
         }
 
         &_m {
-            --_--height: 28px;
+            --_--height: #{variables.$m-height};
             --_--border-radius: var(--g-border-radius-m);
             --_--padding: 12px;
             --_--icon-space: 16px;
@@ -111,7 +111,7 @@ $block: '.#{variables.$ns}button';
         }
 
         &_l {
-            --_--height: 36px;
+            --_--height: #{variables.$l-height};
             --_--border-radius: var(--g-border-radius-l);
             --_--padding: 16px;
             --_--icon-space: 16px;
@@ -119,7 +119,7 @@ $block: '.#{variables.$ns}button';
         }
 
         &_xl {
-            --_--height: 44px;
+            --_--height: #{variables.$xl-height};
             --_--border-radius: var(--g-border-radius-xl);
             --_--padding: 24px;
             --_--icon-space: 20px;

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -135,7 +135,7 @@ $transition-timing-function: ease-in-out;
 
     &_size {
         &_xxs {
-            --_--height: 18px;
+            --_--height: #{variables.$xxs-height};
             --_--border-radius: var(--g-border-radius-xs);
             --_--margin-inline: 6px;
             --_--margin-addon-start: 22px;
@@ -143,7 +143,7 @@ $transition-timing-function: ease-in-out;
         }
 
         &_xs {
-            --_--height: 20px;
+            --_--height: #{variables.$xs-height};
             --_--border-radius: var(--g-border-radius-xs);
             --_--margin-inline: 8px;
             --_--margin-addon-start: 24px;
@@ -151,7 +151,7 @@ $transition-timing-function: ease-in-out;
         }
 
         &_s {
-            --_--height: 24px;
+            --_--height: #{variables.$s-height};
             --_--border-radius: var(--g-border-radius-s);
             --_--margin-inline: 10px;
             --_--margin-addon-start: 28px;
@@ -159,7 +159,7 @@ $transition-timing-function: ease-in-out;
         }
 
         &_m {
-            --_--height: 28px;
+            --_--height: #{variables.$m-height};
             --_--border-radius: var(--g-border-radius-m);
             --_--margin-inline: 12px;
             --_--margin-addon-start: 32px;

--- a/src/components/variables.scss
+++ b/src/components/variables.scss
@@ -1,5 +1,6 @@
 $ns: 'g-';
 
+$xxs-height: 18px;
 $xs-height: 20px;
 $s-height: 24px;
 $m-height: 28px;


### PR DESCRIPTION
## Summary by Sourcery

Use shared SCSS variables for component heights across button and label size variants.

Enhancements:
- Replace hardcoded height values in button and label size modifiers with shared SCSS height variables to centralize sizing tokens.
- Introduce a new $xxs-height variable for the smallest label size to align it with the shared sizing system.