### PR TITLE
fix(TextInput): replace legacy `Popover` with new one

### DIFF
--- a/src/components/controls/TextInput/TextInput.scss
+++ b/src/components/controls/TextInput/TextInput.scss
@@ -148,6 +148,14 @@ $block: '.#{variables.$ns}text-input';
             var(--_--error-icon-padding-inline-end);
     }
 
+    &__error-popover {
+        max-width: 300px;
+    }
+
+    &__error-popover-content {
+        padding: var(--g-spacing-5) var(--g-spacing-4);
+    }
+
     &__additional-content {
         display: flex;
         align-items: center;

--- a/src/components/controls/TextInput/TextInput.tsx
+++ b/src/components/controls/TextInput/TextInput.tsx
@@ -6,8 +6,9 @@ import {TriangleExclamation} from '@gravity-ui/icons';
 
 import {useControlledState, useForkRef, useUniqId} from '../../../hooks';
 import {useElementSize, useFormResetHandler} from '../../../hooks/private';
+import {Alert} from '../../Alert';
 import {Icon} from '../../Icon';
-import {Popover} from '../../legacy';
+import {Popover} from '../../Popover';
 import {block} from '../../utils/cn';
 import {ClearButton, mapTextInputSizeToButtonSize} from '../common';
 import {OuterAdditionalContent} from '../common/OuterAdditionalContent/OuterAdditionalContent';
@@ -233,7 +234,15 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
                         />
                     )}
                     {isErrorIconVisible && (
-                        <Popover content={errorMessage}>
+                        <Popover
+                            hasArrow
+                            content={
+                                <Alert
+                                    theme="clear"
+                                    message={<div role="presentation">{errorMessage}</div>}
+                                />
+                            }
+                        >
                             <span data-qa={CONTROL_ERROR_ICON_QA}>
                                 <Icon
                                     data={TriangleExclamation}

--- a/src/components/controls/TextInput/TextInput.tsx
+++ b/src/components/controls/TextInput/TextInput.tsx
@@ -9,6 +9,7 @@ import {useElementSize, useFormResetHandler} from '../../../hooks/private';
 import {Alert} from '../../Alert';
 import {Icon} from '../../Icon';
 import {Popover} from '../../Popover';
+import {useDirection} from '../../theme';
 import {block} from '../../utils/cn';
 import {ClearButton, mapTextInputSizeToButtonSize} from '../common';
 import {OuterAdditionalContent} from '../common/OuterAdditionalContent/OuterAdditionalContent';
@@ -80,6 +81,8 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
             onUpdate,
             onChange,
         } = props;
+
+        const direction = useDirection();
 
         const {errorMessage, errorPlacement, validationState} = errorPropsMapper({
             error,
@@ -235,9 +238,14 @@ export const TextInput = React.forwardRef<HTMLSpanElement, TextInputProps>(
                     )}
                     {isErrorIconVisible && (
                         <Popover
+                            placement={
+                                direction === 'rtl' ? ['left', 'bottom'] : ['right', 'bottom']
+                            }
+                            className={b('error-popover')}
                             hasArrow
                             content={
                                 <Alert
+                                    className={b('error-popover-content')}
                                     theme="clear"
                                     message={<div role="presentation">{errorMessage}</div>}
                                 />


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure TextInput error messages are displayed via the new Popover implementation using an accessible Alert container.