### PR TITLE
feat(Tabs): implement drag and drop in TabList

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -130,21 +130,61 @@ SANDBOX-->
 
 <!--/GITHUB_BLOCK-->
 
+### Sortable tabs
+
+To enable sorting of tabs with drag and drop.
+
+The `onSortEnd` handler is responsible for preserving the new order: update the state that you use to render `Tab` children according to the received ordered values. If the handler does not update that state, the visual order will return to the previous render order.
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+const initialTabs = [
+  {value: 'first', title: 'First Tab'},
+  {value: 'second', title: 'Second Tab'},
+  {value: 'third', title: 'Third Tab'},
+];
+
+const [tabs, setTabs] = React.useState(initialTabs);
+
+const handleSortEnd = useCallback(
+  (values) => {
+    setTabs(values.map((value) => initialTabs.find((tab) => tab.value === value)!));
+  },
+  [initialTabs, setTabs],
+);
+
+return (
+  <TabList value="first" sortable onSortEnd={handleSortEnd}>
+    {tabs.map((tab) => (
+      <Tab key={tab.value} value={tab.value}>
+        {tab.title}
+      </Tab>
+    ))}
+  </TabList>
+);
+```
+
+<!--/GITHUB_BLOCK-->
+
 ### Properties
 
 `TabList` accepts any valid `div` element props in addition to these:
 
-| Name            | Description                                                                            |               Type               | Default  |
-| :-------------- | :------------------------------------------------------------------------------------- | :------------------------------: | :------: |
-| children        | List of tabs, probably with some wrappers                                              |        `React.ReactNode`         |          |
-| value           | Active tab value                                                                       |             `string`             |          |
-| onUpdate        | Update tab handler                                                                     |    `(value: string) => void`     |          |
-| className       | CSS-class of element                                                                   |             `string`             |          |
-| activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately   |            `boolean`             | `false`  |
-| size            | Element size                                                                           |        `"m"` `"l"` `"xl"`        |  `"m"`   |
-| contentOverflow | How to deal with items that do not fit horizontally (wrap, scroll, or a **More** menu) | `"wrap"` `"scroll"` `"collapse"` | `"wrap"` |
-| moreLabel       | Label for the collapse overflow trigger when the active tab is visible in the list     |        `React.ReactNode`         | `"More"` |
-| qa              | HTML `data-qa` attribute, used in tests                                                |             `string`             |          |
+| Name            | Description                                                                            |                Type                 | Default  |
+| :-------------- | :------------------------------------------------------------------------------------- | :---------------------------------: | :------: |
+| children        | List of tabs, probably with some wrappers                                              |          `React.ReactNode`          |          |
+| value           | Active tab value                                                                       |              `string`               |          |
+| onUpdate        | Update tab handler                                                                     |      `(value: string) => void`      |          |
+| className       | CSS-class of element                                                                   |              `string`               |          |
+| activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately   |              `boolean`              | `false`  |
+| size            | Element size                                                                           |         `"m"` `"l"` `"xl"`          |  `"m"`   |
+| contentOverflow | How to deal with items that do not fit horizontally (wrap, scroll, or a **More** menu) |  `"wrap"` `"scroll"` `"collapse"`   | `"wrap"` |
+| moreLabel       | Label for the collapse overflow trigger when the active tab is visible in the list     |          `React.ReactNode`          | `"More"` |
+| sortable        | Optional flag to enable tabs sorting via drag and drop                                 |              `boolean`              | `false`  |
+| onSortStart     | Sorting start handler                                                                  |            `() => void`             |          |
+| onSortEnd       | Sorting end handler. Receives ordered tab values; update the rendered tab order here   | `(orderedValues: string[]) => void` |          |
+| qa              | HTML `data-qa` attribute, used in tests                                                |              `string`               |          |
 
 ## Tab
 

--- a/src/components/tabs/Tab.tsx
+++ b/src/components/tabs/Tab.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import {mergeRefs} from '../../hooks/useForkRef';
 import {MenuItem} from '../lab/Menu';
 
 import {TabContent} from './TabContent';
@@ -11,16 +12,17 @@ import {isTabComponentProps, isTabLinkProps} from './utils';
 
 import './Tab.scss';
 
+type TabRef<T extends TabComponentElementType> =
+    | React.Ref<HTMLButtonElement>
+    | React.Ref<HTMLAnchorElement>
+    | React.Ref<T extends string ? React.ComponentRef<T> : T>;
+
 export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabProps>(function Tab<
     T extends TabComponentElementType,
->(
-    props: TabProps<T>,
-    ref:
-        | React.Ref<HTMLButtonElement>
-        | React.Ref<HTMLAnchorElement>
-        | React.Ref<T extends string ? React.ComponentRef<T> : T>,
-) {
+>(props: TabProps<T>, ref: TabRef<T>) {
+    const {provided} = props;
     const tabProps = useTab(props);
+    const mergedRef = provided ? mergeRefs(ref as React.Ref<HTMLElement>, provided.innerRef) : ref;
 
     const content = (
         <TabContent
@@ -36,7 +38,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabPr
     if (isTabComponentProps(props)) {
         return React.createElement(props.component, {
             ...tabProps,
-            ref,
+            ref: mergedRef,
             isMenuItem: props.isMenuItem || false,
         });
     }
@@ -48,7 +50,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabPr
             return (
                 <MenuItem
                     {...tabProps}
-                    ref={ref as React.Ref<HTMLAnchorElement>}
+                    ref={mergedRef as React.Ref<HTMLAnchorElement>}
                     href={props.href}
                     rel={rel}
                 >
@@ -58,7 +60,12 @@ export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabPr
         }
 
         return (
-            <a {...tabProps} ref={ref as React.Ref<HTMLAnchorElement>} href={props.href} rel={rel}>
+            <a
+                {...tabProps}
+                ref={mergedRef as React.Ref<HTMLAnchorElement>}
+                href={props.href}
+                rel={rel}
+            >
                 {content}
             </a>
         );
@@ -68,7 +75,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabPr
         return (
             <MenuItem
                 {...tabProps}
-                ref={ref as React.Ref<HTMLButtonElement>}
+                ref={mergedRef as React.Ref<HTMLButtonElement>}
                 type={props.type || 'button'}
                 disabled={props.disabled}
             >
@@ -80,7 +87,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, TabPr
     return (
         <button
             {...tabProps}
-            ref={ref as React.Ref<HTMLButtonElement>}
+            ref={mergedRef as React.Ref<HTMLButtonElement>}
             type={props.type || 'button'}
         >
             {content}

--- a/src/components/tabs/TabList.scss
+++ b/src/components/tabs/TabList.scss
@@ -59,6 +59,10 @@ $tabListCollapseItemBlock: '.#{variables.$ns}tab-list-collapse-item';
         overflow-x: auto;
     }
 
+    button[data-rfd-placeholder-context-id] {
+        opacity: 0;
+    }
+
     #{$tabBlock}:not(:last-child) {
         margin-inline-end: var(--g-tabs-item-gap, var(--_--item-gap));
     }

--- a/src/components/tabs/TabList.tsx
+++ b/src/components/tabs/TabList.tsx
@@ -2,13 +2,24 @@
 
 import * as React from 'react';
 
+import type {DraggableProvided} from '@hello-pangea/dnd';
+import {
+    DragDropContext,
+    Draggable,
+    Droppable,
+    useMouseSensor,
+    useTouchSensor,
+} from '@hello-pangea/dnd';
+
 import {useFocusWithin, useForkRef, useUniqId} from '../../hooks';
 
 import {TabListCollapseItem} from './TabListCollapseItem/TabListCollapseItem';
+import {bTabList} from './constants';
 import {TabContext} from './contexts/TabContext';
 import {useTabList} from './hooks/useTabList';
 import {useTabListCollapsedChildren} from './hooks/useTabListCollapsedChildren';
-import type {TabListProps} from './types';
+import {useTabListDnd} from './hooks/useTabListDnd';
+import type {TabListProps, TabProps} from './types';
 
 import './TabList.scss';
 
@@ -24,6 +35,7 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, re
     const tabListProps = useTabList(props);
 
     const collapseEnabled = props.contentOverflow === 'collapse';
+    const dndEnabled = Boolean(props.sortable);
 
     const collapsedChildrenResults = useTabListCollapsedChildren(
         props.children,
@@ -31,6 +43,13 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, re
         listRef,
         collapseEnabled,
     );
+
+    const {handleDragEnd, handleDragStart} = useTabListDnd({
+        shownChildren: collapsedChildrenResults.shownChildren,
+        collapsedChildren: collapsedChildrenResults.collapsedChildren,
+        onSortStart: props.onSortStart,
+        onSortEnd: props.onSortEnd,
+    });
 
     const [isFocused, setIsFocused] = React.useState(false);
 
@@ -49,20 +68,81 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, re
         [tabContext, value, props.onUpdate, id, isFocused],
     );
 
+    const collapseItem = collapseEnabled ? (
+        <TabListCollapseItem
+            ref={collapsedChildrenResults.collapseItemRef}
+            triggerChild={collapsedChildrenResults.triggerChild}
+            moreLabel={props.moreLabel}
+            size={props.size}
+        >
+            {collapsedChildrenResults.collapsedChildren}
+        </TabListCollapseItem>
+    ) : null;
+
+    const shownChildren = collapsedChildrenResults.shownChildren;
+
+    const renderItem = React.useCallback(
+        (child: React.ReactElement, provided: DraggableProvided) => {
+            const tabChild = child as React.ReactElement<TabProps>;
+
+            return React.cloneElement(tabChild, {
+                provided,
+                className: [tabChild.props.className, bTabList('dnd-item')]
+                    .filter(Boolean)
+                    .join(' '),
+            });
+        },
+        [collapseEnabled, shownChildren.length],
+    );
+
+    if (dndEnabled) {
+        return (
+            <TabContext.Provider value={innerContextValue}>
+                <DragDropContext
+                    onDragEnd={handleDragEnd}
+                    onDragStart={handleDragStart}
+                    enableDefaultSensors={false}
+                    sensors={[useMouseSensor, useTouchSensor]}
+                >
+                    <Droppable droppableId={id} direction="horizontal">
+                        {(droppableProvided) => (
+                            <div
+                                ref={droppableProvided.innerRef}
+                                {...droppableProvided.droppableProps}
+                            >
+                                <div ref={containerRef} {...tabListProps} {...focusWithinProps}>
+                                    {shownChildren.map((child, index) => {
+                                        const draggableId = String(child.key ?? index);
+
+                                        return (
+                                            <Draggable
+                                                key={draggableId}
+                                                draggableId={draggableId}
+                                                index={index}
+                                                disableInteractiveElementBlocking
+                                            >
+                                                {(provided) => renderItem(child, provided)}
+                                            </Draggable>
+                                        );
+                                    })}
+                                    {droppableProvided.placeholder}
+                                    {collapseItem}
+                                </div>
+                            </div>
+                        )}
+                    </Droppable>
+                </DragDropContext>
+            </TabContext.Provider>
+        );
+    }
+
     return (
         <TabContext.Provider value={innerContextValue}>
             <div ref={containerRef} {...tabListProps} {...focusWithinProps}>
                 {collapseEnabled ? (
                     <React.Fragment>
                         {collapsedChildrenResults.shownChildren}
-                        <TabListCollapseItem
-                            ref={collapsedChildrenResults.collapseItemRef}
-                            triggerChild={collapsedChildrenResults.triggerChild}
-                            moreLabel={props.moreLabel}
-                            size={props.size}
-                        >
-                            {collapsedChildrenResults.collapsedChildren}
-                        </TabListCollapseItem>
+                        {collapseItem}
                     </React.Fragment>
                 ) : (
                     props.children

--- a/src/components/tabs/__stories__/TabList.stories.tsx
+++ b/src/components/tabs/__stories__/TabList.stories.tsx
@@ -178,3 +178,54 @@ export const Panels: Story = {
         );
     },
 };
+
+const DragAndDropRender = (args: TabListProps) => {
+    const tabs = getTabsMock({});
+    const [tabOrder, setTabOrder] = React.useState(() => tabs.map((t) => t.value));
+    const [activeTab, setActiveTab] = React.useState(tabs[0].value);
+
+    const orderedTabs = tabOrder.map((slug) => tabs.find((t) => t.value === slug)!);
+
+    const panels = React.useMemo(
+        () =>
+            tabs.map((props, i) => (
+                <TabPanel key={i} value={props.value}>
+                    <div style={{marginTop: '10px'}}>{`Content of ${props.value} tab panel`}</div>
+                </TabPanel>
+            )),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [],
+    );
+
+    return (
+        <TabProvider value={activeTab} onUpdate={setActiveTab}>
+            <TabList
+                {...args}
+                sortable
+                onSortEnd={(slugs) => {
+                    setTabOrder(slugs);
+                }}
+            >
+                {orderedTabs.map((props) => (
+                    <Tab key={props.value} {...props} />
+                ))}
+            </TabList>
+            <div>{panels}</div>
+            <div style={{marginTop: 8, fontSize: 12, color: 'var(--g-color-text-secondary)'}}>
+                Order: {tabOrder.join(', ')}
+            </div>
+        </TabProvider>
+    );
+};
+
+export const WithDragAndDrop: Story = {
+    render: DragAndDropRender,
+};
+
+export const WithDragAndDropAndCollapse: Story = {
+    render: DragAndDropRender,
+    args: {
+        contentOverflow: 'collapse',
+        style: {maxWidth: 400},
+    },
+};

--- a/src/components/tabs/__tests__/TabList.test.tsx
+++ b/src/components/tabs/__tests__/TabList.test.tsx
@@ -406,3 +406,155 @@ test('contentOverflow collapse: with narrow container and single tab does not re
 
     spy.mockRestore();
 });
+
+test('does not render DragDropContext when sortable is not set', () => {
+    render(
+        <TabList value={tab1.value}>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    screen.getAllByRole('tab').forEach((tab) => {
+        expect(tab).not.toHaveAttribute('data-rfd-draggable-id');
+    });
+});
+
+test('renders DragDropContext and Droppable when sortable is true', () => {
+    render(
+        <TabList value={tab1.value} sortable>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    screen.getAllByRole('tab').forEach((tab) => {
+        expect(tab).toHaveAttribute('data-rfd-draggable-id');
+    });
+});
+
+test('preserves tablist role when sortable is true', () => {
+    render(
+        <TabList value={tab1.value} sortable>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+});
+
+test('renders each visible tab inside a Draggable wrapper', () => {
+    render(
+        <TabList value={tab1.value} sortable>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    screen.getAllByRole('tab').forEach((tab) => {
+        expect(tab).toHaveAttribute('data-rfd-draggable-id');
+    });
+});
+
+test('adds dnd item class to each visible tab when sortable is true', () => {
+    render(
+        <TabList value={tab1.value} sortable>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+
+    tabs.forEach((tab) => {
+        expect(tab).toHaveClass('g-tab-list__dnd-item');
+    });
+});
+
+test('move focus on LEFT/RIGHT arrows when sortable is true', async () => {
+    const user = userEvent.setup();
+
+    render(
+        <TabList value={tab2.value} sortable>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab disabled value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+            <Tab value={tab4.value} qa={tab4.qa}>
+                {tab4.title}
+            </Tab>
+        </TabList>,
+    );
+
+    const tabs = screen.queryAllByRole('tab');
+
+    await user.keyboard(`{${KeyCode.TAB}}`);
+    // active tab
+    expect(tabs[1]).toHaveFocus();
+
+    await user.keyboard(`{${KeyCode.ARROW_RIGHT}}`);
+    expect(tabs[3]).toHaveFocus();
+    expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
+
+    await user.keyboard(`{${KeyCode.ARROW_RIGHT}}`);
+    expect(tabs[0]).toHaveFocus();
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+
+    await user.keyboard(`{${KeyCode.ARROW_RIGHT}}`);
+    expect(tabs[1]).toHaveFocus();
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard(`{${KeyCode.ARROW_LEFT}}`);
+    expect(tabs[0]).toHaveFocus();
+
+    await user.keyboard(`{${KeyCode.ARROW_LEFT}}`);
+    expect(tabs[3]).toHaveFocus();
+
+    await user.keyboard(`{${KeyCode.ARROW_LEFT}}`);
+    expect(tabs[1]).toHaveFocus();
+
+    await user.keyboard(`{${KeyCode.ARROW_LEFT}}`);
+    expect(tabs[0]).toHaveFocus();
+});

--- a/src/components/tabs/__tests__/useTabListDnd.test.tsx
+++ b/src/components/tabs/__tests__/useTabListDnd.test.tsx
@@ -1,0 +1,172 @@
+import {Tab} from '..';
+import {act, renderHook} from '../../../../test-utils/utils';
+import {useTabListDnd} from '../hooks/useTabListDnd';
+
+import {tab1, tab2, tab3, tab4} from './constants';
+
+const makeMockChildren = (slugs: string[]) => slugs.map((slug) => <Tab key={slug} value={slug} />);
+
+test('calls onSortStart on drag start', () => {
+    const onSortStart = jest.fn();
+    const children = makeMockChildren([tab1.value, tab2.value, tab3.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortStart}));
+
+    act(() => {
+        result.current.handleDragStart();
+    });
+
+    expect(onSortStart).toHaveBeenCalledTimes(1);
+});
+
+test('calls onSortEnd with reordered slugs on valid drop', () => {
+    const onSortEnd = jest.fn();
+    const slugs = [tab1.value, tab2.value, tab3.value];
+    const children = makeMockChildren(slugs);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab1.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 0},
+            destination: {droppableId: 'list', index: 2},
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).toHaveBeenCalledWith([tab2.value, tab3.value, tab1.value]);
+});
+
+test('calls onSortEnd with collapsed slugs after shown slugs on valid drop', () => {
+    const onSortEnd = jest.fn();
+    const shownChildren = makeMockChildren([tab1.value, tab2.value]);
+    const collapsedChildren = makeMockChildren([tab3.value, tab4.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren, collapsedChildren, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab1.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 0},
+            destination: {droppableId: 'list', index: 1},
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).toHaveBeenCalledWith([tab2.value, tab1.value, tab3.value, tab4.value]);
+});
+
+test('does not call onSortEnd when dropped on the same index', () => {
+    const onSortEnd = jest.fn();
+    const children = makeMockChildren([tab1.value, tab2.value, tab3.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab1.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 1},
+            destination: {droppableId: 'list', index: 1},
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).not.toHaveBeenCalled();
+});
+
+test('does not call onSortEnd when destination is null (drop cancelled)', () => {
+    const onSortEnd = jest.fn();
+    const children = makeMockChildren([tab1.value, tab2.value, tab3.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab1.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 0},
+            destination: null,
+            reason: 'CANCEL',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).not.toHaveBeenCalled();
+});
+
+test('does not call onSortEnd when onSortEnd is not provided', () => {
+    const children = makeMockChildren([tab1.value, tab2.value, tab3.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children}));
+
+    expect(() => {
+        act(() => {
+            result.current.handleDragEnd({
+                draggableId: tab1.value,
+                type: 'DEFAULT',
+                source: {droppableId: 'list', index: 0},
+                destination: {droppableId: 'list', index: 2},
+                reason: 'DROP',
+                mode: 'FLUID',
+                combine: null,
+            });
+        });
+    }).not.toThrow();
+});
+
+test('calls onSortEnd with reordered slugs when moving last shown tab to the first position', () => {
+    const onSortEnd = jest.fn();
+    const children = makeMockChildren([tab1.value, tab2.value, tab3.value]);
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab3.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 2},
+            destination: {droppableId: 'list', index: 0},
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).toHaveBeenCalledWith([tab3.value, tab1.value, tab2.value]);
+});
+
+test('keeps a deterministic empty slug for unsupported children on sort end', () => {
+    const onSortEnd = jest.fn();
+    const children = [
+        <Tab key={tab1.value} value={tab1.value} />,
+        <span key="unsupported-child">Unsupported child</span>,
+        <Tab key={tab2.value} value={tab2.value} />,
+    ];
+
+    const {result} = renderHook(() => useTabListDnd({shownChildren: children, onSortEnd}));
+
+    act(() => {
+        result.current.handleDragEnd({
+            draggableId: tab1.value,
+            type: 'DEFAULT',
+            source: {droppableId: 'list', index: 0},
+            destination: {droppableId: 'list', index: 2},
+            reason: 'DROP',
+            mode: 'FLUID',
+            combine: null,
+        });
+    });
+
+    expect(onSortEnd).toHaveBeenCalledWith(['', tab2.value, tab1.value]);
+});

--- a/src/components/tabs/hooks/useTab.ts
+++ b/src/components/tabs/hooks/useTab.ts
@@ -9,6 +9,20 @@ export type TabElementProps = React.HTMLAttributes<HTMLElement> & {
     [key: `data-${string}`]: string | undefined;
 };
 
+function getStyle(
+    provided: TabProps['provided'],
+    style: React.CSSProperties | undefined,
+): React.CSSProperties | undefined {
+    if (!style) {
+        return provided?.draggableProps.style;
+    }
+
+    return {
+        ...provided?.draggableProps.style,
+        ...style,
+    };
+}
+
 export function useTab<T extends TabComponentElementType>(tabProps: TabProps<T>): TabElementProps {
     const tabContext = React.useContext(TabContext);
 
@@ -65,6 +79,7 @@ export function useTab<T extends TabComponentElementType>(tabProps: TabProps<T>)
         component: _component,
         qa: _qa,
         isMenuItem: _isMenuItem,
+        provided,
         ...htmlProps
     } = tabProps;
 
@@ -75,7 +90,7 @@ export function useTab<T extends TabComponentElementType>(tabProps: TabProps<T>)
         tabIndex: isSelected && !isDisabled && !isFocused ? 0 : -1,
     };
 
-    return {
+    const elementProps = {
         ...htmlRest,
         ...(tabProps.isMenuItem ? {} : tabRoleProps),
         'aria-selected': isSelected,
@@ -87,5 +102,15 @@ export function useTab<T extends TabComponentElementType>(tabProps: TabProps<T>)
         className: bTab({active: isSelected, disabled: isDisabled}, tabProps.className),
         'data-qa': tabProps.qa,
         [TAB_DATA_ATTRIBUTE]: tabProps.value,
+    };
+
+    const {'aria-describedby': _ariaDescribedBy, ...restDragHandleProps} =
+        provided?.dragHandleProps ?? {};
+
+    return {
+        ...provided?.draggableProps,
+        ...restDragHandleProps,
+        ...elementProps,
+        style: getStyle(provided, elementProps.style),
     };
 }

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -120,6 +120,9 @@ export function useTabList(
         qa: _qa,
         contentOverflow,
         moreLabel: _moreLabel,
+        sortable: _sortable,
+        onSortStart: _onSortStart,
+        onSortEnd: _onSortEnd,
         ...htmlProps
     } = tabListProps;
 

--- a/src/components/tabs/hooks/useTabListDnd.ts
+++ b/src/components/tabs/hooks/useTabListDnd.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import type {DropResult} from '@hello-pangea/dnd';
+
+import {getTabNodePropsFromReactNode} from '../utils';
+
+interface UseTabListDndParams {
+    shownChildren: React.ReactNode;
+    collapsedChildren?: React.ReactNode;
+    onSortStart?: () => void;
+    onSortEnd?: (orderedSlugs: string[]) => void;
+}
+
+export function useTabListDnd({
+    shownChildren,
+    collapsedChildren,
+    onSortStart,
+    onSortEnd,
+}: UseTabListDndParams) {
+    const handleDragStart = React.useCallback(() => {
+        onSortStart?.();
+    }, [onSortStart]);
+
+    const handleDragEnd = React.useCallback(
+        (result: DropResult) => {
+            if (!result.destination) return;
+            const {source, destination} = result;
+            if (source.index === destination.index) return;
+
+            const shownSlugs =
+                React.Children.map(
+                    shownChildren,
+                    (child) => getTabNodePropsFromReactNode(child)?.value ?? '',
+                ) ?? [];
+
+            const collapsedSlugs = collapsedChildren
+                ? (React.Children.map(
+                      collapsedChildren,
+                      (child) => getTabNodePropsFromReactNode(child)?.value ?? '',
+                  ) ?? [])
+                : [];
+
+            const reordered = [...shownSlugs, ...collapsedSlugs];
+            const [moved] = reordered.splice(source.index, 1);
+            reordered.splice(destination.index, 0, moved);
+
+            onSortEnd?.(reordered);
+        },
+        [shownChildren, collapsedChildren, onSortEnd],
+    );
+
+    return {handleDragEnd, handleDragStart};
+}

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -1,5 +1,7 @@
 import type * as React from 'react';
 
+import type {DraggableProvided} from '@hello-pangea/dnd';
+
 import type {LabelProps} from '../Label';
 import type {DOMProps, QAProps} from '../types';
 
@@ -23,6 +25,9 @@ export interface TabListProps
     moreLabel?: React.ReactNode;
     activateOnFocus?: boolean;
     children?: React.ReactNode;
+    sortable?: boolean;
+    onSortStart?: () => void;
+    onSortEnd?: (orderedSlugs: string[]) => void;
 }
 
 interface TabCommonProps extends QAProps, DOMProps {
@@ -37,6 +42,8 @@ interface TabCommonProps extends QAProps, DOMProps {
     children?: React.ReactNode;
     /** Tab was collapsed and rendered in `Menu` */
     isMenuItem?: boolean;
+    /** DnD provided object injected by `TabList` when sorting is enabled */
+    provided?: DraggableProvided;
 }
 
 export interface TabButtonProps


### PR DESCRIPTION
## Summary by Sourcery

Add optional drag-and-drop sorting support to TabList and integrate it with Tab components while preserving existing behavior when sorting is disabled.

New Features:
- Introduce a sortable TabList mode that enables drag-and-drop reordering of tabs, including when tabs are collapsed into an overflow menu.

Enhancements:
- Wire Tab components and styling to work with the drag-and-drop library, including placeholder handling and DnD-specific classes, without breaking keyboard navigation or accessibility.
- Add a dedicated useTabListDnd hook to encapsulate drag-and-drop reordering logic for tab lists.
- Document sortable tabs usage and expose new sortable, onSortStart, and onSortEnd props in the TabList API, with Storybook examples demonstrating drag-and-drop with and without collapsing.

Tests:
- Extend TabList tests to cover sortable behavior, drag-and-drop wiring, and keyboard focus movement when sorting is enabled.
- Add unit tests for the useTabListDnd hook to validate sorting callbacks and edge cases such as cancelled drops and unsupported children.