### PR TITLE
feat(Progress): add custom color to colorStop

### DIFF
--- a/src/components/Progress/ProgressWithValue.tsx
+++ b/src/components/Progress/ProgressWithValue.tsx
@@ -6,6 +6,7 @@ import {getOffset, getTheme} from './utils';
 export function ProgressWithValue(props: ProgressWithValueProps) {
     const {value, loading, text} = props;
     const offset = getOffset(value);
+    const {theme, color} = getTheme(props);
 
     if (!Number.isFinite(value)) {
         return null;
@@ -13,8 +14,11 @@ export function ProgressWithValue(props: ProgressWithValueProps) {
 
     return (
         <div
-            className={progressBlock('item', {theme: getTheme(props), loading})}
-            style={{transform: `translateX(calc(var(--g-flow-direction) * ${offset}%))`}}
+            className={progressBlock('item', {theme, loading})}
+            style={{
+                transform: `translateX(calc(var(--g-flow-direction) * ${offset}%))`,
+                backgroundColor: color,
+            }}
         >
             <ProgressInnerText offset={offset} text={text} />
         </div>

--- a/src/components/Progress/ProgressWithValue.tsx
+++ b/src/components/Progress/ProgressWithValue.tsx
@@ -1,3 +1,5 @@
+import type {CnMods} from '../utils/cn';
+
 import {ProgressInnerText} from './ProgressInnerText';
 import {progressBlock} from './constants';
 import type {ProgressWithValueProps} from './types';
@@ -8,19 +10,27 @@ export function ProgressWithValue(props: ProgressWithValueProps) {
     const offset = getOffset(value);
     const {theme, color} = getTheme(props);
 
-    if (!Number.isFinite(value)) {
-        return null;
+    const modifiers: CnMods = {
+        loading,
+    };
+
+    if (typeof color === 'undefined') {
+        modifiers.theme = theme || 'default';
     }
 
-    return (
-        <div
-            className={progressBlock('item', {theme, loading})}
-            style={{
-                transform: `translateX(calc(var(--g-flow-direction) * ${offset}%))`,
-                backgroundColor: color,
-            }}
-        >
-            <ProgressInnerText offset={offset} text={text} />
-        </div>
-    );
+    if (Number.isFinite(value)) {
+        return (
+            <div
+                className={progressBlock('item', modifiers)}
+                style={{
+                    transform: `translateX(calc(var(--g-flow-direction) * ${offset}%))`,
+                    backgroundColor: color,
+                }}
+            >
+                <ProgressInnerText offset={offset} text={text} />
+            </div>
+        );
+    }
+
+    return null;
 }

--- a/src/components/Progress/README-ru.md
+++ b/src/components/Progress/README-ru.md
@@ -149,6 +149,44 @@ SANDBOX-->
 
 <!--/GITHUB_BLOCK-->
 
+Используйте необязательное свойство `color`, чтобы переопределить цвет темы:
+
+<!--SANDBOX
+import {Box, Progress} from '@gravity-ui/uikit';
+
+const colorStops = [
+    {theme: 'danger', stop: 20, color: '#ff4444'},
+    {theme: 'warning', stop: 50, color: '#ffaa00'},
+    {theme: 'success', stop: 100, color: '#44ff44'},
+];
+
+export default function () {
+    return (
+        <>
+            <Box width={'30%'}>
+                <Progress value={10} colorStops={colorStops} />
+            </Box>
+            <Box width={'30%'}>
+                <Progress value={40} colorStops={colorStops} />
+            </Box>
+            <Box width={'30%'}>
+                <Progress value={60} colorStops={colorStops} />
+            </Box>
+        </>
+    );
+}
+SANDBOX-->
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+<Progress value={10} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+<Progress value={40} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+<Progress value={60} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+```
+
+<!--/GITHUB_BLOCK-->
+
 ## Стек
 
 <!--SANDBOX
@@ -202,18 +240,18 @@ SANDBOX-->
 
 ## Свойства
 
-| Имя             | Описание                                                                                                                                       |                   Тип                    | Значение по умолчанию |
-| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------: | :-------------------: |
-| className       | HTML-атрибут `class`.                                                                                                                          |                 `string`                 |                       |
-| colorStops      | Задает брейкпоинты с темами.                                                                                                                   | ` Array<{theme: string; stop: number;}>` |                       |
-| colorStopsValue | Устанавливает значение для выбора текущей точки остановки цвета или альтернативное значение для `colorStops`. Диапазон значений — от 0 до 100. |                 `number`                 |                       |
-| loading         | Включает или отключает состояние `loading`.                                                                                                    |                `boolean`                 |        `false`        |
-| size            | Задает размер прогресс-бара. Отображение текста доступно только при размере `"m"`.                                                             |                 `string`                 |         `"m"`         |
-| stack           | Конфигурация составного прогресс-бара. Необязательное свойство, если указано `value`.                                                          |             ` Array<Stack>`              |                       |
-| stackClassName  | HTML-атрибут `name` для стека.                                                                                                                 |                 `string`                 |                       |
-| text            | Текст внутри прогресс-бара.                                                                                                                    |                 `string`                 |                       |
-| theme           | Задает цвет прогресса.                                                                                                                         |                 `string`                 |      `"default"`      |
-| value           | Текущее значение прогресса. Диапазон значений — от 0 до 100. Свойство `stack` является необязательным и используется как `maxValue`.           |                 `number`                 |                       |
+| Имя             | Описание                                                                                                                                       |                           Тип                           | Значение по умолчанию |
+| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- | :-----------------------------------------------------: | :-------------------: |
+| className       | HTML-атрибут `class`.                                                                                                                          |                        `string`                         |                       |
+| colorStops      | Задает брейкпоинты с темами.                                                                                                                   | ` Array<{theme: string; stop: number; color?: string}>` |                       |
+| colorStopsValue | Устанавливает значение для выбора текущей точки остановки цвета или альтернативное значение для `colorStops`. Диапазон значений — от 0 до 100. |                        `number`                         |                       |
+| loading         | Включает или отключает состояние `loading`.                                                                                                    |                        `boolean`                        |        `false`        |
+| size            | Задает размер прогресс-бара. Отображение текста доступно только при размере `"m"`.                                                             |                        `string`                         |         `"m"`         |
+| stack           | Конфигурация составного прогресс-бара. Необязательное свойство, если указано `value`.                                                          |                     ` Array<Stack>`                     |                       |
+| stackClassName  | HTML-атрибут `name` для стека.                                                                                                                 |                        `string`                         |                       |
+| text            | Текст внутри прогресс-бара.                                                                                                                    |                        `string`                         |                       |
+| theme           | Задает цвет прогресса.                                                                                                                         |                        `string`                         |      `"default"`      |
+| value           | Текущее значение прогресса. Диапазон значений — от 0 до 100. Свойство `stack` является необязательным и используется как `maxValue`.           |                        `number`                         |                       |
 
 ### `Stack`
 

--- a/src/components/Progress/README.md
+++ b/src/components/Progress/README.md
@@ -149,6 +149,44 @@ SANDBOX-->
 
 <!--/GITHUB_BLOCK-->
 
+Use the optional `color` property to override the theme color:
+
+<!--SANDBOX
+import {Box, Progress} from '@gravity-ui/uikit';
+
+const colorStops = [
+    {theme: 'danger', stop: 20, color: '#ff4444'},
+    {theme: 'warning', stop: 50, color: '#ffaa00'},
+    {theme: 'success', stop: 100, color: '#44ff44'},
+];
+
+export default function () {
+    return (
+        <>
+            <Box width={'30%'}>
+                <Progress value={10} colorStops={colorStops} />
+            </Box>
+            <Box width={'30%'}>
+                <Progress value={40} colorStops={colorStops} />
+            </Box>
+            <Box width={'30%'}>
+                <Progress value={60} colorStops={colorStops} />
+            </Box>
+        </>
+    );
+}
+SANDBOX-->
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+<Progress value={10} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+<Progress value={40} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+<Progress value={60} colorStops={[{theme: 'danger', stop: 20, color: '#ff4444'}, {theme: 'warning', stop: 50, color: '#ffaa00'}, {theme: 'success', stop: 100, color: '#44ff44'}]} />
+```
+
+<!--/GITHUB_BLOCK-->
+
 ## Stack
 
 <!--SANDBOX
@@ -202,18 +240,18 @@ SANDBOX-->
 
 ## Properties
 
-| Name            | Description                                                                                                                         |                  Type                   |   Default   |
-| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------: | :---------: |
-| className       | HTML `class` attribute                                                                                                              |                `string`                 |             |
-| colorStops      | Sets breakpoints with themes                                                                                                        | `Array<{theme: string; stop: number;}>` |             |
-| colorStopsValue | Sets the value for choosing the current stop or alternative value for colorStops. The available range is from 0 to 100.             |                `number`                 |             |
-| loading         | Toggles the `loading` state                                                                                                         |                `boolean`                |   `false`   |
-| size            | Sets the progress bar size. The progress bar text can only be displayed in `"m"` size.                                              |                `string`                 |    `"m"`    |
-| stack           | Configuration of composite progress bar. Not required if a `value` is provided.                                                     |             `Array<Stack>`              |             |
-| stackClassName  | HTML `class` attribute of stack                                                                                                     |                `string`                 |             |
-| text            | Text inside the progress bar                                                                                                        |               `ReactNode`               |             |
-| theme           | Sets progress color                                                                                                                 |                `string`                 | `"default"` |
-| value           | Current progress value. The available range is from 0 to 100. Using the `stack` property value is optional and is used as maxValue. |                `number`                 |             |
+| Name            | Description                                                                                                                         |                          Type                          |   Default   |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------: | :---------: |
+| className       | HTML `class` attribute                                                                                                              |                        `string`                        |             |
+| colorStops      | Sets breakpoints with themes                                                                                                        | `Array<{theme: string; stop: number; color?: string}>` |             |
+| colorStopsValue | Sets the value for choosing the current stop or alternative value for colorStops. The available range is from 0 to 100.             |                        `number`                        |             |
+| loading         | Toggles the `loading` state                                                                                                         |                       `boolean`                        |   `false`   |
+| size            | Sets the progress bar size. The progress bar text can only be displayed in `"m"` size.                                              |                        `string`                        |    `"m"`    |
+| stack           | Configuration of composite progress bar. Not required if a `value` is provided.                                                     |                     `Array<Stack>`                     |             |
+| stackClassName  | HTML `class` attribute of stack                                                                                                     |                        `string`                        |             |
+| text            | Text inside the progress bar                                                                                                        |                      `ReactNode`                       |             |
+| theme           | Sets progress color                                                                                                                 |                        `string`                        | `"default"` |
+| value           | Current progress value. The available range is from 0 to 100. Using the `stack` property value is optional and is used as maxValue. |                        `number`                        |             |
 
 ### `Stack`
 

--- a/src/components/Progress/__stories__/Progress.stories.tsx
+++ b/src/components/Progress/__stories__/Progress.stories.tsx
@@ -150,3 +150,44 @@ const AnimationTemplate: StoryFn<typeof Progress> = (args) => {
 };
 
 export const Animation = AnimationTemplate.bind({});
+
+const ColorStopsCustom: StoryFn<typeof Progress> = (args) => {
+    return (
+        <React.Fragment>
+            <Progress
+                {...args}
+                value={10}
+                text="Custom color at 10%"
+                colorStops={[
+                    {theme: 'danger', stop: 20, color: '#ff0051'},
+                    {theme: 'warning', stop: 50, color: '#ffdd00'},
+                    {theme: 'success', stop: 100, color: '#00ff8c'},
+                ]}
+            />
+            <br />
+            <Progress
+                {...args}
+                value={35}
+                text="Custom color at 35%"
+                colorStops={[
+                    {theme: 'danger', stop: 20, color: '#ff0051'},
+                    {theme: 'warning', stop: 50, color: '#ffdd00'},
+                    {theme: 'success', stop: 100, color: '#00ff8c'},
+                ]}
+            />
+            <br />
+            <Progress
+                {...args}
+                value={75}
+                text="Custom color at 75%"
+                colorStops={[
+                    {theme: 'danger', stop: 20, color: '#ff0051'},
+                    {theme: 'warning', stop: 50, color: '#ffdd00'},
+                    {theme: 'success', stop: 100, color: '#00ff8c'},
+                ]}
+            />
+        </React.Fragment>
+    );
+};
+
+export const ColorStops = ColorStopsCustom.bind({});

--- a/src/components/Progress/types.ts
+++ b/src/components/Progress/types.ts
@@ -19,6 +19,7 @@ export interface Stack {
 export interface ProgressColorStops {
     theme: ProgressTheme;
     stop: number;
+    color?: string;
 }
 
 interface ProgressGeneralProps extends QAProps {

--- a/src/components/Progress/utils.ts
+++ b/src/components/Progress/utils.ts
@@ -1,5 +1,10 @@
 import type {ProgressTheme, ProgressWithValueProps, Stack} from './types';
 
+type ThemeWithCustomColor = {
+    theme: ProgressTheme;
+    color?: string;
+};
+
 export function getOffset(value: number): number {
     return value < 100 ? value - 100 : 0;
 }
@@ -8,7 +13,7 @@ export function getValueFromStack(stack: Stack[]): number {
     return stack.reduce((sum, {value}) => sum + value, 0);
 }
 
-export function getTheme(props: ProgressWithValueProps): ProgressTheme {
+export function getTheme(props: ProgressWithValueProps): ThemeWithCustomColor {
     const {theme, colorStops, colorStopsValue, value} = props;
 
     if (colorStops) {
@@ -20,8 +25,15 @@ export function getTheme(props: ProgressWithValueProps): ProgressTheme {
             return currentValue >= minValue && currentValue <= maxValue;
         });
 
-        return matchingColorStopItem ? matchingColorStopItem.theme : (theme as ProgressTheme);
+        return matchingColorStopItem
+            ? {
+                  theme: matchingColorStopItem.theme,
+                  color: matchingColorStopItem.color,
+              }
+            : {theme: theme as ProgressTheme};
     }
 
-    return theme as ProgressTheme;
+    return {
+        theme: theme as ProgressTheme,
+    };
 }


### PR DESCRIPTION
## Summary by Sourcery

Allow Progress color stops to specify and apply custom background colors based on value thresholds.

New Features:
- Add support for specifying custom colors in Progress colorStops entries and apply them to the progress bar background.

Enhancements:
- Extend Progress stories to showcase multiple custom-colored colorStop configurations.


Closes #2593

