### PR TITLE
fix(Select): replace legacy `Popover` with new one

### DIFF
--- a/src/components/Select/components/SelectControl/SelectControl.scss
+++ b/src/components/Select/components/SelectControl/SelectControl.scss
@@ -250,4 +250,12 @@ $blockButton: '.#{variables.$ns}select-control__button';
             outline: 0;
         }
     }
+
+    &__error-popover {
+        max-width: 300px;
+    }
+
+    &__error-popover-content {
+        padding: var(--g-spacing-5) var(--g-spacing-4);
+    }
 }

--- a/src/components/Select/components/SelectControl/SelectControl.tsx
+++ b/src/components/Select/components/SelectControl/SelectControl.tsx
@@ -215,8 +215,10 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
 
                 {errorMessage && (
                     <Popover
+                        className={selectControlBlock('error-popover')}
                         content={
                             <Alert
+                                className={selectControlBlock('error-popover-content')}
                                 theme="clear"
                                 message={<div role="presentation">{errorMessage}</div>}
                             />

--- a/src/components/Select/components/SelectControl/SelectControl.tsx
+++ b/src/components/Select/components/SelectControl/SelectControl.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import {ChevronDown, TriangleExclamation} from '@gravity-ui/icons';
 
-import {useUniqId} from '../../../../hooks';
+import {Alert} from '../../../Alert';
 import {Icon} from '../../../Icon';
-import {Popover} from '../../../legacy';
+import {Popover} from '../../../Popover';
 import type {AriaLabelingProps} from '../../../types';
 import type {CnMods} from '../../../utils/cn';
 import {filterDOMProps} from '../../../utils/filterDOMProps';
@@ -81,7 +81,6 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
     const showOptionsText = Boolean(selectedOptionsContent);
     const showPlaceholder = Boolean(placeholder && !showOptionsText);
     const hasValue = Array.isArray(value) && value.filter(Boolean).length > 0;
-    const errorTooltipId = useUniqId();
 
     const [isDisabledButtonAnimation, setIsDisabledButtonAnimation] = React.useState(false);
 
@@ -215,10 +214,16 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
                 {renderClearIcon({})}
 
                 {errorMessage && (
-                    <Popover content={errorMessage} tooltipId={errorTooltipId}>
+                    <Popover
+                        content={
+                            <Alert
+                                theme="clear"
+                                message={<div role="presentation">{errorMessage}</div>}
+                            />
+                        }
+                    >
                         <button
                             aria-label={t('label_show-error-info')}
-                            aria-describedby={errorTooltipId}
                             type={'button'}
                             className={selectControlBlock('error-icon')}
                         >

--- a/src/components/Select/components/SelectControl/SelectControl.tsx
+++ b/src/components/Select/components/SelectControl/SelectControl.tsx
@@ -7,6 +7,7 @@ import {ChevronDown, TriangleExclamation} from '@gravity-ui/icons';
 import {Alert} from '../../../Alert';
 import {Icon} from '../../../Icon';
 import {Popover} from '../../../Popover';
+import {useDirection} from '../../../theme';
 import type {AriaLabelingProps} from '../../../types';
 import type {CnMods} from '../../../utils/cn';
 import {filterDOMProps} from '../../../utils/filterDOMProps';
@@ -81,6 +82,8 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
     const showOptionsText = Boolean(selectedOptionsContent);
     const showPlaceholder = Boolean(placeholder && !showOptionsText);
     const hasValue = Array.isArray(value) && value.filter(Boolean).length > 0;
+
+    const direction = useDirection();
 
     const [isDisabledButtonAnimation, setIsDisabledButtonAnimation] = React.useState(false);
 
@@ -215,6 +218,8 @@ export const SelectControl = React.forwardRef<HTMLButtonElement, ControlProps>((
 
                 {errorMessage && (
                     <Popover
+                        placement={direction === 'rtl' ? ['left', 'bottom'] : ['right', 'bottom']}
+                        hasArrow
                         className={selectControlBlock('error-popover')}
                         content={
                             <Alert


### PR DESCRIPTION
## Summary by Sourcery

Replace the Select control error message popover with the new Popover implementation and adjust error styling.

Enhancements:
- Wrap Select control error messages in an Alert inside the new Popover component for improved presentation and accessibility.
- Add styling for the Select control error popover container and its content, including max-width and padding.