### PR TITLE
docs(Popover): add migration guide

### DIFF
--- a/src/components/Popover/__stories__/Migration.stories.tsx
+++ b/src/components/Popover/__stories__/Migration.stories.tsx
@@ -1,0 +1,284 @@
+import * as React from 'react';
+
+import type {Meta, StoryObj} from '@storybook/react-webpack5';
+import {action} from 'storybook/actions';
+
+import {Alert} from '../../Alert';
+import {Button} from '../../Button';
+import {Text} from '../../Text';
+import {Flex} from '../../layout';
+import {Popover as LegacyPopover} from '../../legacy/Popover';
+import {Popover} from '../Popover';
+
+const meta: Meta = {
+    title: 'Components/Overlays/Popover/Legacy vs New',
+    parameters: {
+        layout: 'centered',
+    },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+function Column({label, children}: {label: string; children: React.ReactNode}) {
+    return (
+        <Flex direction="column" alignItems="center" gap={2}>
+            <div style={{fontWeight: 'bold'}}>{label}</div>
+            {children}
+        </Flex>
+    );
+}
+
+export const Default: Story = {
+    render: () => (
+        <Flex gap={8} alignItems="center">
+            <Column label="Legacy">
+                <LegacyPopover title="Title" content="Some text" theme="info">
+                    <Button>Hover me</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label="New">
+                <Popover
+                    content={
+                        <Alert
+                            theme="clear"
+                            title="Title"
+                            // title is set and theme !== "announcement" → dim the message
+                            message={<Text color="secondary">Some text</Text>}
+                        />
+                    }
+                    hasArrow
+                    placement={['right', 'bottom']}
+                    onOpenChange={action('onOpenChange')}
+                >
+                    <Button>Hover me</Button>
+                </Popover>
+            </Column>
+        </Flex>
+    ),
+};
+
+export const WithActionsAndClose: Story = {
+    render: () => (
+        <Flex gap={8} alignItems="center">
+            <Column label="Legacy">
+                <LegacyPopover
+                    title="Update available"
+                    content="A new version is ready to install."
+                    tooltipActionButton={{text: 'Update', onClick: action('legacy: update')}}
+                    tooltipCancelButton={{text: 'Dismiss', onClick: action('legacy: dismiss')}}
+                    hasClose
+                    onCloseClick={action('legacy: close')}
+                    theme="info"
+                    placement={['right', 'bottom']}
+                >
+                    <Button>Hover me</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label="New">
+                <Popover
+                    content={
+                        <Alert
+                            theme="clear"
+                            title="Update available"
+                            // title is set and theme was "info" (!== "announcement") → dim the message
+                            message={
+                                <Text color="secondary">A new version is ready to install.</Text>
+                            }
+                            // `{text, handler}` descriptors can't carry a per-button `view` —
+                            // use the `<Alert.Actions>` children form to match the legacy
+                            // "info" theme's button views (action: normal, cancel: flat).
+                            actions={
+                                <Alert.Actions>
+                                    <Alert.Action view="normal" onClick={action('new: update')}>
+                                        Update
+                                    </Alert.Action>
+                                    <Alert.Action view="flat" onClick={action('new: dismiss')}>
+                                        Dismiss
+                                    </Alert.Action>
+                                </Alert.Actions>
+                            }
+                            onClose={action('new: close')}
+                        />
+                    }
+                    hasArrow
+                    placement={['right', 'bottom']}
+                >
+                    <Button>Hover me</Button>
+                </Popover>
+            </Column>
+        </Flex>
+    ),
+};
+
+export const Themes: Story = {
+    render: () => (
+        <Flex gap={8} wrap justifyContent="center">
+            <Column label="Legacy: info">
+                <LegacyPopover
+                    content="Info tooltip"
+                    theme="info"
+                    placement="bottom"
+                    tooltipActionButton={{text: 'Action', onClick: action('legacy info: action')}}
+                    tooltipCancelButton={{text: 'Cancel', onClick: action('legacy info: cancel')}}
+                >
+                    <Button>info</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label="New: clear (closest match)">
+                <Popover
+                    content={
+                        <Alert
+                            theme="clear"
+                            message="Info tooltip"
+                            // legacy "info" theme button views: action=normal, cancel=flat
+                            actions={
+                                <Alert.Actions>
+                                    <Alert.Action
+                                        view="normal"
+                                        onClick={action('new info: action')}
+                                    >
+                                        Action
+                                    </Alert.Action>
+                                    <Alert.Action view="flat" onClick={action('new info: cancel')}>
+                                        Cancel
+                                    </Alert.Action>
+                                </Alert.Actions>
+                            }
+                        />
+                    }
+                    hasArrow
+                    placement="bottom"
+                >
+                    <Button>clear</Button>
+                </Popover>
+            </Column>
+            <Column label="Legacy: special">
+                <LegacyPopover
+                    content="Special tooltip"
+                    theme="special"
+                    placement="bottom"
+                    tooltipActionButton={{
+                        text: 'Action',
+                        onClick: action('legacy special: action'),
+                    }}
+                    tooltipCancelButton={{
+                        text: 'Cancel',
+                        onClick: action('legacy special: cancel'),
+                    }}
+                >
+                    <Button>special</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label="New: clear + brand background">
+                <Popover
+                    // set the surface color on Popup's own CSS var, not inside Alert
+                    style={{
+                        '--g-popup-background-color': 'var(--g-color-base-brand)',
+                        '--g-popup-border-color': 'var(--g-color-base-brand)',
+                    }}
+                    content={
+                        <Alert
+                            theme="clear"
+                            style={{color: 'var(--g-color-text-brand-contrast)'}}
+                            message="Special tooltip"
+                            // legacy "special" theme button views: action=normal-contrast, cancel=flat-contrast
+                            actions={
+                                <Alert.Actions>
+                                    <Alert.Action
+                                        view="normal-contrast"
+                                        onClick={action('new special: action')}
+                                    >
+                                        Action
+                                    </Alert.Action>
+                                    <Alert.Action
+                                        view="flat-contrast"
+                                        onClick={action('new special: cancel')}
+                                    >
+                                        Cancel
+                                    </Alert.Action>
+                                </Alert.Actions>
+                            }
+                        />
+                    }
+                    hasArrow
+                    placement="bottom"
+                >
+                    <Button>brand</Button>
+                </Popover>
+            </Column>
+            <Column label="Legacy: announcement">
+                <LegacyPopover
+                    content="Announcement tooltip"
+                    theme="announcement"
+                    placement="bottom"
+                    tooltipActionButton={{
+                        text: 'Action',
+                        onClick: action('legacy announcement: action'),
+                    }}
+                    tooltipCancelButton={{
+                        text: 'Cancel',
+                        onClick: action('legacy announcement: cancel'),
+                    }}
+                >
+                    <Button>announcement</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label="New: normal (no exact match)">
+                <Popover
+                    content={
+                        <Alert
+                            theme="normal"
+                            view="filled"
+                            message="Announcement tooltip (approx.)"
+                            // legacy "announcement" theme button views: action=normal-contrast, cancel=outlined
+                            actions={
+                                <Alert.Actions>
+                                    <Alert.Action
+                                        view="normal-contrast"
+                                        onClick={action('new announcement: action')}
+                                    >
+                                        Action
+                                    </Alert.Action>
+                                    <Alert.Action
+                                        view="outlined"
+                                        onClick={action('new announcement: cancel')}
+                                    >
+                                        Cancel
+                                    </Alert.Action>
+                                </Alert.Actions>
+                            }
+                        />
+                    }
+                    hasArrow
+                    placement="bottom"
+                >
+                    <Button>normal</Button>
+                </Popover>
+            </Column>
+        </Flex>
+    ),
+};
+
+export const ClickOnly: Story = {
+    render: () => (
+        <Flex gap={8} alignItems="center">
+            <Column label="Legacy: openOnHover={false}">
+                <LegacyPopover content="Click-only content" openOnHover={false} theme="info">
+                    <Button>Click me</Button>
+                </LegacyPopover>
+            </Column>
+            <Column label='New: trigger="click"'>
+                <Popover
+                    content={<Alert theme="clear" message="Click-only content" />}
+                    hasArrow
+                    trigger="click"
+                    placement={['right', 'bottom']}
+                >
+                    <Button>Click me</Button>
+                </Popover>
+            </Column>
+        </Flex>
+    ),
+};

--- a/src/components/Popover/migration-guide.md
+++ b/src/components/Popover/migration-guide.md
@@ -1,0 +1,151 @@
+# Migration from legacy Popover
+
+The legacy `Popover` (`@gravity-ui/uikit/legacy`) is a fully-styled tooltip/popover: it renders its own title, content, links, action/cancel buttons, close button and colored themes.
+
+The new `Popover` (`@gravity-ui/uikit`) is a thin, headless wrapper around [`Popup`](../Popup/README.md) — it only handles trigger interactivity (hover/click, delays, dismiss, focus) and renders whatever `content` you pass it, without any built-in title/buttons/theme styling.
+
+To reproduce the old look, render an [`Alert`](../Alert/README.md) as `content`. `Alert`'s `theme="clear"` is designed for exactly this: no background/border of its own (the new `Popover`/`Popup` already provides the surface), just a title/message/actions/close-button layout.
+
+## Quick example
+
+```diff
+- <Popover content="Some text" title="Title" theme="info">
+-   <Button>Trigger</Button>
+- </Popover>
++ <Popover
++   content={
++     <Alert
++       theme="clear"
++       title="Title"
++       // title is set and theme !== "announcement" → dim the message
++       message={<Text color="secondary">Some text</Text>}
++     />
++   }
++   hasArrow
++ >
++   <Button>Trigger</Button>
++ </Popover>
+```
+
+Note that `hasArrow` is set explicitly above.
+
+## Behavior and positioning props
+
+| Legacy                                                                      | New                                                         | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openOnHover`                                                               | `trigger` (`'all'` \| `'click'`)                            | `openOnHover={false}` → `trigger="click"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `behavior` + `delayOpening`/`delayClosing`                                  | `openDelay`/`closeDelay`                                    | Legacy enum: `immediate` = `[0, 0]`, `delayed` = `[300, 300]` (default), `delayedClosing` = `[0, 300]`. Only set `openDelay`/`closeDelay` explicitly if the legacy usage customized `behavior`/`delayOpening`/`delayClosing` away from the default — map the resulting `[open, close]` pair directly. If the legacy call never touched those props (just relied on the `"delayed"` default), prefer the new `Popover`'s own default (`openDelay=500`/`closeDelay=250`) instead of forcing `300`/`300` to match — there's nothing to preserve, and the new default is a reasonable one on its own |
+| `hasArrow` (default `true`)                                                 | `hasArrow` (default `false`)                                | same prop, opposite default — set explicitly to keep an arrow                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `placement` (default `['right', 'bottom']`, or `['left', 'bottom']` in RTL) | `placement` (default `'bottom'`, Floating UI's own default) | same prop, different default — set explicitly to keep the old position                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `tooltipOffset`                                                             | `offset`                                                    | same Floating UI offset concept                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `disablePortal`                                                             | `disablePortal`                                             | same                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `strategy`                                                                  | `strategy`                                                  | same                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `initialOpen` / imperative `ref`                                            | `open` + `onOpenChange`                                     | new `Popover` is always controlled/uncontrolled via `open`, no `initialOpen` — seed your own state to `true` if you need an initially-open popover                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `onOpenChange`                                                              | `onOpenChange`                                              | same name, new signature adds `(open, event, reason)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `disabled`                                                                  | `disabled`                                                  | same                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `focusTrap`                                                                 | `modal`                                                     | same concept (trap focus while open)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `autoFocus`                                                                 | `initialFocus={0}`                                          | roughly equivalent — focuses the first focusable element                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `restoreFocusRef`                                                           | `returnFocus`                                               | same concept, accepts a ref or a boolean                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `qa`                                                                        | `qa`                                                        | same, but is now passed straight to `Popup` instead of being suffixed with `-tooltip`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `className` (on the trigger wrapper `div`)                                  | apply to your trigger element directly                      | new `Popover` has no wrapper `div` — `children` itself receives the interaction props                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+
+## Props with no equivalent
+
+- **`anchorRef`/`anchorElement`** (detached/anchor-only mode, popover with no visible trigger child) — new `Popover` always requires a `children` trigger element to attach interaction props to. For a detached anchor, use [`Popup`](../Popup/README.md) directly — it already accepts `anchorElement`/`anchorRef` and needs no trigger.
+- **Imperative `ref`** (`openTooltip`/`closeTooltip`, `PopoverInstanceProps`) — new `Popover` exposes no ref API. Replace with a controlled `open` + `onOpenChange` state that you toggle yourself.
+- **`autoclosable={false}`** (stays open once hovered, only closes on an explicit trigger click) — no direct equivalent. Reproduce with controlled `open` state where your `onOpenChange` ignores hover-driven close events and only reacts to explicit close actions.
+- **`offset` (`{top, left, block, inline}`)** — this shifted the _trigger wrapper_ via inline style, not the popup itself. New `Popover` has no wrapper to apply this to — wrap your trigger element yourself with the desired offset instead.
+
+## Content props → `Alert`
+
+Render `<Alert theme="clear" ... />` as `content`. `Popup` already supplies the background/border/shadow/border-radius surface, so an `Alert` with its own filled/outlined surface would double it up — `theme="clear"` gives just padding and layout.
+
+| Legacy                                                               | `Alert` equivalent                                                                                                                                                                                                                                 |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title` (`string`)                                                   | `title`                                                                                                                                                                                                                                            |
+| `content` (`ReactNode`)                                              | `message` — dim it with `<Text color="secondary">` when `title` is set and `theme !== 'announcement'`, see note below                                                                                                                              |
+| `htmlContent` (raw HTML string)                                      | no direct equivalent — render it yourself, e.g. `message={<div dangerouslySetInnerHTML={{__html: htmlContent}} />}`                                                                                                                                |
+| `contentClassName`                                                   | `className` on the `Alert`                                                                                                                                                                                                                         |
+| `tooltipActionButton` + `tooltipCancelButton` (`{text, onClick}`)    | `actions={<Alert.Actions><Alert.Action view="..." onClick={...}>text</Alert.Action><Alert.Action view="..." onClick={...}>text</Alert.Action></Alert.Actions>}` — see note below                                                                   |
+| `links` (`{text, href, target, onClick}[]`) + `forceLinksAppearance` | no built-in equivalent — render your own links inside `message`                                                                                                                                                                                    |
+| `hasClose` + `onCloseClick`                                          | `onClose` — passing it automatically renders `Alert`'s own close button, no separate boolean needed                                                                                                                                                |
+| `size` (`'s'` \| `'l'`)                                              | `size` (`'s'` \| `'m'` \| `'l'`) — `'s'` → `'s'`, `'l'` → `'l'` is closest, but check padding: `--g-popover-padding`/`--g-popover-max-width` have no `Alert` equivalent, use `--g-alert-padding` or your own `style`/`className` for custom sizing |
+
+When a legacy tooltip had both a `title` and a `theme` other than `"announcement"`, its content was dimmed to a secondary color (`src/components/legacy/Popover/components/Content/Content.tsx`: `secondary={hasTitle ? theme !== 'announcement' : false}`, applied via `opacity: 0.7`). `Alert` doesn't dim `message` based on `title`/`theme` on its own, so wrap `message` in [`Text`](../Text/README.md) with `color="secondary"` yourself when that condition holds:
+
+```tsx
+<Alert theme="clear" title="Title" message={<Text color="secondary">Some text</Text>} />
+```
+
+`Alert`'s `actions` prop also accepts a plain `AlertAction[]` array of `{text, handler}` descriptors, which is simpler — but `AlertActions` only reads `text`/`handler` off each item, so there's no way to set a per-button `view` through that form. Legacy gave the action/cancel buttons a `view` that depended on `theme` (`src/components/legacy/Popover/components/Buttons/helpers/getButtonView.ts`), so reproducing the original look needs the `<Alert.Actions>`/`<Alert.Action view="...">` form with an explicit `view` per your legacy `theme`:
+
+| Legacy `theme`   | Action button `view` | Cancel button `view` |
+| ---------------- | -------------------- | -------------------- |
+| `info` (default) | `normal`             | `flat`               |
+| `special`        | `normal-contrast`    | `flat-contrast`      |
+| `announcement`   | `normal-contrast`    | `outlined`           |
+
+## Theme mapping (approximate)
+
+Legacy `theme`: `'info'` \| `'special'` \| `'announcement'`. `Alert` `theme`: `'normal'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` \| `'utility'` \| `'clear'`.
+
+- `theme="info"` (legacy default, plain surface) → `Alert theme="clear"`, relying on `Popup`'s own neutral surface. Closest match.
+- `theme="special"` (brand-colored solid surface) → keep `Alert theme="clear"` (layout only) and set the surface color on `Popup`'s own CSS variables — via `style` on the new `Popover`, not inside `Alert` — using the same variables legacy set for this theme:
+
+  ```tsx
+  <Popover
+    style={{
+      '--g-popup-background-color': 'var(--g-color-base-brand)',
+      '--g-popup-border-color': 'var(--g-color-base-brand)',
+    }}
+    content={<Alert theme="clear" style={{color: 'var(--g-color-text-brand-contrast)'}} ... />}
+    ...
+  >
+  ```
+
+  `--g-popup-background-color`/`--g-popup-border-color` are read by `Popup` itself (`src/components/Popup/Popup.scss`), the same way legacy's `.popover-legacy__tooltip_theme_special` set them on the tooltip root (`src/components/legacy/Popover/Popover.scss`) — setting them on `Alert` instead would only paint its own content box, not the actual `Popup` surface/border behind it. The text `color` override still belongs on the content (`Alert`/`Text`), since it's about the readability of what's drawn on top of that surface, not the surface itself — `--g-color-text-brand-contrast` (a real design token) is a safer choice than a hardcoded light color, since it already resolves to whichever of light/dark text reads better against `--g-color-base-brand` per theme. Action/cancel buttons still use the `normal-contrast`/`flat-contrast` views from the [button-view table above](#content-props--alert), which are already designed to read on a colored background.
+
+- `theme="announcement"` (dark solid surface with contrast buttons) has **no exact `Alert` equivalent** — none of `Alert`'s filled themes are that dark/neutral color. Either accept the closest palette-wise `Alert` theme (`normal`), or apply the same `Popover`-level `style` approach as `special` above using `var(--g-color-base-simple-hover-solid)` (the variable legacy used for this theme's `--g-popup-background-color`/`--g-popup-border-color`).
+
+## Full example
+
+```diff
+- <Popover
+-   title="Update available"
+-   content="A new version is ready to install."
+-   tooltipActionButton={{text: 'Update', onClick: handleUpdate}}
+-   tooltipCancelButton={{text: 'Dismiss', onClick: handleDismiss}}
+-   hasClose
+-   onCloseClick={handleClose}
+-   theme="info"
+-   placement={['right', 'bottom']}
+- >
+-   <Button>Trigger</Button>
+- </Popover>
++ <Popover
++   content={
++     <Alert
++       theme="clear"
++       title="Update available"
++       // title is set and theme was "info" (!== "announcement") → dim the message
++       message={<Text color="secondary">A new version is ready to install.</Text>}
++       // theme was "info" → action view="normal", cancel view="flat"
++       actions={
++         <Alert.Actions>
++           <Alert.Action view="normal" onClick={handleUpdate}>
++             Update
++           </Alert.Action>
++           <Alert.Action view="flat" onClick={handleDismiss}>
++             Dismiss
++           </Alert.Action>
++         </Alert.Actions>
++       }
++       onClose={handleClose}
++     />
++   }
++   hasArrow
++   placement={['right', 'bottom']}
++ >
++   <Button>Trigger</Button>
++ </Popover>
+```


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document how to migrate from the legacy Popover to the new Popover using Alert-based content, updated behavior props, and theme mappings.