### PR TITLE
fix(Popup): keep status as 'initial' until positioned to avoid open flash

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbsDropdownMenu.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsDropdownMenu.tsx
@@ -92,6 +92,7 @@ export function BreadcrumbsDropdownMenu({
                 <Button.Icon>...</Button.Icon>
             </Button>
             <Popup
+                open={open}
                 floatingContext={context}
                 floatingRef={setFloating}
                 floatingInteractions={interactions}

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -349,7 +349,9 @@ function PopupComponent(rawProps: PopupProps) {
                                 ...floatingStylesProp,
                             }}
                             data-floating-ui-placement={finalPlacement}
-                            data-floating-ui-status={status}
+                            data-floating-ui-status={
+                                status === 'open' && !isPositioned ? 'initial' : status
+                            }
                             aria-modal={modal && isMounted ? true : undefined}
                             {...getFloatingProps()}
                         >


### PR DESCRIPTION
Problem
When a Popup opens, it can briefly flash at the top-left corner before snapping to the anchor.

The floating reference is registered in a useEffect, so Floating UI computes and applies the position transform one render later. The enter animation, however, is driven by useFloatingTransition via the data-floating-ui-status attribute: as soon as it switches to open, the CSS starts fading the popup in (opacity: 0 → 1). If that fade starts before the position transform has been applied (which happens when the popup is opened inside a heavy / busy subtree, e.g. a large virtualized table, where the positioning render is delayed), the popup becomes visible while still sitting at its unpositioned top: 0; left: 0. The result is a visible corner flash. On lighter trees the positioning render wins the race, so the issue is timing-dependent.

Fix
Report the status as initial while the popup is opening but not yet positioned:

In the initial state the popup stays opacity: 0, so it remains invisible until Floating UI has positioned it; only then does it switch to open and fade in — already at the anchor.