### PR TITLE
feat: default props provider

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
+
 import {AccordionProvider} from './AccordionContext';
 import {AccordionItem} from './AccordionItem/AccordionItem';
 import {AccordionSummary} from './AccordionSummary/AccordionSummary';
@@ -12,9 +14,10 @@ import type {AccordionProps, AccordionValue} from './types';
 import './Accordion.scss';
 
 export const Accordion = React.forwardRef(function Accordion<Multiple extends boolean = false>(
-    props: AccordionProps<Multiple>,
+    rawProps: AccordionProps<Multiple>,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
+    const props = useDefaultProps('Accordion', rawProps);
     const {t} = i18n.useTranslation();
     const {
         size = 'm',

--- a/src/components/ActionTooltip/ActionTooltip.tsx
+++ b/src/components/ActionTooltip/ActionTooltip.tsx
@@ -6,6 +6,7 @@ import {Hotkey} from '../Hotkey';
 import type {HotkeyProps} from '../Hotkey';
 import {Tooltip} from '../Tooltip';
 import type {TooltipProps} from '../Tooltip';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -27,15 +28,16 @@ const b = block('action-tooltip');
 const DEFAULT_OPEN_DELAY = 500;
 const DEFAULT_CLOSE_DELAY = 0;
 
-export function ActionTooltip({
-    title,
-    description,
-    hotkey,
-    openDelay = DEFAULT_OPEN_DELAY,
-    closeDelay = DEFAULT_CLOSE_DELAY,
-    className,
-    ...restProps
-}: ActionTooltipProps) {
+export function ActionTooltip(rawProps: ActionTooltipProps) {
+    const {
+        title,
+        description,
+        hotkey,
+        openDelay = DEFAULT_OPEN_DELAY,
+        closeDelay = DEFAULT_CLOSE_DELAY,
+        className,
+        ...restProps
+    } = useDefaultProps('ActionTooltip', rawProps);
     const content = React.useMemo(
         () => (
             <React.Fragment>

--- a/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/components/ActionsPanel/ActionsPanel.tsx
@@ -5,6 +5,7 @@ import {Xmark} from '@gravity-ui/icons';
 import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Text} from '../Text';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {CollapseActions} from './components/CollapseActions';
@@ -15,15 +16,9 @@ import './ActionsPanel.scss';
 
 const b = block('actions-panel');
 
-export const ActionsPanel = ({
-    className,
-    actions,
-    onClose,
-    renderNote,
-    noteClassName,
-    qa,
-    maxRowActions,
-}: ActionsPanelProps) => {
+export const ActionsPanel = (rawProps: ActionsPanelProps) => {
+    const {className, actions, onClose, renderNote, noteClassName, qa, maxRowActions} =
+        useDefaultProps('ActionsPanel', rawProps);
     const {t} = i18n.useTranslation();
     return (
         <div className={b(null, className)} data-qa={qa}>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -6,6 +6,7 @@ import {Button} from '../Button';
 import {Card} from '../Card';
 import {Icon} from '../Icon';
 import {colorText} from '../Text';
+import {useDefaultProps} from '../theme/useDefaultProps';
 
 import {AlertAction} from './AlertAction';
 import {AlertActions} from './AlertActions';
@@ -28,7 +29,8 @@ function alertSizeToIconSize(alertSize: AlertSize): number {
     }
 }
 
-export const Alert = (props: AlertProps) => {
+export const Alert = (rawProps: AlertProps) => {
+    const props = useDefaultProps('Alert', rawProps);
     const {
         theme = 'normal',
         view = 'filled',

--- a/src/components/ArrowToggle/ArrowToggle.tsx
+++ b/src/components/ArrowToggle/ArrowToggle.tsx
@@ -1,6 +1,7 @@
 import {ChevronDown} from '@gravity-ui/icons';
 
 import {Icon} from '../Icon';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -14,7 +15,13 @@ export interface ArrowToggleProps extends QAProps {
 
 const b = block('arrow-toggle');
 
-export function ArrowToggle({size = 16, direction = 'bottom', className, qa}: ArrowToggleProps) {
+export function ArrowToggle(rawProps: ArrowToggleProps) {
+    const {
+        size = 16,
+        direction = 'bottom',
+        className,
+        qa,
+    } = useDefaultProps('ArrowToggle', rawProps);
     return (
         <span
             style={{width: size, height: size}}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
 import {AvatarIcon} from './AvatarIcon';
@@ -10,7 +11,8 @@ import type {AvatarProps} from './types/main';
 
 import './Avatar.scss';
 
-export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((rawProps, ref) => {
+    const props = useDefaultProps('Avatar', rawProps);
     const {
         size = DEFAULT_AVATAR_SIZE,
         theme = 'normal',

--- a/src/components/AvatarStack/AvatarStack.tsx
+++ b/src/components/AvatarStack/AvatarStack.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {AvatarStackItem} from './AvatarStackItem';
@@ -16,8 +17,8 @@ const b = block('avatar-stack');
 const DEFAULT_MORE_BUTTON_STYLE = {zIndex: 0};
 
 const AvatarStackComponent = React.forwardRef<HTMLUListElement, AvatarStackProps>(
-    (
-        {
+    (rawProps, ref) => {
+        const {
             max = AVATAR_STACK_DEFAULT_MAX,
             total,
             overlapSize = 's',
@@ -26,9 +27,7 @@ const AvatarStackComponent = React.forwardRef<HTMLUListElement, AvatarStackProps
             className,
             renderMore,
             moreVariant,
-        },
-        ref,
-    ) => {
+        } = useDefaultProps('AvatarStack', rawProps);
         const visibleItems: React.ReactElement[] = [];
 
         /** All avatars amount */

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {useCollapseChildren, useForkRef, useResizeObserver} from '../../hooks';
 import type {PopupPlacement} from '../Popup';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, Key, QAProps} from '../types';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
@@ -30,9 +31,10 @@ export interface BreadcrumbsProps extends DOMProps, AriaLabelingProps, QAProps {
 }
 
 export const Breadcrumbs = React.forwardRef(function Breadcrumbs(
-    props: BreadcrumbsProps,
+    rawProps: BreadcrumbsProps,
     ref: React.Ref<HTMLOListElement>,
 ) {
+    const props = useDefaultProps('Breadcrumbs', rawProps);
     const listRef = React.useRef<HTMLOListElement>(null);
     const containerRef = useForkRef(ref, listRef);
     const menuRef = React.useRef<HTMLLIElement>(null);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {isIcon, isSvg} from '../utils/common';
@@ -35,7 +36,7 @@ export type ButtonPin =
 
 export type ButtonWidth = 'auto' | 'max';
 
-interface ButtonCommonProps extends QAProps, DOMProps {
+export interface ButtonCommonProps extends QAProps, DOMProps {
     view?: ButtonView;
     size?: ButtonSize;
     pin?: ButtonPin;
@@ -94,12 +95,13 @@ export type ButtonProps<T extends ButtonCustomElementType = undefined> =
 const b = block('button');
 
 const _Button = React.forwardRef(function Button<T extends ButtonCustomElementType>(
-    props: ButtonProps<T>,
+    rawProps: ButtonProps<T>,
     ref:
         | React.Ref<HTMLButtonElement>
         | React.Ref<HTMLAnchorElement>
         | React.Ref<T extends string ? React.ComponentRef<T> : T>,
 ) {
+    const props = useDefaultProps('Button', rawProps);
     const {
         view = 'normal',
         size = 'm',

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {useActionHandlers} from '../../hooks';
 import type {BoxProps} from '../layout';
 import {Box} from '../layout';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import './Card.scss';
@@ -43,7 +44,8 @@ const roles = {
     container: undefined,
 };
 
-export const Card = React.forwardRef<HTMLDivElement, CardProps>(function Card(props, ref) {
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(function Card(rawProps, ref) {
+    const props = useDefaultProps('Card', rawProps);
     const {
         type = 'container',
         theme,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {useCheckbox} from '../../hooks/private';
 import {ControlLabel} from '../ControlLabel';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {ControlProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -24,7 +25,8 @@ export interface CheckboxProps extends ControlProps, DOMProps, QAProps {
 const b = block('checkbox');
 
 export const Checkbox = React.forwardRef<HTMLLabelElement, CheckboxProps>(
-    function Checkbox(props, ref) {
+    function Checkbox(rawProps, ref) {
+        const props = useDefaultProps('Checkbox', rawProps);
         const {
             size = 'm',
             indeterminate,

--- a/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/src/components/ClipboardButton/ClipboardButton.tsx
@@ -12,6 +12,7 @@ import type {
     CopyToClipboardStatus,
     OnCopyHandler,
 } from '../CopyToClipboard/types';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import i18n from './i18n';
@@ -80,7 +81,8 @@ const ClipboardButtonComponent = (props: ClipboardButtonComponentProps) => {
     );
 };
 
-export function ClipboardButton(props: ClipboardButtonProps) {
+export function ClipboardButton(rawProps: ClipboardButtonProps) {
+    const props = useDefaultProps('ClipboardButton', rawProps);
     const {
         text,
         timeout = DEFAULT_TIMEOUT,

--- a/src/components/ClipboardIcon/ClipboardIcon.tsx
+++ b/src/components/ClipboardIcon/ClipboardIcon.tsx
@@ -2,13 +2,15 @@ import {Copy, CopyCheck, CopyXmark} from '@gravity-ui/icons';
 
 import type {CopyToClipboardStatus} from '../CopyToClipboard/types';
 import {Icon} from '../Icon';
+import {useDefaultProps} from '../theme/useDefaultProps';
 export interface ClipboardIconProps {
     size?: number;
     status: CopyToClipboardStatus;
     className?: string;
 }
 
-export function ClipboardIcon({status, ...rest}: ClipboardIconProps) {
+export function ClipboardIcon(rawProps: ClipboardIconProps) {
+    const {status, ...rest} = useDefaultProps('ClipboardIcon', rawProps);
     if (status === 'error') {
         return <Icon data={CopyXmark} {...rest} />;
     }

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -2,12 +2,15 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
+
 import {copyText} from './copyText';
 import type {CopyToClipboardProps, CopyToClipboardStatus} from './types';
 
 const INITIAL_STATUS: CopyToClipboardStatus = 'pending';
 
-export function CopyToClipboard(props: CopyToClipboardProps) {
+export function CopyToClipboard(rawProps: CopyToClipboardProps) {
+    const props = useDefaultProps('CopyToClipboard', rawProps);
     const {children, text, timeout, onCopy} = props;
 
     const textRef = React.useRef('');

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {filterDOMProps} from '../utils/filterDOMProps';
 import {isOfType} from '../utils/isOfType';
 import {warnOnce} from '../utils/warn';
@@ -11,16 +12,17 @@ import type {DefinitionListProps} from './types';
 
 import './DefinitionList.scss';
 
-export function DefinitionList({
-    responsive,
-    direction = 'horizontal',
-    nameMaxWidth,
-    contentMaxWidth,
-    className,
-    children,
-    qa,
-    ...restProps
-}: DefinitionListProps) {
+export function DefinitionList(rawProps: DefinitionListProps) {
+    const {
+        responsive,
+        direction = 'horizontal',
+        nameMaxWidth,
+        contentMaxWidth,
+        className,
+        children,
+        qa,
+        ...restProps
+    } = useDefaultProps('DefinitionList', rawProps);
     const normalizedChildren = prepareChildren(children);
     const withCopy = normalizedChildren.some((item) => item.props.copyText);
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import type {ModalCloseReason, ModalProps} from '../Modal';
 import {Modal} from '../Modal';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -50,34 +51,35 @@ export interface DialogProps extends AriaLabelingProps, QAProps {
     disableHeightTransition?: boolean;
 }
 
-export function Dialog({
-    container,
-    children,
-    open,
-    disableBodyScrollLock = false,
-    disableEscapeKeyDown = false,
-    disableOutsideClick = false,
-    initialFocus,
-    returnFocus,
-    keepMounted = false,
-    size,
-    contentOverflow = 'visible',
-    className,
-    modalClassName,
-    hasCloseButton = true,
-    disableHeightTransition = false,
-    onEscapeKeyDown,
-    onEnterKeyDown,
-    onOpenChange,
-    onOutsideClick,
-    onClose,
-    onTransitionIn,
-    onTransitionInComplete,
-    onTransitionOut,
-    onTransitionOutComplete,
-    qa,
-    ...restProps
-}: DialogProps) {
+export function Dialog(rawProps: DialogProps) {
+    const {
+        container,
+        children,
+        open,
+        disableBodyScrollLock = false,
+        disableEscapeKeyDown = false,
+        disableOutsideClick = false,
+        initialFocus,
+        returnFocus,
+        keepMounted = false,
+        size,
+        contentOverflow = 'visible',
+        className,
+        modalClassName,
+        hasCloseButton = true,
+        disableHeightTransition = false,
+        onEscapeKeyDown,
+        onEnterKeyDown,
+        onOpenChange,
+        onOutsideClick,
+        onClose,
+        onTransitionIn,
+        onTransitionInComplete,
+        onTransitionOut,
+        onTransitionOutComplete,
+        qa,
+        ...restProps
+    } = useDefaultProps('Dialog', rawProps);
     const handleCloseButtonClick = React.useCallback(
         (event: React.MouseEvent) => {
             onClose(event.nativeEvent, 'closeButtonClick');

--- a/src/components/Disclosure/Disclosure.tsx
+++ b/src/components/Disclosure/Disclosure.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {isOfType} from '../utils/isOfType';
 
@@ -49,7 +50,8 @@ const isDisclosureSummaryComponent = isOfType(DisclosureSummary);
 
 // @ts-expect-error this ts-error is appears when forwarding ref. It complains that DisclosureComposition props is not provided initially
 export const Disclosure: React.FunctionComponent<DisclosureProps> & DisclosureComposition =
-    React.forwardRef<HTMLDivElement, DisclosureProps>(function Disclosure(props, ref) {
+    React.forwardRef<HTMLDivElement, DisclosureProps>(function Disclosure(rawProps, ref) {
+        const props = useDefaultProps('Disclosure', rawProps);
         const {
             size = 'm',
             disabled = false,

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -17,28 +18,31 @@ export interface DividerProps extends AriaLabelingProps, DOMProps, QAProps {
 
 const b = block('divider');
 
-export const Divider = React.forwardRef<HTMLDivElement, DividerProps>(function Divider(props, ref) {
-    const {
-        orientation = 'horizontal',
-        className,
-        style,
-        qa,
-        children,
-        align = 'start',
-        ...restProps
-    } = props;
+export const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
+    function Divider(rawProps, ref) {
+        const props = useDefaultProps('Divider', rawProps);
+        const {
+            orientation = 'horizontal',
+            className,
+            style,
+            qa,
+            children,
+            align = 'start',
+            ...restProps
+        } = props;
 
-    return (
-        <div
-            {...filterDOMProps(restProps, {labelable: true})}
-            className={b({orientation, align}, className)}
-            ref={ref}
-            style={style}
-            data-qa={qa}
-            role="separator"
-            aria-orientation={orientation === 'vertical' ? 'vertical' : undefined}
-        >
-            {children}
-        </div>
-    );
-});
+        return (
+            <div
+                {...filterDOMProps(restProps, {labelable: true})}
+                className={b({orientation, align}, className)}
+                ref={ref}
+                style={style}
+                data-qa={qa}
+                role="separator"
+                aria-orientation={orientation === 'vertical' ? 'vertical' : undefined}
+            >
+                {children}
+            </div>
+        );
+    },
+);

--- a/src/components/Drawer/components/Drawer.tsx
+++ b/src/components/Drawer/components/Drawer.tsx
@@ -15,6 +15,7 @@ import {useForkRef} from '../../../hooks';
 import {useFloatingTransition} from '../../../hooks/private/useFloatingTransition';
 import type {ModalProps} from '../../Modal';
 import {Portal} from '../../Portal';
+import {useDefaultProps} from '../../theme/useDefaultProps';
 import {block} from '../../utils/cn';
 import {filterDOMProps} from '../../utils/filterDOMProps';
 import {DRAWER_ANIMATION_DURATION_MS} from '../constants';
@@ -84,40 +85,41 @@ export interface DrawerProps
     disableTransition?: boolean;
 }
 
-export const Drawer = ({
-    open,
-    onOpenChange,
-    placement = 'left',
-    children,
-    contentClassName,
-    resizable = false,
-    size,
-    minSize,
-    maxSize,
-    onResizeStart,
-    onResizeEnd,
-    onResize,
-    className,
-    style,
-    qa,
-    disableEscapeKeyDown,
-    initialFocus,
-    returnFocus,
-    disableBodyScrollLock = false,
-    contentOverflow = 'visible',
-    disableVisuallyHiddenDismiss,
-    onTransitionIn,
-    onTransitionInComplete,
-    onTransitionOut,
-    onTransitionOutComplete,
-    floatingRef,
-    disablePortal,
-    keepMounted = false,
-    container,
-    hideVeil = false,
-    disableTransition = false,
-    ...restProps
-}: DrawerProps) => {
+export const Drawer = (rawProps: DrawerProps) => {
+    const {
+        open,
+        onOpenChange,
+        placement = 'left',
+        children,
+        contentClassName,
+        resizable = false,
+        size,
+        minSize,
+        maxSize,
+        onResizeStart,
+        onResizeEnd,
+        onResize,
+        className,
+        style,
+        qa,
+        disableEscapeKeyDown,
+        initialFocus,
+        returnFocus,
+        disableBodyScrollLock = false,
+        contentOverflow = 'visible',
+        disableVisuallyHiddenDismiss,
+        onTransitionIn,
+        onTransitionInComplete,
+        onTransitionOut,
+        onTransitionOutComplete,
+        floatingRef,
+        disablePortal,
+        keepMounted = false,
+        container,
+        hideVeil = false,
+        disableTransition = false,
+        ...restProps
+    } = useDefaultProps('Drawer', rawProps);
     const floatingNodeId = useFloatingNodeId();
     const disableOutsideClick = hideVeil || restProps.disableOutsideClick;
 

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -10,6 +10,7 @@ import type {ButtonProps} from '../Button';
 import {Icon} from '../Icon';
 import type {MenuProps} from '../Menu';
 import type {PopupProps} from '../Popup';
+import {useDefaultProps} from '../theme/useDefaultProps';
 
 import {cnDropdownMenu} from './DropdownMenu.classname';
 import {DropdownMenuContext} from './DropdownMenuContext';
@@ -97,25 +98,26 @@ export type ControlledDropdownMenuProps<T> = DropdownMenuProps<T> & {
     onOpenToggle: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const DropdownMenu = <T,>({
-    items = [],
-    size = 'm',
-    icon = <Icon data={Ellipsis} />,
-    open,
-    onOpenToggle,
-    hideOnScroll = true,
-    data,
-    disabled,
-    switcher,
-    renderSwitcher,
-    switcherWrapperClassName,
-    defaultSwitcherProps,
-    defaultSwitcherClassName,
-    onSwitcherClick,
-    menuProps,
-    popupProps,
-    children,
-}: DropdownMenuProps<T> | ControlledDropdownMenuProps<T>) => {
+const DropdownMenu = <T,>(rawProps: DropdownMenuProps<T> | ControlledDropdownMenuProps<T>) => {
+    const {
+        items = [],
+        size = 'm',
+        icon = <Icon data={Ellipsis} />,
+        open,
+        onOpenToggle,
+        hideOnScroll = true,
+        data,
+        disabled,
+        switcher,
+        renderSwitcher,
+        switcherWrapperClassName,
+        defaultSwitcherProps,
+        defaultSwitcherClassName,
+        onSwitcherClick,
+        menuProps,
+        popupProps,
+        children,
+    } = useDefaultProps('DropdownMenu', rawProps);
     const anchorRef = React.useRef<HTMLDivElement | null>(null);
 
     const {isPopupShown, togglePopup, closePopup} = usePopupVisibility(

--- a/src/components/FilePreview/FilePreview.tsx
+++ b/src/components/FilePreview/FilePreview.tsx
@@ -17,6 +17,7 @@ import {Icon} from '../Icon';
 import type {IconData} from '../Icon';
 import {Text} from '../Text';
 import {useMobile} from '../mobile';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -64,7 +65,8 @@ interface CompactFilePreviewProps extends FilePreviewBaseProps {
 
 export type FilePreviewProps = DefaultFilePreviewProps | CompactFilePreviewProps;
 
-export function FilePreview(props: FilePreviewProps) {
+export function FilePreview(rawProps: FilePreviewProps) {
+    const props = useDefaultProps('FilePreview', rawProps);
     const {className, qa, file, imageSrc, description, onClick, view = 'default', selected} = props;
 
     const actions = view === 'default' && 'actions' in props ? props.actions : undefined;

--- a/src/components/HelpMark/HelpMark.tsx
+++ b/src/components/HelpMark/HelpMark.tsx
@@ -5,6 +5,7 @@ import {CircleQuestion} from '@gravity-ui/icons';
 import {Icon} from '../Icon';
 import {Popover} from '../Popover';
 import type {PopoverProps} from '../Popover';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -23,25 +24,36 @@ export interface HelpMarkProps extends QAProps, React.ButtonHTMLAttributes<HTMLB
     children?: React.ReactNode;
 }
 
-export const HelpMark = React.forwardRef<HTMLButtonElement, HelpMarkProps>(function HelpMark(
-    {children, qa, className, iconSize = 'm', popoverProps, ...restProps},
-    ref,
-) {
-    return (
-        <Popover
-            content={<div className={b('popover')}>{children}</div>}
-            hasArrow
-            {...popoverProps}
-        >
-            <button
-                {...restProps}
-                ref={ref}
-                type="button"
-                className={b({size: iconSize}, className)}
-                data-qa={qa}
+export const HelpMark = React.forwardRef<HTMLButtonElement, HelpMarkProps>(
+    function HelpMark(rawProps, ref) {
+        const {
+            children,
+            qa,
+            className,
+            iconSize = 'm',
+            popoverProps,
+            ...restProps
+        } = useDefaultProps('HelpMark', rawProps);
+        return (
+            <Popover
+                content={<div className={b('popover')}>{children}</div>}
+                hasArrow
+                {...popoverProps}
             >
-                <Icon data={CircleQuestion} size={ICON_SIZE_MAP[iconSize]} className={b('icon')} />
-            </button>
-        </Popover>
-    );
-});
+                <button
+                    {...restProps}
+                    ref={ref}
+                    type="button"
+                    className={b({size: iconSize}, className)}
+                    data-qa={qa}
+                >
+                    <Icon
+                        data={CircleQuestion}
+                        size={ICON_SIZE_MAP[iconSize]}
+                        className={b('icon')}
+                    />
+                </button>
+            </Popover>
+        );
+    },
+);

--- a/src/components/Hotkey/Hotkey.tsx
+++ b/src/components/Hotkey/Hotkey.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -33,7 +34,8 @@ export interface HotkeyProps extends AriaLabelingProps, DOMProps, QAProps {
     platform?: Platform;
 }
 
-export const Hotkey = React.forwardRef<HTMLElement, HotkeyProps>(function Hotkey(props, ref) {
+export const Hotkey = React.forwardRef<HTMLElement, HotkeyProps>(function Hotkey(rawProps, ref) {
+    const props = useDefaultProps('Hotkey', rawProps);
     const {value, platform, view = 'light', qa, style, className, ...restProps} = props;
 
     const groups = parseHotkeys(value, {platform});

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import type {ColorTextBaseProps} from '../Text/colorText/colorText';
 import {colorText} from '../Text/colorText/colorText';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {a11yHiddenSvgProps} from '../utils/svg';
@@ -37,123 +38,119 @@ export interface IconProps extends QAProps, DOMProps {
 const b = block('icon');
 
 export const Icon: React.ForwardRefExoticComponent<IconProps & React.RefAttributes<SVGSVGElement>> &
-    IconComposition = React.forwardRef<SVGSVGElement, IconProps>(
-    (
-        {
-            data,
-            width,
-            height,
-            size,
-            className,
-            style,
-            color,
-            fill = 'currentColor',
-            stroke = 'none',
-            qa,
-        },
-        ref,
-    ) => {
-        // This component supports four different ways to load and use icons:
-        // - svg-react-loader
-        // - svg-sprite-loader
-        // - @svgr/webpack
-        // - string with raw svg
+    IconComposition = React.forwardRef<SVGSVGElement, IconProps>((rawProps, ref) => {
+    const {
+        data,
+        width,
+        height,
+        size,
+        className,
+        style,
+        color,
+        fill = 'currentColor',
+        stroke = 'none',
+        qa,
+    } = useDefaultProps('Icon', rawProps);
+    // This component supports four different ways to load and use icons:
+    // - svg-react-loader
+    // - svg-sprite-loader
+    // - @svgr/webpack
+    // - string with raw svg
 
-        let w, h;
+    let w, h;
 
-        if (size) {
-            w = size;
-            h = size;
+    if (size) {
+        w = size;
+        h = size;
+    }
+
+    if (width) {
+        w = width;
+    }
+
+    if (height) {
+        h = height;
+    }
+
+    // Parsing viewBox to get width and height in case they were not specified
+    // For svg-react-loader svg attributes are available in component defaultProps
+    // In case with @svgr/webpack svg attributes can be fetched from the react element
+    // after calling svgr-component without any propses
+    let viewBox: string | undefined;
+
+    if (isSpriteData(data)) {
+        ({viewBox} = data);
+    } else if (isStringSvgData(data)) {
+        viewBox = getStringViewBox(data);
+    } else if (isComponentSvgData(data)) {
+        ({viewBox} = data.defaultProps);
+    } else if (isSvgrData(data)) {
+        const el = data({}) as React.ReactElement;
+
+        if (el) {
+            ({viewBox} = el.props);
         }
+    }
 
-        if (width) {
-            w = width;
+    if (viewBox && (!w || !h)) {
+        const values = viewBox.split(/\s+|\s*,\s*/);
+
+        if (!w) {
+            w = values[2];
         }
-
-        if (height) {
-            h = height;
+        if (!h) {
+            h = values[3];
         }
+    }
 
-        // Parsing viewBox to get width and height in case they were not specified
-        // For svg-react-loader svg attributes are available in component defaultProps
-        // In case with @svgr/webpack svg attributes can be fetched from the react element
-        // after calling svgr-component without any propses
-        let viewBox: string | undefined;
+    const hasStyleColor = style?.color !== undefined;
 
-        if (isSpriteData(data)) {
-            ({viewBox} = data);
-        } else if (isStringSvgData(data)) {
-            viewBox = getStringViewBox(data);
-        } else if (isComponentSvgData(data)) {
-            ({viewBox} = data.defaultProps);
-        } else if (isSvgrData(data)) {
-            const el = data({}) as React.ReactElement;
+    const svgClassName =
+        color && !hasStyleColor ? colorText({color}, b(null, className)) : b(null, className);
 
-            if (el) {
-                ({viewBox} = el.props);
-            }
-        }
+    const props = {
+        xmlns: 'http://www.w3.org/2000/svg',
+        xmlnsXlink: 'http://www.w3.org/1999/xlink',
+        width: w,
+        height: h,
+        className: svgClassName,
+        style,
+        fill,
+        stroke,
+        'data-qa': qa,
+        ...a11yHiddenSvgProps,
+    };
 
-        if (viewBox && (!w || !h)) {
-            const values = viewBox.split(/\s+|\s*,\s*/);
+    if (isStringSvgData(data)) {
+        const preparedData = prepareStringData(data);
 
-            if (!w) {
-                w = values[2];
-            }
-            if (!h) {
-                h = values[3];
-            }
-        }
+        return <svg {...props} ref={ref} dangerouslySetInnerHTML={{__html: preparedData}} />;
+    }
 
-        const hasStyleColor = style?.color !== undefined;
-
-        const svgClassName =
-            color && !hasStyleColor ? colorText({color}, b(null, className)) : b(null, className);
-
-        const props = {
-            xmlns: 'http://www.w3.org/2000/svg',
-            xmlnsXlink: 'http://www.w3.org/1999/xlink',
-            width: w,
-            height: h,
-            className: svgClassName,
-            style,
-            fill,
-            stroke,
-            'data-qa': qa,
-            ...a11yHiddenSvgProps,
-        };
-
-        if (isStringSvgData(data)) {
-            const preparedData = prepareStringData(data);
-
-            return <svg {...props} ref={ref} dangerouslySetInnerHTML={{__html: preparedData}} />;
-        }
-
-        if (isSpriteData(data)) {
-            const href = Icon.prefix + (data.url || `#${data.id}`);
-
-            return (
-                <svg {...props} viewBox={viewBox} ref={ref}>
-                    <use href={href} xlinkHref={href} />
-                </svg>
-            );
-        }
-
-        // SVG wrapping is needed for compability with sprite-loader
-        // So we removing width and height for internal component so only external one is specifying them
-
-        const IconComponent = data;
-        if (IconComponent.defaultProps) {
-            IconComponent.defaultProps.width = IconComponent.defaultProps.height = undefined;
-        }
+    if (isSpriteData(data)) {
+        const href = Icon.prefix + (data.url || `#${data.id}`);
 
         return (
-            <svg {...props} ref={ref}>
-                <IconComponent width={undefined} height={undefined} />
+            <svg {...props} viewBox={viewBox} ref={ref}>
+                <use href={href} xlinkHref={href} />
             </svg>
         );
-    },
-);
+    }
+
+    // SVG wrapping is needed for compability with sprite-loader
+    // So we removing width and height for internal component so only external one is specifying them
+
+    const IconComponent = data;
+    if (IconComponent.defaultProps) {
+        IconComponent.defaultProps.width = IconComponent.defaultProps.height = undefined;
+    }
+
+    return (
+        <svg {...props} ref={ref}>
+            <IconComponent width={undefined} height={undefined} />
+        </svg>
+    );
+});
 
 Icon.displayName = 'Icon';
 Icon.prefix = '';

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -8,6 +8,7 @@ import {ClipboardIcon} from '../ClipboardIcon';
 import {CopyToClipboard} from '../CopyToClipboard';
 import type {CopyToClipboardStatus} from '../CopyToClipboard';
 import {Icon} from '../Icon';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -63,9 +64,10 @@ export interface LabelProps extends QAProps {
 }
 
 export const Label = React.forwardRef(function Label(
-    props: LabelProps,
+    rawProps: LabelProps,
     ref: React.Ref<HTMLDivElement>,
 ) {
+    const props = useDefaultProps('Label', rawProps);
     const {
         type = 'default',
         theme = 'normal',

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {eventBroker} from '../utils/event-broker';
@@ -27,8 +28,8 @@ export interface LinkProps
 
 const b = block('link');
 
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
-    {
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(rawProps, ref) {
+    const {
         view = 'normal',
         visitable = false,
         underline = false,
@@ -38,9 +39,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
         qa,
         onClickCapture,
         ...props
-    },
-    ref,
-) {
+    } = useDefaultProps('Link', rawProps);
     const handleClickCapture = React.useCallback(
         (event: React.MouseEvent<HTMLAnchorElement>) => {
             eventBroker.publish({

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,3 +1,4 @@
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -12,7 +13,8 @@ export interface LoaderProps extends QAProps {
     size?: LoaderSize;
 }
 
-export function Loader({size = 's', className, qa}: LoaderProps) {
+export function Loader(rawProps: LoaderProps) {
+    const {size = 's', className, qa} = useDefaultProps('Loader', rawProps);
     return (
         <div className={b({size}, className)} data-qa={qa}>
             <div className={b('left')} />

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -31,10 +32,15 @@ interface MenuComponent
 }
 
 // TODO: keyboard navigation, Up/Down arrows and Enter
-export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(function Menu(
-    {size = 'm', children, style, className, qa, ...restProps},
-    ref,
-) {
+export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(function Menu(rawProps, ref) {
+    const {
+        size = 'm',
+        children,
+        style,
+        className,
+        qa,
+        ...restProps
+    } = useDefaultProps('Menu', rawProps);
     return (
         <ul
             {...filterDOMProps(restProps, {labelable: true})}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -27,6 +27,7 @@ import {useAnimateHeight} from '../../hooks/private';
 import {useFloatingTransition} from '../../hooks/private/useFloatingTransition';
 import {Portal} from '../Portal';
 import type {PortalProps} from '../Portal';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -108,36 +109,37 @@ const b = block('modal');
 
 const TRANSITION_DURATION = 150;
 
-function ModalComponent({
-    open = false,
-    onOpenChange,
-    keepMounted = false,
-    disableBodyScrollLock = false,
-    disableEscapeKeyDown,
-    disableOutsideClick,
-    initialFocus,
-    returnFocus,
-    disableVisuallyHiddenDismiss,
-    onEscapeKeyDown,
-    onOutsideClick,
-    onClose,
-    onEnterKeyDown,
-    onTransitionIn,
-    onTransitionInComplete,
-    onTransitionOut,
-    onTransitionOutComplete,
-    children,
-    style,
-    contentOverflow = 'visible',
-    className,
-    contentClassName,
-    container,
-    disablePortal,
-    qa,
-    floatingRef,
-    disableHeightTransition = false,
-    ...restProps
-}: ModalProps) {
+function ModalComponent(rawProps: ModalProps) {
+    const {
+        open = false,
+        onOpenChange,
+        keepMounted = false,
+        disableBodyScrollLock = false,
+        disableEscapeKeyDown,
+        disableOutsideClick,
+        initialFocus,
+        returnFocus,
+        disableVisuallyHiddenDismiss,
+        onEscapeKeyDown,
+        onOutsideClick,
+        onClose,
+        onEnterKeyDown,
+        onTransitionIn,
+        onTransitionInComplete,
+        onTransitionOut,
+        onTransitionOutComplete,
+        children,
+        style,
+        contentOverflow = 'visible',
+        className,
+        contentClassName,
+        container,
+        disablePortal,
+        qa,
+        floatingRef,
+        disableHeightTransition = false,
+        ...restProps
+    } = useDefaultProps('Modal', rawProps);
     useLayer({open, type: 'modal'});
 
     const overlayRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -8,6 +8,7 @@ import {useFormResetHandler} from '../../hooks/private';
 import {TextInput} from '../controls/TextInput';
 import type {BaseInputControlProps} from '../controls/types';
 import {getInputControlState} from '../controls/utils';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {NumericArrows} from './NumericArrows/NumericArrows';
@@ -87,202 +88,209 @@ function getStringValue(value: number | null) {
     return value === null ? '' : String(value);
 }
 
-export const NumberInput = React.forwardRef<HTMLSpanElement, NumberInputProps>(function NumberInput(
-    {endContent, defaultValue: externalDefaultValue, ...props},
-    ref,
-) {
-    const {
-        value: externalValue,
-        onChange: handleChange,
-        onUpdate: externalOnUpdate,
-        min: externalMin,
-        max: externalMax,
-        shiftMultiplier: externalShiftMultiplier = 10,
-        step: externalStep,
-        size = 'm',
-        view = 'normal',
-        disabled,
-        hiddenControls,
-        validationState,
-        onBlur,
-        onKeyDown,
-        allowDecimal = false,
-        className,
-    } = props;
+export const NumberInput = React.forwardRef<HTMLSpanElement, NumberInputProps>(
+    function NumberInput(rawProps, ref) {
+        const {
+            endContent,
+            defaultValue: externalDefaultValue,
+            ...props
+        } = useDefaultProps('NumberInput', rawProps);
+        const {
+            value: externalValue,
+            onChange: handleChange,
+            onUpdate: externalOnUpdate,
+            min: externalMin,
+            max: externalMax,
+            shiftMultiplier: externalShiftMultiplier = 10,
+            step: externalStep,
+            size = 'm',
+            view = 'normal',
+            disabled,
+            hiddenControls,
+            validationState,
+            onBlur,
+            onKeyDown,
+            allowDecimal = false,
+            className,
+        } = props;
 
-    const {
-        min,
-        max,
-        step: baseStep,
-        value: internalValue,
-        defaultValue,
-        shiftMultiplier,
-    } = getInternalState({
-        min: externalMin,
-        max: externalMax,
-        step: externalStep,
-        shiftMultiplier: externalShiftMultiplier,
-        allowDecimal,
-        value: externalValue,
-        defaultValue: externalDefaultValue,
-    });
+        const {
+            min,
+            max,
+            step: baseStep,
+            value: internalValue,
+            defaultValue,
+            shiftMultiplier,
+        } = getInternalState({
+            min: externalMin,
+            max: externalMax,
+            step: externalStep,
+            shiftMultiplier: externalShiftMultiplier,
+            allowDecimal,
+            value: externalValue,
+            defaultValue: externalDefaultValue,
+        });
 
-    const [value, setValue] = useControlledState(
-        internalValue,
-        defaultValue ?? null,
-        externalOnUpdate,
-    );
+        const [value, setValue] = useControlledState(
+            internalValue,
+            defaultValue ?? null,
+            externalOnUpdate,
+        );
 
-    const [inputValue, setInputValue] = React.useState(getStringValue(value));
+        const [inputValue, setInputValue] = React.useState(getStringValue(value));
 
-    React.useEffect(() => {
-        const stringPropsValue = getStringValue(value);
-        if (!areStringRepresentationOfNumbersEqual(inputValue, stringPropsValue)) {
-            setInputValue(stringPropsValue);
-        }
-    }, [value, inputValue]);
-
-    const clamp = !(allowDecimal && !externalStep);
-
-    const safeValue = value ?? 0;
-
-    const state = getInputControlState(validationState);
-
-    const canIncrementNumber = safeValue < (max ?? Number.MAX_SAFE_INTEGER);
-
-    const canDecrementNumber = safeValue > (min ?? Number.MIN_SAFE_INTEGER);
-
-    const innerControlRef = React.useRef<HTMLInputElement>(null);
-    const fieldRef = useFormResetHandler({
-        initialValue: value,
-        onReset: setValue,
-    });
-    const handleRef = useForkRef(props.controlRef, innerControlRef, fieldRef);
-
-    const handleValueDelta = (
-        e:
-            | React.MouseEvent<HTMLButtonElement>
-            | React.WheelEvent<HTMLInputElement>
-            | React.KeyboardEvent<HTMLInputElement>,
-        direction: 'up' | 'down',
-    ) => {
-        const step = e.shiftKey ? shiftMultiplier * baseStep : baseStep;
-        const deltaWithSign = direction === 'up' ? step : -step;
-        if (direction === 'up' ? canIncrementNumber : canDecrementNumber) {
-            const newValue = clampToNearestStepValue({
-                value: safeValue + deltaWithSign,
-                step: baseStep,
-                min,
-                max,
-                direction,
-            });
-            setValue?.(newValue);
-            setInputValue(newValue.toString());
-        }
-    };
-
-    const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
-        if (e.key === KeyCode.ARROW_DOWN) {
-            e.preventDefault();
-            handleValueDelta(e, 'down');
-        } else if (e.key === KeyCode.ARROW_UP) {
-            e.preventDefault();
-            handleValueDelta(e, 'up');
-        } else if (e.key === KeyCode.HOME) {
-            e.preventDefault();
-            if (min !== undefined) {
-                setValue?.(min);
-                setInputValue(min.toString());
+        React.useEffect(() => {
+            const stringPropsValue = getStringValue(value);
+            if (!areStringRepresentationOfNumbersEqual(inputValue, stringPropsValue)) {
+                setInputValue(stringPropsValue);
             }
-        } else if (e.key === KeyCode.END) {
-            e.preventDefault();
-            if (max !== undefined) {
+        }, [value, inputValue]);
+
+        const clamp = !(allowDecimal && !externalStep);
+
+        const safeValue = value ?? 0;
+
+        const state = getInputControlState(validationState);
+
+        const canIncrementNumber = safeValue < (max ?? Number.MAX_SAFE_INTEGER);
+
+        const canDecrementNumber = safeValue > (min ?? Number.MIN_SAFE_INTEGER);
+
+        const innerControlRef = React.useRef<HTMLInputElement>(null);
+        const fieldRef = useFormResetHandler({
+            initialValue: value,
+            onReset: setValue,
+        });
+        const handleRef = useForkRef(props.controlRef, innerControlRef, fieldRef);
+
+        const handleValueDelta = (
+            e:
+                | React.MouseEvent<HTMLButtonElement>
+                | React.WheelEvent<HTMLInputElement>
+                | React.KeyboardEvent<HTMLInputElement>,
+            direction: 'up' | 'down',
+        ) => {
+            const step = e.shiftKey ? shiftMultiplier * baseStep : baseStep;
+            const deltaWithSign = direction === 'up' ? step : -step;
+            if (direction === 'up' ? canIncrementNumber : canDecrementNumber) {
                 const newValue = clampToNearestStepValue({
-                    value: max,
+                    value: safeValue + deltaWithSign,
                     step: baseStep,
                     min,
                     max,
+                    direction,
                 });
                 setValue?.(newValue);
                 setInputValue(newValue.toString());
             }
-        }
-        onKeyDown?.(e);
-    };
+        };
 
-    const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-        if (clamp && value !== null) {
-            const clampedValue = clampToNearestStepValue({
-                value,
-                step: baseStep,
-                min,
-                max,
-            });
-
-            if (value !== clampedValue) {
-                setValue?.(clampedValue);
+        const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+            if (e.key === KeyCode.ARROW_DOWN) {
+                e.preventDefault();
+                handleValueDelta(e, 'down');
+            } else if (e.key === KeyCode.ARROW_UP) {
+                e.preventDefault();
+                handleValueDelta(e, 'up');
+            } else if (e.key === KeyCode.HOME) {
+                e.preventDefault();
+                if (min !== undefined) {
+                    setValue?.(min);
+                    setInputValue(min.toString());
+                }
+            } else if (e.key === KeyCode.END) {
+                e.preventDefault();
+                if (max !== undefined) {
+                    const newValue = clampToNearestStepValue({
+                        value: max,
+                        step: baseStep,
+                        min,
+                        max,
+                    });
+                    setValue?.(newValue);
+                    setInputValue(newValue.toString());
+                }
             }
-            setInputValue(clampedValue.toString());
-        }
-        onBlur?.(e);
-    };
+            onKeyDown?.(e);
+        };
 
-    const handleUpdate = (v: string) => {
-        setInputValue(v);
-        const preparedStringValue = getPossibleNumberSubstring(v, allowDecimal);
-        updateCursorPosition(innerControlRef, v, preparedStringValue);
-        const {valid, value: parsedNumberValue} = getParsedValue(preparedStringValue);
-        if (valid && parsedNumberValue !== value) {
-            setValue?.(parsedNumberValue);
-        }
-    };
+        const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+            if (clamp && value !== null) {
+                const clampedValue = clampToNearestStepValue({
+                    value,
+                    step: baseStep,
+                    min,
+                    max,
+                });
 
-    const handleInput: React.FormEventHandler<HTMLInputElement> = (e) => {
-        const preparedStringValue = getPossibleNumberSubstring(e.currentTarget.value, allowDecimal);
-        updateCursorPosition(innerControlRef, e.currentTarget.value, preparedStringValue);
-    };
-
-    return (
-        <TextInput
-            {...props}
-            className={b({size, view, state}, className)}
-            controlProps={{
-                ...props.controlProps,
-                onInput: handleInput,
-                role: 'spinbutton',
-                inputMode: allowDecimal ? 'decimal' : 'numeric',
-                pattern: props.controlProps?.pattern ?? getInputPattern(!allowDecimal, false),
-                'aria-valuemin': props.min,
-                'aria-valuemax': props.max,
-                'aria-valuenow': value === null ? undefined : value,
-            }}
-            controlRef={handleRef}
-            value={inputValue}
-            onChange={handleChange}
-            onUpdate={handleUpdate}
-            onKeyDown={handleKeyDown}
-            onBlur={handleBlur}
-            ref={ref}
-            endContent={
-                <React.Fragment>
-                    {endContent}
-                    {hiddenControls ? null : (
-                        <NumericArrows
-                            className={b('arrows')}
-                            size={size}
-                            disabled={disabled}
-                            onUpClick={(e) => {
-                                innerControlRef.current?.focus();
-                                handleValueDelta(e, 'up');
-                            }}
-                            onDownClick={(e) => {
-                                innerControlRef.current?.focus();
-                                handleValueDelta(e, 'down');
-                            }}
-                        />
-                    )}
-                </React.Fragment>
+                if (value !== clampedValue) {
+                    setValue?.(clampedValue);
+                }
+                setInputValue(clampedValue.toString());
             }
-        />
-    );
-});
+            onBlur?.(e);
+        };
+
+        const handleUpdate = (v: string) => {
+            setInputValue(v);
+            const preparedStringValue = getPossibleNumberSubstring(v, allowDecimal);
+            updateCursorPosition(innerControlRef, v, preparedStringValue);
+            const {valid, value: parsedNumberValue} = getParsedValue(preparedStringValue);
+            if (valid && parsedNumberValue !== value) {
+                setValue?.(parsedNumberValue);
+            }
+        };
+
+        const handleInput: React.FormEventHandler<HTMLInputElement> = (e) => {
+            const preparedStringValue = getPossibleNumberSubstring(
+                e.currentTarget.value,
+                allowDecimal,
+            );
+            updateCursorPosition(innerControlRef, e.currentTarget.value, preparedStringValue);
+        };
+
+        return (
+            <TextInput
+                {...props}
+                className={b({size, view, state}, className)}
+                controlProps={{
+                    ...props.controlProps,
+                    onInput: handleInput,
+                    role: 'spinbutton',
+                    inputMode: allowDecimal ? 'decimal' : 'numeric',
+                    pattern: props.controlProps?.pattern ?? getInputPattern(!allowDecimal, false),
+                    'aria-valuemin': props.min,
+                    'aria-valuemax': props.max,
+                    'aria-valuenow': value === null ? undefined : value,
+                }}
+                controlRef={handleRef}
+                value={inputValue}
+                onChange={handleChange}
+                onUpdate={handleUpdate}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                ref={ref}
+                endContent={
+                    <React.Fragment>
+                        {endContent}
+                        {hiddenControls ? null : (
+                            <NumericArrows
+                                className={b('arrows')}
+                                size={size}
+                                disabled={disabled}
+                                onUpClick={(e) => {
+                                    innerControlRef.current?.focus();
+                                    handleValueDelta(e, 'up');
+                                }}
+                                onDownClick={(e) => {
+                                    innerControlRef.current?.focus();
+                                    handleValueDelta(e, 'down');
+                                }}
+                            />
+                        )}
+                    </React.Fragment>
+                }
+            />
+        );
+    },
+);

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import './Overlay.scss';
@@ -15,7 +16,13 @@ export interface OverlayProps {
     children?: React.ReactNode;
 }
 
-export function Overlay({className, background = 'base', visible = false, children}: OverlayProps) {
+export function Overlay(rawProps: OverlayProps) {
+    const {
+        className,
+        background = 'base',
+        visible = false,
+        children,
+    } = useDefaultProps('Overlay', rawProps);
     return (
         <div className={b({visible}, className)}>
             <div className={b('background', {style: background})} />

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {useMobile} from '../mobile';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {
@@ -19,20 +20,21 @@ import './Pagination.scss';
 
 const b = block('pagination');
 
-export const Pagination = ({
-    page,
-    pageSize,
-    total,
-    size: propSize,
-    onUpdate,
-    compact: propCompact = true,
-    pageSizeOptions,
-    showPages = true,
-    showInput = false,
-    view: propView = 'outlined',
-    className,
-    qa,
-}: PaginationProps) => {
+export const Pagination = (rawProps: PaginationProps) => {
+    const {
+        page,
+        pageSize,
+        total,
+        size: propSize,
+        onUpdate,
+        compact: propCompact = true,
+        pageSizeOptions,
+        showPages = true,
+        showInput = false,
+        view: propView = 'outlined',
+        className,
+        qa,
+    } = useDefaultProps('Pagination', rawProps);
     const mobile = useMobile();
 
     const size = getSize({propSize, mobile});

--- a/src/components/Palette/Palette.tsx
+++ b/src/components/Palette/Palette.tsx
@@ -6,6 +6,7 @@ import {useSelect} from '../../hooks';
 import {useForkRef} from '../../hooks/useForkRef/useForkRef';
 import type {ButtonProps} from '../Button';
 import {Button} from '../Button';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -83,127 +84,130 @@ export interface PaletteProps
 interface PaletteComponent
     extends React.ForwardRefExoticComponent<PaletteProps & React.RefAttributes<HTMLDivElement>> {}
 
-export const Palette = React.forwardRef<HTMLDivElement, PaletteProps>(function Palette(props, ref) {
-    const {
-        size = 'm',
-        multiple = true,
-        options = [],
-        columns = 6,
-        disabled,
-        style,
-        className,
-        rowClassName,
-        optionClassName,
-        qa,
-        onFocus,
-        onBlur,
-    } = props;
+export const Palette = React.forwardRef<HTMLDivElement, PaletteProps>(
+    function Palette(rawProps, ref) {
+        const props = useDefaultProps('Palette', rawProps);
+        const {
+            size = 'm',
+            multiple = true,
+            options = [],
+            columns = 6,
+            disabled,
+            style,
+            className,
+            rowClassName,
+            optionClassName,
+            qa,
+            onFocus,
+            onBlur,
+        } = props;
 
-    const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(
-        undefined,
-    );
-    const focusedOption =
-        focusedOptionIndex === undefined ? undefined : options[focusedOptionIndex];
+        const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(
+            undefined,
+        );
+        const focusedOption =
+            focusedOptionIndex === undefined ? undefined : options[focusedOptionIndex];
 
-    const innerRef = React.useRef<HTMLDivElement>(null);
-    const handleRef = useForkRef(ref, innerRef);
+        const innerRef = React.useRef<HTMLDivElement>(null);
+        const handleRef = useForkRef(ref, innerRef);
 
-    const {value, handleSelection} = useSelect({
-        value: props.value,
-        defaultValue: props.defaultValue,
-        multiple,
-        onUpdate: props.onUpdate,
-    });
+        const {value, handleSelection} = useSelect({
+            value: props.value,
+            defaultValue: props.defaultValue,
+            multiple,
+            onUpdate: props.onUpdate,
+        });
 
-    const rows = React.useMemo(() => getPaletteRows(options, columns), [columns, options]);
+        const rows = React.useMemo(() => getPaletteRows(options, columns), [columns, options]);
 
-    const focusOnOptionWithIndex = React.useCallback((index: number) => {
-        if (!innerRef.current) return;
+        const focusOnOptionWithIndex = React.useCallback((index: number) => {
+            if (!innerRef.current) return;
 
-        const $options = Array.from(
-            innerRef.current.querySelectorAll(`.${b('option')}`),
-        ) as HTMLButtonElement[];
+            const $options = Array.from(
+                innerRef.current.querySelectorAll(`.${b('option')}`),
+            ) as HTMLButtonElement[];
 
-        if (!$options[index]) return;
+            if (!$options[index]) return;
 
-        $options[index].focus();
+            $options[index].focus();
 
-        setFocusedOptionIndex(index);
-    }, []);
+            setFocusedOptionIndex(index);
+        }, []);
 
-    const tryToFocus = (newIndex: number) => {
-        if (newIndex === focusedOptionIndex || newIndex < 0 || newIndex >= options.length) {
-            return;
-        }
+        const tryToFocus = (newIndex: number) => {
+            if (newIndex === focusedOptionIndex || newIndex < 0 || newIndex >= options.length) {
+                return;
+            }
 
-        focusOnOptionWithIndex(newIndex);
-    };
+            focusOnOptionWithIndex(newIndex);
+        };
 
-    const gridProps = usePaletteGrid({
-        disabled,
-        onFocus: (event) => {
-            focusOnOptionWithIndex(0);
-            onFocus?.(event);
-        },
-        onBlur: (event) => {
-            setFocusedOptionIndex(undefined);
-            onBlur?.(event);
-        },
-        whenFocused:
-            focusedOptionIndex !== undefined && focusedOption
-                ? {
-                      selectItem: () => handleSelection(focusedOption),
-                      nextItem: () => tryToFocus(focusedOptionIndex + 1),
-                      previousItem: () => tryToFocus(focusedOptionIndex - 1),
-                      nextRow: () => tryToFocus(focusedOptionIndex + columns),
-                      previousRow: () => tryToFocus(focusedOptionIndex - columns),
-                  }
-                : undefined,
-    });
+        const gridProps = usePaletteGrid({
+            disabled,
+            onFocus: (event) => {
+                focusOnOptionWithIndex(0);
+                onFocus?.(event);
+            },
+            onBlur: (event) => {
+                setFocusedOptionIndex(undefined);
+                onBlur?.(event);
+            },
+            whenFocused:
+                focusedOptionIndex !== undefined && focusedOption
+                    ? {
+                          selectItem: () => handleSelection(focusedOption),
+                          nextItem: () => tryToFocus(focusedOptionIndex + 1),
+                          previousItem: () => tryToFocus(focusedOptionIndex - 1),
+                          nextRow: () => tryToFocus(focusedOptionIndex + columns),
+                          previousRow: () => tryToFocus(focusedOptionIndex - columns),
+                      }
+                    : undefined,
+        });
 
-    return (
-        <div
-            {...filterDOMProps(props, {labelable: true})}
-            {...gridProps}
-            ref={handleRef}
-            className={b({size}, className)}
-            style={style}
-            data-qa={qa}
-        >
-            {rows.map((row, rowNumber) => (
-                <div className={b('row', rowClassName)} key={`row-${rowNumber}`} role="row">
-                    {row.map((option) => {
-                        const isSelected = Boolean(value.includes(option.value));
-                        const focused = option === focusedOption;
+        return (
+            <div
+                {...filterDOMProps(props, {labelable: true})}
+                {...gridProps}
+                ref={handleRef}
+                className={b({size}, className)}
+                style={style}
+                data-qa={qa}
+            >
+                {rows.map((row, rowNumber) => (
+                    <div className={b('row', rowClassName)} key={`row-${rowNumber}`} role="row">
+                        {row.map((option) => {
+                            const isSelected = Boolean(value.includes(option.value));
+                            const focused = option === focusedOption;
 
-                        return (
-                            <div
-                                key={option.value}
-                                role="gridcell"
-                                aria-selected={focused ? 'true' : undefined}
-                                aria-readonly={option.disabled}
-                            >
-                                <Button
-                                    className={b('option', optionClassName)}
-                                    tabIndex={-1}
-                                    style={style}
-                                    disabled={disabled || option.disabled}
-                                    title={option.title}
-                                    view={isSelected ? 'normal' : 'flat'}
-                                    selected={isSelected}
-                                    value={option.value}
-                                    size={size}
-                                    onClick={() => handleSelection(option)}
+                            return (
+                                <div
+                                    key={option.value}
+                                    role="gridcell"
+                                    aria-selected={focused ? 'true' : undefined}
+                                    aria-readonly={option.disabled}
                                 >
-                                    <Button.Icon>{option.content ?? option.value}</Button.Icon>
-                                </Button>
-                            </div>
-                        );
-                    })}
-                </div>
-            ))}
-        </div>
-    );
-}) as PaletteComponent;
+                                    <Button
+                                        className={b('option', optionClassName)}
+                                        tabIndex={-1}
+                                        style={style}
+                                        disabled={disabled || option.disabled}
+                                        title={option.title}
+                                        view={isSelected ? 'normal' : 'flat'}
+                                        selected={isSelected}
+                                        value={option.value}
+                                        size={size}
+                                        onClick={() => handleSelection(option)}
+                                    >
+                                        <Button.Icon>{option.content ?? option.value}</Button.Icon>
+                                    </Button>
+                                </div>
+                            );
+                        })}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+) as PaletteComponent;
 
 Palette.displayName = 'Palette';

--- a/src/components/PinInput/PinInput.tsx
+++ b/src/components/PinInput/PinInput.tsx
@@ -9,6 +9,7 @@ import type {TextInputProps, TextInputSize} from '../controls';
 import {TextInput} from '../controls';
 import {OuterAdditionalContent} from '../controls/common/OuterAdditionalContent/OuterAdditionalContent';
 import {useDirection} from '../theme';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, FocusEventHandlers, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -59,7 +60,8 @@ const validate = (type: PinInputType, newValue: string) => {
     }
 };
 
-export const PinInput = React.forwardRef<HTMLDivElement, PinInputProps>((props, ref) => {
+export const PinInput = React.forwardRef<HTMLDivElement, PinInputProps>((rawProps, ref) => {
+    const props = useDefaultProps('PinInput', rawProps);
     const {
         value,
         defaultValue,

--- a/src/components/PlaceholderContainer/PlaceholderContainer.tsx
+++ b/src/components/PlaceholderContainer/PlaceholderContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {Button} from '../Button';
 import type {ButtonProps} from '../Button';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {componentClassName} from './constants';
@@ -21,19 +22,20 @@ const PlaceholderContainerAction = ({text, ...buttonProps}: PlaceholderContainer
     );
 };
 
-export const PlaceholderContainer = ({
-    direction = 'row',
-    align = 'center',
-    size = 'l',
-    className,
-    title,
-    description,
-    image,
-    content,
-    actions,
-    maxWidth,
-    qa,
-}: PlaceholderContainerProps) => {
+export const PlaceholderContainer = (rawProps: PlaceholderContainerProps) => {
+    const {
+        direction = 'row',
+        align = 'center',
+        size = 'l',
+        className,
+        title,
+        description,
+        image,
+        content,
+        actions,
+        maxWidth,
+        qa,
+    } = useDefaultProps('PlaceholderContainer', rawProps);
     const renderTitle = () => {
         if (!title) {
             return null;

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -15,6 +15,7 @@ import {
 import {useControlledState, useForkRef} from '../../hooks';
 import {Popup} from '../Popup';
 import type {PopupProps} from '../Popup';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {getElementRef} from '../utils/getElementRef';
@@ -58,21 +59,22 @@ const DEFAULT_OPEN_DELAY = 500;
 const DEFAULT_CLOSE_DELAY = 250;
 const DEFAULT_REST = 0;
 
-export function Popover({
-    children,
-    open,
-    onOpenChange,
-    toggle = true,
-    disabled,
-    content,
-    trigger = 'all',
-    openDelay = DEFAULT_OPEN_DELAY,
-    closeDelay = DEFAULT_CLOSE_DELAY,
-    rest = DEFAULT_REST,
-    enableSafePolygon,
-    className,
-    ...restProps
-}: PopoverProps) {
+export function Popover(rawProps: PopoverProps) {
+    const {
+        children,
+        open,
+        onOpenChange,
+        toggle = true,
+        disabled,
+        content,
+        trigger = 'all',
+        openDelay = DEFAULT_OPEN_DELAY,
+        closeDelay = DEFAULT_CLOSE_DELAY,
+        rest = DEFAULT_REST,
+        enableSafePolygon,
+        className,
+        ...restProps
+    } = useDefaultProps('Popover', rawProps);
     const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
     const [floatingElement, setFloatingElement] = React.useState<HTMLDivElement | null>(null);
 

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -34,6 +34,7 @@ import {useForkRef} from '../../hooks';
 import {useFloatingTransition} from '../../hooks/private/useFloatingTransition';
 import {Portal} from '../Portal';
 import type {PortalProps} from '../Portal';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -152,49 +153,50 @@ export interface PopupProps
 
 const b = block('popup');
 
-function PopupComponent({
-    keepMounted = false,
-    hasArrow = false,
-    open = false,
-    onOpenChange,
-    strategy,
-    placement: placementProp,
-    offset: offsetProp = 4,
-    anchorElement,
-    anchorRef,
-    floatingMiddlewares,
-    floatingContext,
-    floatingInteractions,
-    floatingRef,
-    floatingStyles: floatingStylesProp,
-    floatingClassName,
-    modal = false,
-    initialFocus: initialFocusProp,
-    returnFocus = true,
-    focusOrder,
-    disableVisuallyHiddenDismiss = !modal,
-    onClose,
-    onEscapeKeyDown,
-    onOutsideClick,
-    disableEscapeKeyDown = false,
-    disableOutsideClick = false,
-    disableFocusOut = false,
-    style,
-    className,
-    children,
-    container,
-    disablePortal = false,
-    disableLayer = false,
-    disableTransition = false,
-    qa,
-    role: roleProp,
-    zIndex = 1000,
-    onTransitionIn,
-    onTransitionOut,
-    onTransitionInComplete,
-    onTransitionOutComplete,
-    ...restProps
-}: PopupProps) {
+function PopupComponent(rawProps: PopupProps) {
+    const {
+        keepMounted = false,
+        hasArrow = false,
+        open = false,
+        onOpenChange,
+        strategy,
+        placement: placementProp,
+        offset: offsetProp = 4,
+        anchorElement,
+        anchorRef,
+        floatingMiddlewares,
+        floatingContext,
+        floatingInteractions,
+        floatingRef,
+        floatingStyles: floatingStylesProp,
+        floatingClassName,
+        modal = false,
+        initialFocus: initialFocusProp,
+        returnFocus = true,
+        focusOrder,
+        disableVisuallyHiddenDismiss = !modal,
+        onClose,
+        onEscapeKeyDown,
+        onOutsideClick,
+        disableEscapeKeyDown = false,
+        disableOutsideClick = false,
+        disableFocusOut = false,
+        style,
+        className,
+        children,
+        container,
+        disablePortal = false,
+        disableLayer = false,
+        disableTransition = false,
+        qa,
+        role: roleProp,
+        zIndex = 1000,
+        onTransitionIn,
+        onTransitionOut,
+        onTransitionInComplete,
+        onTransitionOutComplete,
+        ...restProps
+    } = useDefaultProps('Popup', rawProps);
     useLayer({open, type: 'popup', enabled: !disableLayer});
 
     const contentRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -6,6 +6,7 @@ import {FloatingPortal} from '@floating-ui/react';
 
 import {usePortalContainer} from '../../hooks';
 import {ThemeProvider} from '../theme';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {useThemeContext} from '../theme/useThemeContext';
 import {block} from '../utils/cn';
 
@@ -19,7 +20,8 @@ export interface PortalProps {
     disablePortal?: boolean;
 }
 
-export function Portal({container, children, disablePortal}: PortalProps) {
+export function Portal(rawProps: PortalProps) {
+    const {container, children, disablePortal} = useDefaultProps('Portal', rawProps);
     const defaultContainer = usePortalContainer();
     const {scoped} = useThemeContext();
 

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
+
 import {ProgressWithStack} from './ProgressWithStack';
 import {ProgressWithValue} from './ProgressWithValue';
 import {progressBlock} from './constants';
@@ -9,7 +11,8 @@ import {isProgressWithStack} from './types';
 import './Progress.scss';
 
 export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-    function Progress(props, ref) {
+    function Progress(rawProps, ref) {
+        const props = useDefaultProps('Progress', rawProps);
         const {text = '', theme = 'default', size = 'm', loading = false, className, qa} = props;
         const resolvedProps: ProgressProps = {...props, text, theme, size, loading};
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {useRadio} from '../../hooks/private';
 import {ControlLabel} from '../ControlLabel';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {ControlProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -21,7 +22,8 @@ export interface RadioProps extends ControlProps, DOMProps, QAProps {
     title?: string;
 }
 
-export const Radio = React.forwardRef<HTMLLabelElement, RadioProps>(function Radio(props, ref) {
+export const Radio = React.forwardRef<HTMLLabelElement, RadioProps>(function Radio(rawProps, ref) {
+    const props = useDefaultProps('Radio', rawProps);
     const {size = 'm', disabled = false, content, children, title, style, className, qa} = props;
     const {checked, inputProps} = useRadio(props);
     const text = content || children;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {useRadioGroup} from '../../hooks/private';
 import {Radio} from '../Radio';
 import type {RadioProps, RadioSize} from '../Radio';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {ControlGroupOption, ControlGroupProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -31,7 +32,8 @@ interface RadioGroupComponent
 }
 
 export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
-    function RadioGroup(props, ref) {
+    function RadioGroup(rawProps, ref) {
+        const props = useDefaultProps('RadioGroup', rawProps);
         const {
             size = 'm',
             direction = 'horizontal',
@@ -46,11 +48,11 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
         if (!options) {
             options = (
                 React.Children.toArray(children) as React.ReactElement<RadioProps, typeof Radio>[]
-            ).map(({props}) => ({
-                value: props.value,
-                content: props.content || props.children,
-                disabled: props.disabled,
-                qa: props.qa,
+            ).map(({props: radioProps}) => ({
+                value: radioProps.value,
+                content: radioProps.content || radioProps.children,
+                disabled: radioProps.disabled,
+                qa: radioProps.qa,
             }));
         }
 

--- a/src/components/SegmentedRadioGroup/SegmentedRadioGroup.tsx
+++ b/src/components/SegmentedRadioGroup/SegmentedRadioGroup.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import {RadioGroupContext, useRadioGroup} from '../../hooks/private';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {ControlGroupOption, ControlGroupProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -34,9 +35,10 @@ type SegmentedRadioGroupComponentType = (<T extends string>(
 };
 
 export const SegmentedRadioGroup = React.forwardRef(function SegmentedRadioGroup<T extends string>(
-    props: SegmentedRadioGroupProps<T>,
+    rawProps: SegmentedRadioGroupProps<T>,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
+    const props = useDefaultProps('SegmentedRadioGroup', rawProps);
     const {size = 'm', width, style, className, qa, children} = props;
     const options = props.options;
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -8,6 +8,7 @@ import type {List} from '../List';
 import {OuterAdditionalContent} from '../controls/common/OuterAdditionalContent/OuterAdditionalContent';
 import {errorPropsMapper} from '../controls/utils';
 import {useMobile} from '../mobile';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {CnMods} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
@@ -51,9 +52,10 @@ export const DEFAULT_RENDER_POPUP: SelectRenderPopup = ({renderFilter, renderLis
 };
 
 export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(function Select<T = any>(
-    props: SelectProps<T>,
+    rawProps: SelectProps<T>,
     ref: React.Ref<HTMLButtonElement>,
 ) {
+    const props = useDefaultProps('Select', rawProps);
     const {
         onUpdate,
         onOpenChange,

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -6,6 +6,7 @@ import {FloatingOverlay} from '@floating-ui/react';
 
 import {Portal} from '../Portal/Portal';
 import type {PortalProps} from '../Portal/Portal';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 
 import {SheetContentContainer} from './SheetContent';
@@ -38,23 +39,24 @@ export interface SheetProps extends Pick<PortalProps, 'container' | 'disablePort
     alwaysFullHeight?: boolean;
 }
 
-export const Sheet = ({
-    children,
-    onClose,
-    visible,
-    id,
-    title,
-    className,
-    contentClassName,
-    swipeAreaClassName,
-    allowHideOnContentScroll,
-    hideTopBar,
-    maxContentHeightCoefficient,
-    alwaysFullHeight,
-    container,
-    disablePortal,
-    qa,
-}: SheetProps) => {
+export const Sheet = (rawProps: SheetProps) => {
+    const {
+        children,
+        onClose,
+        visible,
+        id,
+        title,
+        className,
+        contentClassName,
+        swipeAreaClassName,
+        allowHideOnContentScroll,
+        hideTopBar,
+        maxContentHeightCoefficient,
+        alwaysFullHeight,
+        container,
+        disablePortal,
+        qa,
+    } = useDefaultProps('Sheet', rawProps);
     const [open, setOpen] = React.useState(visible);
     const [prevVisible, setPrevVisible] = React.useState(visible);
 

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -24,16 +25,17 @@ export interface SkeletonProps
     height?: number | string;
 }
 
-export function Skeleton({
-    className,
-    style,
-    width,
-    height,
-    qa,
-    animation = 'gradient',
-    variant = 'rect',
-    size,
-}: SkeletonProps) {
+export function Skeleton(rawProps: SkeletonProps) {
+    const {
+        className,
+        style,
+        width,
+        height,
+        qa,
+        animation = 'gradient',
+        variant = 'rect',
+        size,
+    } = useDefaultProps('Skeleton', rawProps);
     return (
         <div
             className={b({animation, variant, size}, className)}

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {useControlledState} from '../../hooks';
 import {useFormResetHandler} from '../../hooks/private';
 import {useDirection} from '../theme';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
@@ -18,7 +19,10 @@ import './Slider.scss';
 const b = block('slider');
 
 export const Slider = React.forwardRef(function Slider(
-    {
+    rawProps: SliderProps,
+    ref: React.ForwardedRef<HTMLDivElement>,
+) {
+    const {
         value,
         defaultValue,
         size = 'm',
@@ -49,9 +53,7 @@ export const Slider = React.forwardRef(function Slider(
         name,
         form,
         ...restProps
-    }: SliderProps,
-    ref: React.ForwardedRef<HTMLDivElement>,
-) {
+    } = useDefaultProps('Slider', rawProps);
     const direction = useDirection();
 
     const innerState = prepareSliderInnerState({

--- a/src/components/Spin/Spin.tsx
+++ b/src/components/Spin/Spin.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -13,7 +14,8 @@ export interface SpinProps extends DOMProps, QAProps {
     size?: SpinSize;
 }
 
-export const Spin = React.forwardRef<HTMLDivElement, SpinProps>(function Spin(props, ref) {
+export const Spin = React.forwardRef<HTMLDivElement, SpinProps>(function Spin(rawProps, ref) {
+    const props = useDefaultProps('Spin', rawProps);
     const {size = 'm', style, className, qa} = props;
 
     return (

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
@@ -21,7 +22,8 @@ export interface StepperProps extends DOMProps, AriaLabelingProps, QAProps {
     separator?: React.ReactNode;
 }
 
-export const Stepper = (props: StepperProps) => {
+export const Stepper = (rawProps: StepperProps) => {
+    const props = useDefaultProps('Stepper', rawProps);
     const {children, value, size = 's', className, onUpdate, separator} = props;
 
     const stepItems = React.useMemo(() => {

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {useCheckbox} from '../../hooks/private';
 import {ControlLabel} from '../ControlLabel';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {ControlProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -21,53 +22,56 @@ export interface SwitchProps extends ControlProps, DOMProps, QAProps {
     title?: string;
 }
 
-export const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(function Switch(props, ref) {
-    const {
-        size = 'm',
-        disabled = false,
-        loading = false,
-        content,
-        children,
-        title,
-        style,
-        className,
-        qa,
-    } = props;
-    const {checked, inputProps} = useCheckbox({
-        ...props,
-        controlProps: {...props.controlProps, role: 'switch'},
-    });
-    const text = content || children;
+export const Switch = React.forwardRef<HTMLLabelElement, SwitchProps>(
+    function Switch(rawProps, ref) {
+        const props = useDefaultProps('Switch', rawProps);
+        const {
+            size = 'm',
+            disabled = false,
+            loading = false,
+            content,
+            children,
+            title,
+            style,
+            className,
+            qa,
+        } = props;
+        const {checked, inputProps} = useCheckbox({
+            ...props,
+            controlProps: {...props.controlProps, role: 'switch'},
+        });
+        const text = content || children;
 
-    const control = (
-        <span className={b('indicator')}>
-            <input {...inputProps} className={b('control')} />
-            <span className={b('outline')} />
-            <span className={b('slider')} />
-        </span>
-    );
+        const control = (
+            <span className={b('indicator')}>
+                <input {...inputProps} className={b('control')} />
+                <span className={b('outline')} />
+                <span className={b('slider')} />
+            </span>
+        );
 
-    return (
-        <ControlLabel
-            ref={ref}
-            title={title}
-            style={style}
-            size={size}
-            disabled={disabled}
-            className={b(
-                {
-                    size,
-                    disabled,
-                    checked,
-                    loading,
-                },
-                className,
-            )}
-            labelClassName={b('text')}
-            qa={qa}
-            control={control}
-        >
-            {text}
-        </ControlLabel>
-    );
-});
+        return (
+            <ControlLabel
+                ref={ref}
+                title={title}
+                style={style}
+                size={size}
+                disabled={disabled}
+                className={b(
+                    {
+                        size,
+                        disabled,
+                        checked,
+                        loading,
+                    },
+                    className,
+                )}
+                labelClassName={b('text')}
+                qa={qa}
+                control={control}
+            >
+                {text}
+            </ControlLabel>
+        );
+    },
+);

--- a/src/components/TableColumnSetup/TableColumnSetup.tsx
+++ b/src/components/TableColumnSetup/TableColumnSetup.tsx
@@ -11,6 +11,7 @@ import type {TableColumnConfig} from '../Table/Table';
 import type {TableColumnSetupItem as NewTableColumnSetupItem} from '../Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup';
 import {TableColumnSetup as NewTableColumnSetup} from '../Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup';
 import type {TableSetting} from '../Table/hoc/withTableSettings/withTableSettings';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import i18n from './i18n';
@@ -55,7 +56,8 @@ export interface TableColumnSetupProps {
     className?: string;
 }
 
-export const TableColumnSetup = (props: TableColumnSetupProps) => {
+export const TableColumnSetup = (rawProps: TableColumnSetupProps) => {
+    const props = useDefaultProps('TableColumnSetup', rawProps);
     const {
         switcher,
         renderSwitcher: renderSwitcherProps,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {DOMProps, QAProps} from '../types';
 
 import {colorText} from './colorText/colorText';
@@ -51,7 +52,10 @@ type TextPropsWithTypedAttrs<T extends React.ElementType> = TextProps<T> &
  * ```
  */
 export const Text = React.forwardRef(function Text<C extends React.ElementType = 'span'>(
-    {
+    rawProps: TextPropsWithTypedAttrs<C>,
+    ref: React.ForwardedRef<C>,
+) {
+    const {
         as,
         children,
         variant,
@@ -64,9 +68,7 @@ export const Text = React.forwardRef(function Text<C extends React.ElementType =
         style: outerStyle,
         qa,
         ...rest
-    }: TextPropsWithTypedAttrs<C>,
-    ref: React.ForwardedRef<C>,
-) {
+    } = useDefaultProps('Text', rawProps);
     const Tag: React.ElementType = as || 'span';
 
     const style: React.CSSProperties = {

--- a/src/components/Toc/Toc.tsx
+++ b/src/components/Toc/Toc.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {QAProps} from '../types';
 import {block} from '../utils/cn';
 
@@ -16,7 +17,8 @@ export interface TocProps extends QAProps {
     onItemClick?: (event: React.MouseEvent) => void;
 }
 
-export const Toc = React.forwardRef<HTMLElement, TocProps>(function Toc(props, ref) {
+export const Toc = React.forwardRef<HTMLElement, TocProps>(function Toc(rawProps, ref) {
+    const props = useDefaultProps('Toc', rawProps);
     const {value: activeValue, items, className, onUpdate, qa, onItemClick} = props;
 
     return (

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,6 +22,7 @@ import {OVERFLOW_PADDING} from '../Popup/constants';
 import {getPlacementOptions} from '../Popup/utils';
 import {Portal} from '../Portal';
 import type {PortalProps} from '../Portal';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import type {AriaLabelingProps, DOMProps, QAProps} from '../types';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
@@ -71,27 +72,28 @@ const DEFAULT_REST = 0;
 const DEFAULT_PLACEMENT: PopupPlacement = 'bottom';
 const DEFAULT_OFFSET = 4;
 
-export function Tooltip({
-    children,
-    open,
-    onOpenChange,
-    strategy,
-    placement: placementProp = DEFAULT_PLACEMENT,
-    offset: offsetProp = DEFAULT_OFFSET,
-    disabled,
-    content,
-    trigger = 'all',
-    role: roleProp = 'tooltip',
-    openDelay = DEFAULT_OPEN_DELAY,
-    closeDelay = DEFAULT_CLOSE_DELAY,
-    rest = DEFAULT_REST,
-    container,
-    disablePortal,
-    className,
-    style,
-    qa,
-    ...restProps
-}: TooltipProps) {
+export function Tooltip(rawProps: TooltipProps) {
+    const {
+        children,
+        open,
+        onOpenChange,
+        strategy,
+        placement: placementProp = DEFAULT_PLACEMENT,
+        offset: offsetProp = DEFAULT_OFFSET,
+        disabled,
+        content,
+        trigger = 'all',
+        role: roleProp = 'tooltip',
+        openDelay = DEFAULT_OPEN_DELAY,
+        closeDelay = DEFAULT_CLOSE_DELAY,
+        rest = DEFAULT_REST,
+        container,
+        disablePortal,
+        className,
+        style,
+        qa,
+        ...restProps
+    } = useDefaultProps('Tooltip', rawProps);
     const [anchorElement, setAnchorElement] = React.useState<HTMLElement | null>(null);
     const {placement, middleware: placementMiddleware} = getPlacementOptions(placementProp, false);
 

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {Avatar} from '../Avatar';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 import {filterDOMProps} from '../utils/filterDOMProps';
 
@@ -11,7 +12,8 @@ import './User.scss';
 
 const b = block('user');
 
-export const User = React.forwardRef<HTMLDivElement, UserProps>((props, ref) => {
+export const User = React.forwardRef<HTMLDivElement, UserProps>((rawProps, ref) => {
+    const props = useDefaultProps('User', rawProps);
     const {avatar, name, description, size = DEFAULT_USER_SIZE, className, style, qa} = props;
 
     const nameTitle = typeof name === 'string' ? name : undefined;

--- a/src/components/UserLabel/UserLabel.tsx
+++ b/src/components/UserLabel/UserLabel.tsx
@@ -5,6 +5,7 @@ import {Envelope, Xmark} from '@gravity-ui/icons';
 import {Avatar} from '../Avatar';
 import type {AvatarProps} from '../Avatar';
 import {Icon} from '../Icon';
+import {useDefaultProps} from '../theme/useDefaultProps';
 import {block} from '../utils/cn';
 
 import {BORDER_COLOR, COMPACT_SIZES, DEFAULT_USER_LABEL_SIZE, ICON_SIZES} from './constants';
@@ -15,110 +16,106 @@ import './UserLabel.scss';
 
 const b = block('user-label');
 
-export const UserLabel = React.forwardRef<HTMLDivElement, UserLabelProps>(
-    (
-        {
-            type = 'person',
-            view = 'outlined',
-            size = DEFAULT_USER_LABEL_SIZE,
-            avatar,
-            text,
-            description,
-            onClick,
-            onCloseClick,
-            className,
-            style,
-            qa,
-        },
-        ref,
-    ) => {
-        const clickable = Boolean(onClick);
-        const closeable = Boolean(onCloseClick);
+export const UserLabel = React.forwardRef<HTMLDivElement, UserLabelProps>((rawProps, ref) => {
+    const {
+        type = 'person',
+        view = 'outlined',
+        size = DEFAULT_USER_LABEL_SIZE,
+        avatar,
+        text,
+        description,
+        onClick,
+        onCloseClick,
+        className,
+        style,
+        qa,
+    } = useDefaultProps('UserLabel', rawProps);
+    const clickable = Boolean(onClick);
+    const closeable = Boolean(onCloseClick);
 
-        const MainComponent = clickable ? 'button' : 'div';
+    const MainComponent = clickable ? 'button' : 'div';
 
-        let avatarView: React.ReactNode = null;
-        let avatarProps: AvatarProps | undefined;
+    let avatarView: React.ReactNode = null;
+    let avatarProps: AvatarProps | undefined;
 
-        if (typeof avatar === 'string') {
-            avatarProps = {imgUrl: avatar};
-        } else if (avatar && !React.isValidElement(avatar)) {
-            if (
-                ('imgUrl' in avatar && avatar.imgUrl) ||
-                ('icon' in avatar && avatar.icon) ||
-                ('text' in avatar && avatar.text)
-            ) {
-                avatarProps = avatar as AvatarProps;
-            } else if (typeof text === 'string') {
-                avatarProps = {text, borderColor: BORDER_COLOR, ...avatar};
+    if (typeof avatar === 'string') {
+        avatarProps = {imgUrl: avatar};
+    } else if (avatar && !React.isValidElement(avatar)) {
+        if (
+            ('imgUrl' in avatar && avatar.imgUrl) ||
+            ('icon' in avatar && avatar.icon) ||
+            ('text' in avatar && avatar.text)
+        ) {
+            avatarProps = avatar as AvatarProps;
+        } else if (typeof text === 'string') {
+            avatarProps = {text, borderColor: BORDER_COLOR, ...avatar};
+        }
+    } else if (!avatar && typeof text === 'string') {
+        avatarProps = {text, borderColor: BORDER_COLOR};
+    }
+
+    switch (type) {
+        case 'email':
+            avatarView = <Avatar icon={Envelope} {...avatarProps} size={size} />;
+            break;
+        case 'empty':
+            avatarView = null;
+            break;
+        case 'person':
+        default:
+            if (React.isValidElement(avatar)) {
+                avatarView = avatar;
+            } else if (avatarProps) {
+                avatarView = <Avatar {...avatarProps} size={size} />;
             }
-        } else if (!avatar && typeof text === 'string') {
-            avatarProps = {text, borderColor: BORDER_COLOR};
-        }
+            break;
+    }
 
-        switch (type) {
-            case 'email':
-                avatarView = <Avatar icon={Envelope} {...avatarProps} size={size} />;
-                break;
-            case 'empty':
-                avatarView = null;
-                break;
-            case 'person':
-            default:
-                if (React.isValidElement(avatar)) {
-                    avatarView = avatar;
-                } else if (avatarProps) {
-                    avatarView = <Avatar {...avatarProps} size={size} />;
-                }
-                break;
-        }
+    const showDescription = Boolean(description && !COMPACT_SIZES.has(size));
 
-        const showDescription = Boolean(description && !COMPACT_SIZES.has(size));
+    const {t} = i18n.useTranslation();
 
-        const {t} = i18n.useTranslation();
-
-        return (
-            <div
-                className={b(
-                    {
-                        view,
-                        size,
-                        empty: !avatarView,
-                        clickable,
-                        closeable,
-                    },
-                    className,
-                )}
-                style={style}
-                data-qa={qa}
-                ref={ref}
+    return (
+        <div
+            className={b(
+                {
+                    view,
+                    size,
+                    empty: !avatarView,
+                    clickable,
+                    closeable,
+                },
+                className,
+            )}
+            style={style}
+            data-qa={qa}
+            ref={ref}
+        >
+            <MainComponent
+                className={b('main')}
+                type={clickable ? 'button' : undefined}
+                onClick={onClick}
             >
-                <MainComponent
-                    className={b('main')}
-                    type={clickable ? 'button' : undefined}
-                    onClick={onClick}
+                {avatarView ? <div className={b('avatar')}>{avatarView}</div> : null}
+                <div className={b('info')}>
+                    <span className={b('text')}>{text}</span>
+                    {showDescription ? (
+                        <span className={b('description')}>{description}</span>
+                    ) : null}
+                </div>
+            </MainComponent>
+            {onCloseClick ? (
+                <button
+                    className={b('close')}
+                    type="button"
+                    aria-label={t('label_remove-button')}
+                    onClick={onCloseClick}
                 >
-                    {avatarView ? <div className={b('avatar')}>{avatarView}</div> : null}
-                    <div className={b('info')}>
-                        <span className={b('text')}>{text}</span>
-                        {showDescription ? (
-                            <span className={b('description')}>{description}</span>
-                        ) : null}
-                    </div>
-                </MainComponent>
-                {onCloseClick ? (
-                    <button
-                        className={b('close')}
-                        type="button"
-                        aria-label={t('label_remove-button')}
-                        onClick={onCloseClick}
-                    >
-                        <Icon className={b('close-icon')} data={Xmark} size={ICON_SIZES[size]} />
-                    </button>
-                ) : null}
-            </div>
-        );
-    },
-);
+                    <Icon className={b('close-icon')} data={Xmark} size={ICON_SIZES[size]} />
+                </button>
+            ) : null}
+        </div>
+    );
+});
 
 UserLabel.displayName = 'UserLabel';

--- a/src/components/controls/TextArea/TextArea.tsx
+++ b/src/components/controls/TextArea/TextArea.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {useControlledState, useForkRef, useUniqId} from '../../../hooks';
 import {useFormResetHandler} from '../../../hooks/private';
+import {useDefaultProps} from '../../theme/useDefaultProps';
 import {block} from '../../utils/cn';
 import {ClearButton, mapTextInputSizeToButtonSize} from '../common';
 import {OuterAdditionalContent} from '../common/OuterAdditionalContent/OuterAdditionalContent';
@@ -38,7 +39,8 @@ export type TextAreaSize = InputControlSize;
 export type TextAreaView = InputControlView;
 
 export const TextArea = React.forwardRef<HTMLSpanElement, TextAreaProps>(
-    function TextArea(props, ref) {
+    function TextArea(rawProps, ref) {
+        const props = useDefaultProps('TextArea', rawProps);
         const {
             view = 'normal',
             size = 'm',

--- a/src/components/controls/TextInput/TextInput.tsx
+++ b/src/components/controls/TextInput/TextInput.tsx
@@ -10,6 +10,7 @@ import {Alert} from '../../Alert';
 import {Icon} from '../../Icon';
 import {Popover} from '../../Popover';
 import {useDirection} from '../../theme';
+import {useDefaultProps} from '../../theme/useDefaultProps';
 import {block} from '../../utils/cn';
 import {ClearButton, mapTextInputSizeToButtonSize} from '../common';
 import {OuterAdditionalContent} from '../common/OuterAdditionalContent/OuterAdditionalContent';
@@ -52,7 +53,8 @@ export type TextInputSize = InputControlSize;
 export type TextInputView = InputControlView;
 
 export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
-    function TextInput(props, ref) {
+    function TextInput(rawProps, ref) {
+        const props = useDefaultProps('TextInput', rawProps);
         const {
             view = 'normal',
             size = 'm',

--- a/src/components/tabs/Tab.tsx
+++ b/src/components/tabs/Tab.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import {MenuItem} from '../lab/Menu';
+import {useDefaultProps} from '../theme/useDefaultProps';
 
 import {TabContent} from './TabContent';
 import {useTab} from './hooks/useTab';
@@ -14,12 +15,13 @@ import './Tab.scss';
 export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabProps>(function Tab<
     T extends TabComponentElementType,
 >(
-    props: TabProps<T>,
+    rawProps: TabProps<T>,
     ref:
         | React.Ref<HTMLButtonElement>
         | React.Ref<HTMLAnchorElement>
         | React.Ref<T extends string ? React.ComponentRef<T> : T>,
 ) {
+    const props = useDefaultProps('Tab', rawProps);
     const tabProps = useTab(props);
 
     const content = (

--- a/src/components/tabs/TabList.tsx
+++ b/src/components/tabs/TabList.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import {useFocusWithin, useForkRef, useUniqId} from '../../hooks';
+import {useDefaultProps} from '../theme/useDefaultProps';
 
 import {TabListCollapseItem} from './TabListCollapseItem/TabListCollapseItem';
 import {TabContext} from './contexts/TabContext';
@@ -12,7 +13,8 @@ import type {TabListProps} from './types';
 
 import './TabList.scss';
 
-export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, ref) => {
+export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((rawProps, ref) => {
+    const props = useDefaultProps('TabList', rawProps);
     const tabContext = React.useContext(TabContext);
     const id = useUniqId();
 

--- a/src/components/tabs/TabPanel.tsx
+++ b/src/components/tabs/TabPanel.tsx
@@ -2,13 +2,16 @@
 
 import * as React from 'react';
 
+import {useDefaultProps} from '../theme/useDefaultProps';
+
 import {TabContext} from './contexts/TabContext';
 import {useTabPanel} from './hooks/useTabPanel';
 import type {TabPanelProps} from './types';
 
 import './TabPanel.scss';
 
-export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>((props, ref) => {
+export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>((rawProps, ref) => {
+    const props = useDefaultProps('TabPanel', rawProps);
     const panelProps = useTabPanel(props);
     return (
         <TabContext.Provider value={undefined}>

--- a/src/components/tabs/TabProvider.tsx
+++ b/src/components/tabs/TabProvider.tsx
@@ -3,11 +3,13 @@
 import * as React from 'react';
 
 import {useUniqId} from '../../hooks';
+import {useDefaultProps} from '../theme/useDefaultProps';
 
 import {TabContext} from './contexts/TabContext';
 import type {TabProviderProps} from './types';
 
-export const TabProvider = ({value, onUpdate, children}: TabProviderProps) => {
+export const TabProvider = (rawProps: TabProviderProps) => {
+    const {value, onUpdate, children} = useDefaultProps('TabProvider', rawProps);
     const id = useUniqId();
     const contextValue = React.useMemo(
         () => ({value, onUpdate, id, isProvider: true}),

--- a/src/components/theme/PrivateDefaultPropsProvider.tsx
+++ b/src/components/theme/PrivateDefaultPropsProvider.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import * as React from 'react';
+
+import type {AccordionProps} from '../Accordion';
+import type {ActionTooltipProps} from '../ActionTooltip';
+import type {ActionsPanelProps} from '../ActionsPanel';
+import type {AlertProps} from '../Alert';
+import type {ArrowToggleProps} from '../ArrowToggle';
+import type {AvatarProps} from '../Avatar';
+import type {AvatarStackProps} from '../AvatarStack';
+import type {BreadcrumbsProps} from '../Breadcrumbs';
+import type {ButtonCommonProps} from '../Button/Button';
+import type {CardProps} from '../Card';
+import type {CheckboxProps} from '../Checkbox';
+import type {ClipboardButtonProps} from '../ClipboardButton';
+import type {ClipboardIconProps} from '../ClipboardIcon';
+import type {CopyToClipboardProps} from '../CopyToClipboard';
+import type {DefinitionListProps} from '../DefinitionList';
+import type {DialogProps} from '../Dialog';
+import type {DisclosureProps} from '../Disclosure';
+import type {DividerProps} from '../Divider';
+import type {DrawerProps} from '../Drawer';
+import type {DropdownMenuProps} from '../DropdownMenu';
+import type {FilePreviewProps} from '../FilePreview';
+import type {HelpMarkProps} from '../HelpMark';
+import type {HotkeyProps} from '../Hotkey';
+import type {IconProps} from '../Icon';
+import type {LabelProps} from '../Label';
+import type {LinkProps} from '../Link';
+import type {LoaderProps} from '../Loader';
+import type {MenuProps} from '../Menu';
+import type {ModalProps} from '../Modal';
+import type {NumberInputProps} from '../NumberInput';
+import type {OverlayProps} from '../Overlay';
+import type {PaginationProps} from '../Pagination';
+import type {PaletteProps} from '../Palette';
+import type {PinInputProps} from '../PinInput';
+import type {PlaceholderContainerProps} from '../PlaceholderContainer';
+import type {PopoverProps} from '../Popover';
+import type {PopupProps} from '../Popup';
+import type {PortalProps} from '../Portal';
+import type {ProgressProps} from '../Progress';
+import type {RadioProps} from '../Radio';
+import type {RadioGroupProps} from '../RadioGroup';
+import type {SegmentedRadioGroupProps} from '../SegmentedRadioGroup';
+import type {SelectProps} from '../Select';
+import type {SheetProps} from '../Sheet';
+import type {SkeletonProps} from '../Skeleton';
+import type {SliderProps} from '../Slider';
+import type {SpinProps} from '../Spin';
+import type {StepperProps} from '../Stepper';
+import type {SwitchProps} from '../Switch';
+import type {TableColumnSetupProps} from '../TableColumnSetup';
+import type {TextProps} from '../Text';
+import type {TocProps} from '../Toc';
+import type {TooltipProps} from '../Tooltip';
+import type {UserProps} from '../User';
+import type {UserLabelProps} from '../UserLabel';
+import type {TextAreaProps} from '../controls/TextArea';
+import type {TextInputProps} from '../controls/TextInput';
+import type {TabListProps, TabPanelProps, TabProps, TabProviderProps} from '../tabs';
+
+export interface ComponentDefaultPropsMap {
+    Accordion?: Partial<AccordionProps<any>>;
+    ActionsPanel?: Partial<ActionsPanelProps>;
+    ActionTooltip?: Partial<ActionTooltipProps>;
+    Alert?: Partial<AlertProps>;
+    ArrowToggle?: Partial<ArrowToggleProps>;
+    Avatar?: Partial<AvatarProps>;
+    AvatarStack?: Partial<AvatarStackProps>;
+    Breadcrumbs?: Partial<BreadcrumbsProps>;
+    Button?: Partial<ButtonCommonProps>;
+    Card?: Partial<CardProps>;
+    Checkbox?: Partial<CheckboxProps>;
+    ClipboardButton?: Partial<ClipboardButtonProps>;
+    ClipboardIcon?: Partial<ClipboardIconProps>;
+    CopyToClipboard?: Partial<CopyToClipboardProps>;
+    DefinitionList?: Partial<DefinitionListProps>;
+    Dialog?: Partial<DialogProps>;
+    Disclosure?: Partial<DisclosureProps>;
+    Divider?: Partial<DividerProps>;
+    Drawer?: Partial<DrawerProps>;
+    DropdownMenu?: Partial<DropdownMenuProps<any>>;
+    FilePreview?: Partial<FilePreviewProps>;
+    HelpMark?: Partial<HelpMarkProps>;
+    Hotkey?: Partial<HotkeyProps>;
+    Icon?: Partial<IconProps>;
+    Label?: Partial<LabelProps>;
+    Link?: Partial<LinkProps>;
+    Loader?: Partial<LoaderProps>;
+    Menu?: Partial<MenuProps>;
+    Modal?: Partial<ModalProps>;
+    NumberInput?: Partial<NumberInputProps>;
+    Overlay?: Partial<OverlayProps>;
+    Pagination?: Partial<PaginationProps>;
+    Palette?: Partial<PaletteProps>;
+    PinInput?: Partial<PinInputProps>;
+    PlaceholderContainer?: Partial<PlaceholderContainerProps>;
+    Popover?: Partial<PopoverProps>;
+    Popup?: Partial<PopupProps>;
+    Portal?: Partial<PortalProps>;
+    Progress?: Partial<ProgressProps>;
+    Radio?: Partial<RadioProps>;
+    RadioGroup?: Partial<RadioGroupProps>;
+    SegmentedRadioGroup?: Partial<SegmentedRadioGroupProps<any>>;
+    Select?: Partial<SelectProps<any>>;
+    Sheet?: Partial<SheetProps>;
+    Skeleton?: Partial<SkeletonProps>;
+    Slider?: Partial<SliderProps<any>>;
+    Spin?: Partial<SpinProps>;
+    Stepper?: Partial<StepperProps>;
+    Switch?: Partial<SwitchProps>;
+    TableColumnSetup?: Partial<TableColumnSetupProps>;
+    Tab?: Partial<TabProps>;
+    TabList?: Partial<TabListProps>;
+    TabPanel?: Partial<TabPanelProps>;
+    TabProvider?: Partial<TabProviderProps>;
+    Text?: Partial<TextProps<any>>;
+    TextArea?: Partial<TextAreaProps>;
+    TextInput?: Partial<TextInputProps>;
+    Toc?: Partial<TocProps>;
+    Tooltip?: Partial<TooltipProps>;
+    User?: Partial<UserProps>;
+    UserLabel?: Partial<UserLabelProps>;
+}
+
+const EMPTY: ComponentDefaultPropsMap = {};
+
+export const PrivateDefaultPropsContext = React.createContext<ComponentDefaultPropsMap>(EMPTY);
+
+export function PrivateDefaultPropsProvider({
+    value = EMPTY,
+    children,
+}: {
+    value?: ComponentDefaultPropsMap;
+    children: React.ReactNode;
+}) {
+    return (
+        <PrivateDefaultPropsContext.Provider value={value}>
+            {children}
+        </PrivateDefaultPropsContext.Provider>
+    );
+}

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -8,7 +8,10 @@ import type {PrivateLayoutProviderProps} from '../layout/LayoutProvider/LayoutPr
 import {block} from '../utils/cn';
 
 import type {ComponentDefaultPropsMap} from './PrivateDefaultPropsProvider';
-import {PrivateDefaultPropsProvider} from './PrivateDefaultPropsProvider';
+import {
+    PrivateDefaultPropsContext,
+    PrivateDefaultPropsProvider,
+} from './PrivateDefaultPropsProvider';
 import {ThemeContext} from './ThemeContext';
 import {ThemeSettingsContext} from './ThemeSettingsContext';
 import type {ThemeSettings} from './ThemeSettingsContext';
@@ -54,6 +57,7 @@ export function ThemeProvider({
     const parentThemeState = React.useContext(ThemeContext);
     const systemThemeState = React.useContext(ThemeSettingsContext);
     const langOptionsState = React.useContext(LangContext);
+    const parentDefaultProps = React.useContext(PrivateDefaultPropsContext);
 
     const hasParentProvider = parentThemeState !== undefined;
     const scoped = hasParentProvider || scopedProp;
@@ -99,6 +103,20 @@ export function ThemeProvider({
         [systemLightTheme, systemDarkTheme],
     );
 
+    const mergedDefaultProps = React.useMemo(() => {
+        if (!defaultProps) {
+            return parentDefaultProps;
+        }
+
+        return [parentDefaultProps, defaultProps].reduce((acc: ComponentDefaultPropsMap, props) => {
+            for (const [key, value] of Object.entries(props)) {
+                acc[key as keyof ComponentDefaultPropsMap] = value;
+            }
+
+            return acc;
+        }, {});
+    }, [parentDefaultProps, defaultProps]);
+
     const langOptionsFinal =
         lang || fallbackLang
             ? {
@@ -110,7 +128,7 @@ export function ThemeProvider({
             : langOptionsState;
     return (
         <PrivateLayoutProvider {...layout}>
-            <PrivateDefaultPropsProvider value={defaultProps}>
+            <PrivateDefaultPropsProvider value={mergedDefaultProps}>
                 <ThemeContext.Provider value={contextValue}>
                     <ThemeSettingsContext.Provider value={themeSettingsContext}>
                         <LangContext.Provider value={langOptionsFinal}>

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -7,6 +7,8 @@ import {PrivateLayoutProvider} from '../layout/LayoutProvider/LayoutProvider';
 import type {PrivateLayoutProviderProps} from '../layout/LayoutProvider/LayoutProvider';
 import {block} from '../utils/cn';
 
+import type {ComponentDefaultPropsMap} from './PrivateDefaultPropsProvider';
+import {PrivateDefaultPropsProvider} from './PrivateDefaultPropsProvider';
 import {ThemeContext} from './ThemeContext';
 import {ThemeSettingsContext} from './ThemeSettingsContext';
 import type {ThemeSettings} from './ThemeSettingsContext';
@@ -33,6 +35,7 @@ export interface ThemeProviderProps extends React.PropsWithChildren<{}>, Partial
     scoped?: boolean;
     rootClassName?: string;
     layout?: Omit<PrivateLayoutProviderProps, 'children'>;
+    defaultProps?: ComponentDefaultPropsMap;
 }
 
 export function ThemeProvider({
@@ -46,6 +49,7 @@ export function ThemeProvider({
     layout,
     lang,
     fallbackLang,
+    defaultProps,
 }: ThemeProviderProps) {
     const parentThemeState = React.useContext(ThemeContext);
     const systemThemeState = React.useContext(ThemeSettingsContext);
@@ -106,19 +110,24 @@ export function ThemeProvider({
             : langOptionsState;
     return (
         <PrivateLayoutProvider {...layout}>
-            <ThemeContext.Provider value={contextValue}>
-                <ThemeSettingsContext.Provider value={themeSettingsContext}>
-                    <LangContext.Provider value={langOptionsFinal}>
-                        {scoped ? (
-                            <div className={b({theme: themeValue}, rootClassName)} dir={direction}>
-                                {children}
-                            </div>
-                        ) : (
-                            children
-                        )}
-                    </LangContext.Provider>
-                </ThemeSettingsContext.Provider>
-            </ThemeContext.Provider>
+            <PrivateDefaultPropsProvider value={defaultProps}>
+                <ThemeContext.Provider value={contextValue}>
+                    <ThemeSettingsContext.Provider value={themeSettingsContext}>
+                        <LangContext.Provider value={langOptionsFinal}>
+                            {scoped ? (
+                                <div
+                                    className={b({theme: themeValue}, rootClassName)}
+                                    dir={direction}
+                                >
+                                    {children}
+                                </div>
+                            ) : (
+                                children
+                            )}
+                        </LangContext.Provider>
+                    </ThemeSettingsContext.Provider>
+                </ThemeContext.Provider>
+            </PrivateDefaultPropsProvider>
         </PrivateLayoutProvider>
     );
 }

--- a/src/components/theme/__tests__/useDefaultProps.test.tsx
+++ b/src/components/theme/__tests__/useDefaultProps.test.tsx
@@ -54,6 +54,14 @@ describe('useDefaultProps', () => {
             expect(result.current).toEqual({view: 'normal', size: 'm'});
         });
 
+        it('use prop set to undefined does not override defaults', () => {
+            const {result} = renderHook(
+                () => useDefaultProps('Button', {view: undefined, size: 'm'}),
+                {wrapper: makeWrapper({Button: {view: 'outlined', size: 'l'}})},
+            );
+            expect(result.current).toEqual({view: 'outlined', size: 'm'});
+        });
+
         it('only overridden props win — unset props use context defaults', () => {
             const {result} = renderHook(() => useDefaultProps('Button', {size: 'm'}), {
                 wrapper: makeWrapper({Button: {view: 'outlined', size: 'l'}}),
@@ -69,51 +77,6 @@ describe('useDefaultProps', () => {
             expect(result.current).toBe(props);
         });
     });
-
-    describe('event handler merging', () => {
-        it('chains context default handler with user handler', () => {
-            const defaultHandler = jest.fn();
-            const userHandler = jest.fn();
-
-            const {result} = renderHook(() => useDefaultProps('Button', {onClick: userHandler}), {
-                // @ts-expect-error
-                wrapper: makeWrapper({Button: {onClick: defaultHandler}}),
-            });
-
-            (result.current as {onClick: () => void}).onClick();
-
-            expect(defaultHandler).toHaveBeenCalledTimes(1);
-            expect(userHandler).toHaveBeenCalledTimes(1);
-        });
-
-        it('calls only the user handler when no default handler is set', () => {
-            const userHandler = jest.fn();
-
-            const {result} = renderHook(() => useDefaultProps('Button', {onClick: userHandler}), {
-                wrapper: makeWrapper({Button: {size: 'l'}}),
-            });
-
-            (result.current as {onClick: () => void}).onClick();
-
-            expect(userHandler).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    describe('className merging', () => {
-        it('concatenates className from context defaults and user props', () => {
-            const {result} = renderHook(() => useDefaultProps('Button', {className: 'user'}), {
-                wrapper: makeWrapper({Button: {className: 'default'}}),
-            });
-            expect((result.current as {className: string}).className).toBe('default user');
-        });
-
-        it('uses only context className when user does not pass className', () => {
-            const {result} = renderHook(() => useDefaultProps('Button', {}), {
-                wrapper: makeWrapper({Button: {className: 'default'}}),
-            });
-            expect((result.current as {className: string}).className).toBe('default');
-        });
-    });
 });
 
 // ---------------------------------------------------------------------------
@@ -123,7 +86,7 @@ describe('useDefaultProps', () => {
 describe('ThemeProvider defaultProps', () => {
     function Consumer({name, props}: {name: Parameters<typeof useDefaultProps>[0]; props: object}) {
         const merged = useDefaultProps(name, props);
-        return <output>{JSON.stringify(merged)}</output>;
+        return <output title={name}>{JSON.stringify(merged)}</output>;
     }
 
     it('passes defaultProps through to useDefaultProps', () => {
@@ -158,17 +121,23 @@ describe('ThemeProvider defaultProps', () => {
         });
     });
 
-    it('inner ThemeProvider defaultProps override outer', () => {
+    it('inner ThemeProvider defaultProps correctly override outer', () => {
         render(
-            <ThemeProvider defaultProps={{Button: {view: 'outlined', size: 'l'}}}>
+            <ThemeProvider
+                defaultProps={{Button: {view: 'outlined', size: 'l'}, Checkbox: {size: 'l'}}}
+            >
                 <ThemeProvider defaultProps={{Button: {view: 'action'}}}>
                     <Consumer name="Button" props={{}} />
+                    <Consumer name="Checkbox" props={{}} />
                 </ThemeProvider>
             </ThemeProvider>,
         );
-        // Inner ThemeProvider provides a fresh context — its value completely replaces the outer
-        expect(JSON.parse(screen.getByRole('status').textContent ?? '{}')).toEqual({
+        // Inner ThemeProvider provides replaces props per component not the whole context
+        expect(JSON.parse(screen.getByTitle('Button').textContent ?? '{}')).toEqual({
             view: 'action',
+        });
+        expect(JSON.parse(screen.getByTitle('Checkbox').textContent ?? '{}')).toEqual({
+            size: 'l',
         });
     });
 });

--- a/src/components/theme/__tests__/useDefaultProps.test.tsx
+++ b/src/components/theme/__tests__/useDefaultProps.test.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+
+import {render, renderHook, screen} from '../../../../test-utils/utils';
+import {PrivateDefaultPropsProvider} from '../PrivateDefaultPropsProvider';
+import {ThemeProvider} from '../ThemeProvider';
+import {useDefaultProps} from '../useDefaultProps';
+
+function makeWrapper(value: React.ComponentProps<typeof PrivateDefaultPropsProvider>['value']) {
+    return function Wrapper({children}: {children: React.ReactNode}) {
+        return <PrivateDefaultPropsProvider value={value}>{children}</PrivateDefaultPropsProvider>;
+    };
+}
+
+describe('useDefaultProps', () => {
+    describe('without a provider', () => {
+        it('returns props unchanged when no provider is present', () => {
+            const props = {view: 'normal' as const, size: 'm' as const};
+            const {result} = renderHook(() => useDefaultProps('Button', props));
+            expect(result.current).toBe(props);
+        });
+    });
+
+    describe('with a provider but no defaults for the component', () => {
+        it('returns props unchanged when provider has no entry for the component', () => {
+            const props = {view: 'normal' as const};
+            const {result} = renderHook(() => useDefaultProps('Button', props), {
+                wrapper: makeWrapper({TextInput: {size: 'l'}}),
+            });
+            expect(result.current).toBe(props);
+        });
+
+        it('returns props unchanged when provider value is empty', () => {
+            const props = {size: 'm' as const};
+            const {result} = renderHook(() => useDefaultProps('TextInput', props), {
+                wrapper: makeWrapper({}),
+            });
+            expect(result.current).toBe(props);
+        });
+    });
+
+    describe('prop merging priority', () => {
+        it('applies context defaults when component receives no props', () => {
+            const {result} = renderHook(() => useDefaultProps('Button', {}), {
+                wrapper: makeWrapper({Button: {view: 'outlined', size: 'l'}}),
+            });
+            expect(result.current).toEqual({view: 'outlined', size: 'l'});
+        });
+
+        it('user props override context defaults', () => {
+            const {result} = renderHook(
+                () => useDefaultProps('Button', {view: 'normal', size: 'm'}),
+                {wrapper: makeWrapper({Button: {view: 'outlined', size: 'l'}})},
+            );
+            expect(result.current).toEqual({view: 'normal', size: 'm'});
+        });
+
+        it('only overridden props win — unset props use context defaults', () => {
+            const {result} = renderHook(() => useDefaultProps('Button', {size: 'm'}), {
+                wrapper: makeWrapper({Button: {view: 'outlined', size: 'l'}}),
+            });
+            expect(result.current).toEqual({view: 'outlined', size: 'm'});
+        });
+
+        it('does not leak defaults from one component to another', () => {
+            const props = {size: 'm' as const};
+            const {result} = renderHook(() => useDefaultProps('TextInput', props), {
+                wrapper: makeWrapper({Button: {view: 'outlined'}}),
+            });
+            expect(result.current).toBe(props);
+        });
+    });
+
+    describe('event handler merging', () => {
+        it('chains context default handler with user handler', () => {
+            const defaultHandler = jest.fn();
+            const userHandler = jest.fn();
+
+            const {result} = renderHook(() => useDefaultProps('Button', {onClick: userHandler}), {
+                // @ts-expect-error
+                wrapper: makeWrapper({Button: {onClick: defaultHandler}}),
+            });
+
+            (result.current as {onClick: () => void}).onClick();
+
+            expect(defaultHandler).toHaveBeenCalledTimes(1);
+            expect(userHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('calls only the user handler when no default handler is set', () => {
+            const userHandler = jest.fn();
+
+            const {result} = renderHook(() => useDefaultProps('Button', {onClick: userHandler}), {
+                wrapper: makeWrapper({Button: {size: 'l'}}),
+            });
+
+            (result.current as {onClick: () => void}).onClick();
+
+            expect(userHandler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('className merging', () => {
+        it('concatenates className from context defaults and user props', () => {
+            const {result} = renderHook(() => useDefaultProps('Button', {className: 'user'}), {
+                wrapper: makeWrapper({Button: {className: 'default'}}),
+            });
+            expect((result.current as {className: string}).className).toBe('default user');
+        });
+
+        it('uses only context className when user does not pass className', () => {
+            const {result} = renderHook(() => useDefaultProps('Button', {}), {
+                wrapper: makeWrapper({Button: {className: 'default'}}),
+            });
+            expect((result.current as {className: string}).className).toBe('default');
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ThemeProvider integration
+// ---------------------------------------------------------------------------
+
+describe('ThemeProvider defaultProps', () => {
+    function Consumer({name, props}: {name: Parameters<typeof useDefaultProps>[0]; props: object}) {
+        const merged = useDefaultProps(name, props);
+        return <output>{JSON.stringify(merged)}</output>;
+    }
+
+    it('passes defaultProps through to useDefaultProps', () => {
+        render(
+            <ThemeProvider defaultProps={{Button: {view: 'outlined', size: 'l'}}}>
+                <Consumer name="Button" props={{size: 'm'}} />
+            </ThemeProvider>,
+        );
+        expect(JSON.parse(screen.getByRole('status').textContent ?? '{}')).toEqual({
+            view: 'outlined',
+            size: 'm',
+        });
+    });
+
+    it('does not affect components with no entry in defaultProps', () => {
+        render(
+            <ThemeProvider defaultProps={{Button: {view: 'outlined'}}}>
+                <Consumer name="TextInput" props={{size: 's'}} />
+            </ThemeProvider>,
+        );
+        expect(JSON.parse(screen.getByRole('status').textContent ?? '{}')).toEqual({size: 's'});
+    });
+
+    it('works correctly when defaultProps is omitted', () => {
+        render(
+            <ThemeProvider>
+                <Consumer name="Button" props={{view: 'normal'}} />
+            </ThemeProvider>,
+        );
+        expect(JSON.parse(screen.getByRole('status').textContent ?? '{}')).toEqual({
+            view: 'normal',
+        });
+    });
+
+    it('inner ThemeProvider defaultProps override outer', () => {
+        render(
+            <ThemeProvider defaultProps={{Button: {view: 'outlined', size: 'l'}}}>
+                <ThemeProvider defaultProps={{Button: {view: 'action'}}}>
+                    <Consumer name="Button" props={{}} />
+                </ThemeProvider>
+            </ThemeProvider>,
+        );
+        // Inner ThemeProvider provides a fresh context — its value completely replaces the outer
+        expect(JSON.parse(screen.getByRole('status').textContent ?? '{}')).toEqual({
+            view: 'action',
+        });
+    });
+});

--- a/src/components/theme/index.ts
+++ b/src/components/theme/index.ts
@@ -12,3 +12,4 @@ export * from './withDirection';
 export * from './getThemeType';
 export {useLang} from './useLang';
 export type {Theme, RealTheme, ThemeType, Direction, ThemeContextProps} from './types';
+export type {ComponentDefaultPropsMap} from './PrivateDefaultPropsProvider';

--- a/src/components/theme/useDefaultProps.ts
+++ b/src/components/theme/useDefaultProps.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import {mergeProps} from '../utils/mergeProps';
+
+import type {ComponentDefaultPropsMap} from './PrivateDefaultPropsProvider';
+import {PrivateDefaultPropsContext} from './PrivateDefaultPropsProvider';
+
+export function useDefaultProps<K extends keyof ComponentDefaultPropsMap, T extends object>(
+    componentName: K,
+    props: T,
+): T {
+    const ctx = React.useContext(PrivateDefaultPropsContext);
+    const defaults = ctx[componentName];
+
+    if (!defaults) {
+        return props;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return mergeProps(defaults as any, props as any) as unknown as T;
+}

--- a/src/components/theme/useDefaultProps.ts
+++ b/src/components/theme/useDefaultProps.ts
@@ -1,21 +1,30 @@
 import * as React from 'react';
 
-import {mergeProps} from '../utils/mergeProps';
-
 import type {ComponentDefaultPropsMap} from './PrivateDefaultPropsProvider';
 import {PrivateDefaultPropsContext} from './PrivateDefaultPropsProvider';
 
 export function useDefaultProps<K extends keyof ComponentDefaultPropsMap, T extends object>(
     componentName: K,
-    props: T,
+    componentProps: T,
 ): T {
     const ctx = React.useContext(PrivateDefaultPropsContext);
-    const defaults = ctx[componentName];
+    const defaultProps = ctx[componentName];
 
-    if (!defaults) {
-        return props;
+    if (!defaultProps) {
+        return componentProps;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return mergeProps(defaults as any, props as any) as unknown as T;
+    const cleanedProps: Record<string, unknown> = {};
+    for (const k in componentProps) {
+        if (componentProps[k as keyof T] !== undefined) {
+            cleanedProps[k] = componentProps[k as keyof T];
+        }
+    }
+
+    return [defaultProps, cleanedProps].reduce((acc: Record<string, unknown>, props) => {
+        for (const [key, value] of Object.entries(props)) {
+            acc[key] = value;
+        }
+        return acc;
+    }, {}) as unknown as T;
 }

--- a/src/components/utils/__tests__/mergeProps.test.ts
+++ b/src/components/utils/__tests__/mergeProps.test.ts
@@ -1,0 +1,137 @@
+import {mergeProps} from '../mergeProps';
+
+describe('mergeProps', () => {
+    describe('basic merging', () => {
+        it('should return empty object for no arguments', () => {
+            expect(mergeProps()).toEqual({});
+        });
+
+        it('should return props unchanged when single object passed', () => {
+            expect(mergeProps({id: 'foo', disabled: true})).toEqual({id: 'foo', disabled: true});
+        });
+
+        it('should merge two objects, last value wins for plain props', () => {
+            expect(mergeProps({id: 'first', role: 'button'}, {id: 'second'})).toEqual({
+                id: 'second',
+                role: 'button',
+            });
+        });
+
+        it('should merge three objects', () => {
+            // @ts-expect-error
+            expect(mergeProps({a: 1}, {b: 2}, {c: 3})).toEqual({a: 1, b: 2, c: 3});
+        });
+
+        it('should overwrite with undefined when explicitly passed', () => {
+            expect(mergeProps({id: 'foo'}, {id: undefined})).toEqual({id: undefined});
+        });
+    });
+
+    describe('event handlers', () => {
+        it('should call both handlers when merged', () => {
+            const first = jest.fn();
+            const second = jest.fn();
+            const {onClick} = mergeProps({onClick: first}, {onClick: second}) as {
+                onClick: (...args: unknown[]) => unknown;
+            };
+            onClick('arg');
+            expect(first).toHaveBeenCalledWith('arg');
+            expect(second).toHaveBeenCalledWith('arg');
+        });
+
+        it('should return first defined return value', () => {
+            const {onClick} = mergeProps({onClick: () => 'first'}, {onClick: () => 'second'}) as {
+                onClick: () => unknown;
+            };
+            expect(onClick()).toBe('first');
+        });
+
+        it('should return undefined when all handlers return undefined', () => {
+            const {onClick} = mergeProps(
+                {onClick: () => undefined},
+                {onClick: () => undefined},
+            ) as {onClick: () => unknown};
+            expect(onClick()).toBeUndefined();
+        });
+
+        it('should chain three event handlers', () => {
+            const calls: number[] = [];
+            const {onChange} = mergeProps(
+                {onChange: () => calls.push(1)},
+                {onChange: () => calls.push(2)},
+                {onChange: () => calls.push(3)},
+            ) as {onChange: () => void};
+            onChange();
+            expect(calls).toEqual([1, 2, 3]);
+        });
+
+        it('should silently drop non-function on* values (matched by event pattern)', () => {
+            // on* keys matching the event pattern are only processed when the value is a function;
+            // non-function values are not forwarded to the result
+            // @ts-expect-error
+            expect(mergeProps({onSomething: 'string'}, {onSomething: 'override'})).toEqual({});
+        });
+
+        it('should not treat on* with lowercase third char as event handlers', () => {
+            // "online" — third char 'l' is not uppercase
+            const first = jest.fn();
+            const second = jest.fn();
+            // @ts-expect-error
+            const result = mergeProps({online: first}, {online: second}) as {online: unknown};
+            expect(result.online).toBe(second);
+            expect(first).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('className merging', () => {
+        it('should concatenate className', () => {
+            expect(mergeProps({className: 'foo'}, {className: 'bar'})).toEqual({
+                className: 'foo bar',
+            });
+        });
+
+        it('should concatenate className across three objects', () => {
+            expect(mergeProps({className: 'a'}, {className: 'b'}, {className: 'c'})).toEqual({
+                className: 'a b c',
+            });
+        });
+
+        it('should set className when only one object has it', () => {
+            expect(mergeProps({id: 'x'}, {className: 'bar'})).toEqual({
+                id: 'x',
+                className: 'bar',
+            });
+        });
+
+        it('should overwrite className when first object has no className', () => {
+            expect(mergeProps({id: 'x'}, {className: 'bar'}, {className: 'baz'})).toEqual({
+                id: 'x',
+                className: 'bar baz',
+            });
+        });
+
+        it('should concatenate *ClassName props', () => {
+            // @ts-expect-error
+            expect(mergeProps({modalClassName: 'base'}, {modalClassName: 'extra'})).toEqual({
+                modalClassName: 'base extra',
+            });
+        });
+
+        it('should concatenate multiple *ClassName props independently', () => {
+            expect(
+                mergeProps(
+                    // @ts-expect-error
+                    {className: 'a', contentClassName: 'c1'},
+                    {className: 'b', contentClassName: 'c2'},
+                ),
+            ).toEqual({className: 'a b', contentClassName: 'c1 c2'});
+        });
+
+        it('should overwrite className when value is not a string', () => {
+            // undefined className from second object → plain overwrite
+            expect(mergeProps({className: 'foo'}, {className: undefined})).toEqual({
+                className: undefined,
+            });
+        });
+    });
+});

--- a/src/components/utils/mergeProps.ts
+++ b/src/components/utils/mergeProps.ts
@@ -24,6 +24,12 @@ export function mergeProps(...propsList: (React.HTMLProps<HTMLElement> & {})[]) 
                             .find((v) => v !== undefined);
                     };
                 }
+            } else if (
+                (key === 'className' || key.endsWith('ClassName')) &&
+                typeof acc[key] === 'string' &&
+                typeof value === 'string'
+            ) {
+                acc[key] = `${acc[key]} ${value}`;
             } else {
                 acc[key] = value;
             }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a themable default props system and integrate it across core UI components.

New Features:
- Add a default props context and hook that allow configuring component default props via ThemeProvider.

Enhancements:
- Wire multiple components (inputs, layout, feedback, navigation, overlay, etc.) to consume default props from the new context.
- Extend props merging utilities to support concatenating className-style fields when combining defaults with user props.
- Expose the default props map type from the theme module for external configuration.

Tests:
- Add unit tests for the useDefaultProps hook and its interaction with ThemeProvider.
- Add unit tests for the mergeProps utility to validate the new merging behavior for className and handlers.