### PR TITLE
refactor!: restrict-enum-usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,10 @@ export default defineConfig([
                         "MemberExpression[object.name='React'][property.name='useLayoutEffect']",
                     message: "Please use 'src/hooks/useLayoutEffect' instead.",
                 },
+                {
+                    selector: 'TSEnumDeclaration',
+                    message: 'Don\'t use enums. Use union types or "as const" objects instead.',
+                },
             ],
             'jsx-a11y/no-autofocus': 'off',
             'import/no-extraneous-dependencies': 'off',
@@ -54,6 +58,7 @@ export default defineConfig([
     {
         files: ['**/*.ts', '**/*.tsx'],
         rules: {
+            '@typescript-eslint/no-redeclare': 'off',
             '@typescript-eslint/prefer-ts-expect-error': 'error',
             '@typescript-eslint/consistent-type-imports': [
                 'error',

--- a/src/components/lab/ColorPicker/types.ts
+++ b/src/components/lab/ColorPicker/types.ts
@@ -1,4 +1,5 @@
-export enum Modes {
-    Hex = 'HEX',
-    Rgb = 'RGB',
-}
+export const Modes = {
+    Hex: 'HEX',
+    Rgb: 'RGB',
+} as const;
+export type Modes = (typeof Modes)[keyof typeof Modes];

--- a/src/components/legacy/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/legacy/Breadcrumbs/Breadcrumbs.tsx
@@ -66,15 +66,19 @@ const GAP_WIDTH = 4;
 
 const b = block('breadcrumbs-legacy');
 
-export enum LastDisplayedItemsCount {
-    One = 1,
-    Two = 2,
-}
+export const LastDisplayedItemsCount = {
+    One: 1,
+    Two: 2,
+} as const;
+export type LastDisplayedItemsCount =
+    (typeof LastDisplayedItemsCount)[keyof typeof LastDisplayedItemsCount];
 
-export enum FirstDisplayedItemsCount {
-    Zero = 0,
-    One = 1,
-}
+export const FirstDisplayedItemsCount = {
+    Zero: 0,
+    One: 1,
+} as const;
+export type FirstDisplayedItemsCount =
+    (typeof FirstDisplayedItemsCount)[keyof typeof FirstDisplayedItemsCount];
 
 /**
  * @deprecated

--- a/src/components/legacy/Popover/config.ts
+++ b/src/components/legacy/Popover/config.ts
@@ -1,8 +1,9 @@
-export enum PopoverBehavior {
-    Immediate = 'immediate',
-    Delayed = 'delayed',
-    DelayedClosing = 'delayedClosing',
-}
+export const PopoverBehavior = {
+    Immediate: 'immediate',
+    Delayed: 'delayed',
+    DelayedClosing: 'delayedClosing',
+} as const;
+export type PopoverBehavior = (typeof PopoverBehavior)[keyof typeof PopoverBehavior];
 
 export const delayByBehavior = {
     [PopoverBehavior.Immediate]: [0, 0],

--- a/src/components/legacy/Tabs/Tabs.tsx
+++ b/src/components/legacy/Tabs/Tabs.tsx
@@ -14,10 +14,11 @@ import './Tabs.scss';
 
 const b = block('tabs-legacy');
 
-export enum TabsDirection {
-    Horizontal = 'horizontal',
-    Vertical = 'vertical',
-}
+export const TabsDirection = {
+    Horizontal: 'horizontal',
+    Vertical: 'vertical',
+} as const;
+export type TabsDirection = (typeof TabsDirection)[keyof typeof TabsDirection];
 
 export type TabsSize = 'm' | 'l' | 'xl';
 

--- a/src/components/mobile/constants.ts
+++ b/src/components/mobile/constants.ts
@@ -1,10 +1,11 @@
 import {block} from '../utils/cn';
 
-export enum Platform {
-    IOS = 'ios',
-    ANDROID = 'android',
-    BROWSER = 'browser',
-}
+export const Platform = {
+    IOS: 'ios',
+    ANDROID: 'android',
+    BROWSER: 'browser',
+} as const;
+export type Platform = (typeof Platform)[keyof typeof Platform];
 
 const b = block('root');
 export const rootMobileClassName = b({mobile: true}).split(/\s+/)[1];

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,9 +1,10 @@
 import type {StringWithSuggest} from './types';
 
-export enum Lang {
-    Ru = 'ru',
-    En = 'en',
-}
+export const Lang = {
+    Ru: 'ru',
+    En: 'en',
+} as const;
+export type Lang = (typeof Lang)[keyof typeof Lang];
 
 interface Config {
     lang: StringWithSuggest<Lang>;


### PR DESCRIPTION
## Summary by Sourcery

Replace various TypeScript enums with "as const" object literals and corresponding union types, and enforce this pattern via ESLint.

Enhancements:
- Refactor legacy UI components and utilities (Breadcrumbs, Popover, mobile Platform, ColorPicker modes, Tabs direction, and Lang config) to use const objects and type unions instead of enums.
- Relax the @typescript-eslint/no-redeclare rule to allow paired value objects and type aliases in TypeScript files.

Build:
- Add a custom ESLint rule discouraging use of TypeScript enums in favor of union types or const objects.