### PR TITLE
feat(Tabs): add renderTabs for library-agnostic drag-and-drop

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -130,21 +130,105 @@ SANDBOX-->
 
 <!--/GITHUB_BLOCK-->
 
+### Drag and drop
+
+`TabList` stays drag-and-drop-library agnostic. The `renderTabs` prop is a seam: `TabList` computes
+the visible tabs itself (respecting `contentOverflow`, keeping the overflow **More** menu working) and
+hands them to you to wrap in the DnD library of your choice. Collapsed tabs are always rendered as plain
+`<Tab>` in the overflow menu and are not passed to `renderTabs`.
+
+Example with [`@hello-pangea/dnd`](https://github.com/hello-pangea/dnd):
+
+<!--GITHUB_BLOCK-->
+
+```tsx
+import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+
+// `renderTabs` receives only the visible tabs, so drag indexes are relative to them.
+// Capture the visible order and reorder by value on drop (works with `contentOverflow="collapse"` too).
+const shownValuesRef = React.useRef<string[]>([]);
+
+const onDragEnd = ({destination, draggableId}) => {
+  if (!destination) return;
+  const toValue = shownValuesRef.current[destination.index];
+  setTabs((prev) => reorder(prev, indexByValue(prev, draggableId), indexByValue(prev, toValue)));
+};
+
+<DragDropContext onDragEnd={onDragEnd}>
+  <Droppable droppableId="tabs" direction="horizontal">
+    {(droppableProvided) => (
+      <TabList
+        ref={droppableProvided.innerRef}
+        {...droppableProvided.droppableProps}
+        value={value}
+        onUpdate={setValue}
+        renderTabs={(shown) => {
+          shownValuesRef.current = shown.map((tab) => tab.props.value);
+          return (
+            <>
+              {shown.map((tab, index) => (
+                <Draggable
+                  key={tab.key}
+                  draggableId={String(tab.props.value)}
+                  index={index}
+                  // Tab renders an interactive <button>, and dnd blocks drag start from
+                  // interactive elements by default — opt out of that.
+                  disableInteractiveElementBlocking
+                >
+                  {(dragProvided) =>
+                    React.cloneElement(tab, {
+                      ref: dragProvided.innerRef,
+                      ...dragProvided.draggableProps,
+                      ...dragProvided.dragHandleProps,
+                    })
+                  }
+                </Draggable>
+              ))}
+              {droppableProvided.placeholder}
+            </>
+          );
+        }}
+      >
+        {tabs.map((tab) => (
+          <Tab key={tab.value} value={tab.value}>
+            {tab.title}
+          </Tab>
+        ))}
+      </TabList>
+    )}
+  </Droppable>
+</DragDropContext>;
+```
+
+<!--/GITHUB_BLOCK-->
+
+Notes:
+
+- `renderTabs` must return exactly one visible tab per received element, preserve each element's `key`,
+  and must not add extra DOM around a tab (a `.g-tab` must stay a direct child of the list). In
+  development, `TabList` warns if this contract is broken. This means only no-wrapper / render-prop DnD
+  libraries are supported (e.g. `@hello-pangea/dnd`, or `@dnd-kit`'s `useSortable` attached to the tab node).
+- `@hello-pangea/dnd` renders its placeholder with the same tag as the dragged item (a `<button>`), which
+  picks up default button styling. Reset it: `[data-rfd-placeholder-context-id] { appearance: none; border: 0; background: transparent; }`.
+- Reordering is pointer-driven; tab keyboard navigation (arrows / Home / End) is preserved. Keyboard-based
+  reordering is out of scope and would be owned by the DnD library.
+
 ### Properties
 
 `TabList` accepts any valid `div` element props in addition to these:
 
-| Name            | Description                                                                            |               Type               | Default  |
-| :-------------- | :------------------------------------------------------------------------------------- | :------------------------------: | :------: |
-| children        | List of tabs, probably with some wrappers                                              |        `React.ReactNode`         |          |
-| value           | Active tab value                                                                       |             `string`             |          |
-| onUpdate        | Update tab handler                                                                     |    `(value: string) => void`     |          |
-| className       | CSS-class of element                                                                   |             `string`             |          |
-| activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately   |            `boolean`             | `false`  |
-| size            | Element size                                                                           |        `"m"` `"l"` `"xl"`        |  `"m"`   |
-| contentOverflow | How to deal with items that do not fit horizontally (wrap, scroll, or a **More** menu) | `"wrap"` `"scroll"` `"collapse"` | `"wrap"` |
-| moreLabel       | Label for the collapse overflow trigger when the active tab is visible in the list     |        `React.ReactNode`         | `"More"` |
-| qa              | HTML `data-qa` attribute, used in tests                                                |             `string`             |          |
+| Name            | Description                                                                            |                       Type                        | Default  |
+| :-------------- | :------------------------------------------------------------------------------------- | :-----------------------------------------------: | :------: |
+| children        | List of tabs, probably with some wrappers                                              |                 `React.ReactNode`                 |          |
+| value           | Active tab value                                                                       |                     `string`                      |          |
+| onUpdate        | Update tab handler                                                                     |             `(value: string) => void`             |          |
+| className       | CSS-class of element                                                                   |                     `string`                      |          |
+| activateOnFocus | Activate tab on focus. Use this only if panel's content can be displayed immediately   |                     `boolean`                     | `false`  |
+| size            | Element size                                                                           |                `"m"` `"l"` `"xl"`                 |  `"m"`   |
+| contentOverflow | How to deal with items that do not fit horizontally (wrap, scroll, or a **More** menu) |         `"wrap"` `"scroll"` `"collapse"`          | `"wrap"` |
+| moreLabel       | Label for the collapse overflow trigger when the active tab is visible in the list     |                 `React.ReactNode`                 | `"More"` |
+| renderTabs      | Wraps the visible tabs, e.g. to enable drag-and-drop with any library (see below)      | `(tabs: React.ReactElement[]) => React.ReactNode` |          |
+| qa              | HTML `data-qa` attribute, used in tests                                                |                     `string`                      |          |
 
 ## Tab
 

--- a/src/components/tabs/TabList.tsx
+++ b/src/components/tabs/TabList.tsx
@@ -34,6 +34,7 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((rawProps,
         value,
         listRef,
         collapseEnabled,
+        Boolean(props.onCollapseUpdate),
     );
 
     const [isFocused, setIsFocused] = React.useState(false);
@@ -76,6 +77,14 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((rawProps,
             );
         }
     });
+
+    const {onCollapseUpdate} = props;
+    const visibleItemCount = shownChildren.length;
+    React.useEffect(() => {
+        if (collapseEnabled) {
+            onCollapseUpdate?.({visibleItemCount});
+        }
+    }, [collapseEnabled, onCollapseUpdate, visibleItemCount]);
 
     return (
         <TabContext.Provider value={innerContextValue}>

--- a/src/components/tabs/TabList.tsx
+++ b/src/components/tabs/TabList.tsx
@@ -4,8 +4,10 @@ import * as React from 'react';
 
 import {useFocusWithin, useForkRef, useUniqId} from '../../hooks';
 import {useDefaultProps} from '../theme/useDefaultProps';
+import {warnOnce} from '../utils/warn';
 
 import {TabListCollapseItem} from './TabListCollapseItem/TabListCollapseItem';
+import {bTab} from './constants';
 import {TabContext} from './contexts/TabContext';
 import {useTabList} from './hooks/useTabList';
 import {useTabListCollapsedChildren} from './hooks/useTabListCollapsedChildren';
@@ -51,12 +53,36 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((rawProps,
         [tabContext, value, props.onUpdate, id, isFocused],
     );
 
+    const {renderTabs} = props;
+    const {shownChildren} = collapsedChildrenResults;
+    const shownTabs = renderTabs ? renderTabs(shownChildren) : undefined;
+
+    // Dev-only validation of the `renderTabs` result: `warnOnce` already gates on
+    // NODE_ENV and dedupes. We check the actual DOM (the element tree can't be validated
+    // reliably — dnd libraries hide the `<Tab>` behind a render function).
+    React.useEffect(() => {
+        if (!renderTabs || !listRef.current) {
+            return;
+        }
+        const tabClassName = bTab();
+        const shownCount = Array.from(listRef.current.children).filter((child) =>
+            child.classList.contains(tabClassName),
+        ).length;
+        if (shownCount !== shownChildren.length) {
+            warnOnce(
+                'TabList: `renderTabs` must render exactly one visible tab per received element ' +
+                    '(preserve keys, no extra wrapper DOM around a tab). A wrapper element breaks ' +
+                    'the `contentOverflow="collapse"` measurement.',
+            );
+        }
+    });
+
     return (
         <TabContext.Provider value={innerContextValue}>
             <div ref={containerRef} {...tabListProps} {...focusWithinProps}>
                 {collapseEnabled ? (
                     <React.Fragment>
-                        {collapsedChildrenResults.shownChildren}
+                        {shownTabs ?? shownChildren}
                         <TabListCollapseItem
                             ref={collapsedChildrenResults.collapseItemRef}
                             triggerChild={collapsedChildrenResults.triggerChild}
@@ -67,7 +93,7 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>((rawProps,
                         </TabListCollapseItem>
                     </React.Fragment>
                 ) : (
-                    props.children
+                    (shownTabs ?? props.children)
                 )}
             </div>
         </TabContext.Provider>

--- a/src/components/tabs/__stories__/TabList.stories.tsx
+++ b/src/components/tabs/__stories__/TabList.stories.tsx
@@ -258,6 +258,79 @@ export const DragAndDropCollapse: Story = {
     },
 };
 
+/**
+ * Alternative approach (option B): instead of `renderTabs`, `TabList` reports how many tabs are
+ * visible via `onCollapseUpdate`, and the consumer wraps only the first N (`slice(0, count)`) into
+ * DnD, passing the rest as plain `<Tab>`.
+ *
+ * Trade-off to observe: `onCollapseUpdate` makes the collapse STRICT-PREFIX, so the active tab is
+ * NOT kept visible. Open "More" and pick a collapsed tab — it becomes active but stays inside the
+ * menu, and the strip shows no active indicator. (Compare with `DragAndDropCollapse` above, where
+ * the active tab is always visible.) The dnd placeholder is omitted here because in this approach it
+ * would be counted as a collapsed tab and inflate the "More" counter.
+ */
+const OnCollapseUpdateRender = (args: TabListProps) => {
+    const [tabs, setTabs] = React.useState<TabProps[]>(() => getTabsMock({}));
+    const [value, setValue] = React.useState(tabs[0].value);
+    const [visibleItemCount, setVisibleItemCount] = React.useState(tabs.length);
+
+    const onDragEnd = ({source, destination}: DropResult) => {
+        if (!destination) {
+            return;
+        }
+        setTabs((prev) => reorder(prev, source.index, destination.index));
+    };
+
+    const visibleTabs = tabs.slice(0, visibleItemCount);
+    const collapsedTabs = tabs.slice(visibleItemCount);
+
+    return (
+        <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="tab-list" direction="horizontal">
+                {(droppableProvided) => (
+                    <TabList
+                        {...args}
+                        ref={droppableProvided.innerRef}
+                        value={value}
+                        onUpdate={setValue}
+                        {...droppableProvided.droppableProps}
+                        onCollapseUpdate={({visibleItemCount: count}) => setVisibleItemCount(count)}
+                    >
+                        {visibleTabs.map((tab, index) => (
+                            <Draggable
+                                key={tab.value}
+                                draggableId={tab.value}
+                                index={index}
+                                disableInteractiveElementBlocking
+                            >
+                                {(draggableProvided) => (
+                                    <Tab
+                                        {...tab}
+                                        ref={draggableProvided.innerRef}
+                                        {...draggableProvided.draggableProps}
+                                        {...draggableProvided.dragHandleProps}
+                                    />
+                                )}
+                            </Draggable>
+                        ))}
+                        {collapsedTabs.map((tab) => (
+                            <Tab key={tab.value} {...tab} />
+                        ))}
+                    </TabList>
+                )}
+            </Droppable>
+        </DragDropContext>
+    );
+};
+
+export const OnCollapseUpdateDragAndDrop: Story = {
+    render: OnCollapseUpdateRender,
+    args: {
+        contentOverflow: 'collapse',
+        style: {maxWidth: 320},
+    },
+};
+
 export const Panels: Story = {
     render: (args) => {
         const tabs = getTabsMock({});

--- a/src/components/tabs/__stories__/TabList.stories.tsx
+++ b/src/components/tabs/__stories__/TabList.stories.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+import type {DropResult} from '@hello-pangea/dnd';
 import type {Meta, StoryObj} from '@storybook/react-webpack5';
 
 import {Showcase} from '../../../demo/Showcase';
@@ -9,7 +11,7 @@ import {Tab} from '../Tab';
 import {TabList} from '../TabList';
 import {TabPanel} from '../TabPanel';
 import {TabProvider} from '../TabProvider';
-import type {TabListProps} from '../types';
+import type {TabListProps, TabProps} from '../types';
 
 import {getTabsMock} from './getTabsMock';
 
@@ -145,6 +147,115 @@ export const ContentOverflow: Story = {
             ))}
         </Showcase>
     ),
+};
+
+function reorder<T>(list: T[], startIndex: number, endIndex: number): T[] {
+    const result = [...list];
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+}
+
+/**
+ * `renderTabs` is a library-agnostic seam: `TabList` computes the visible tabs (respecting
+ * `contentOverflow`) and hands them here to be wrapped in the DnD library of your choice.
+ * The collapsed tabs are still rendered as plain `<Tab>` in the overflow menu.
+ */
+const DragAndDropRender = (args: TabListProps) => {
+    const [tabs, setTabs] = React.useState<TabProps[]>(() => getTabsMock({}));
+    const [value, setValue] = React.useState(tabs[0].value);
+
+    // `renderTabs` receives only the visible tabs, so drag indexes are relative to them.
+    // Capture the visible order here and reorder by value on drop (works with `collapse` too).
+    const shownValuesRef = React.useRef<string[]>([]);
+
+    const onDragEnd = ({destination, draggableId}: DropResult) => {
+        if (!destination) {
+            return;
+        }
+        const toValue = shownValuesRef.current[destination.index];
+        setTabs((prev) => {
+            const from = prev.findIndex((tab) => tab.value === draggableId);
+            const to = prev.findIndex((tab) => tab.value === toValue);
+            return from === -1 || to === -1 ? prev : reorder(prev, from, to);
+        });
+    };
+
+    return (
+        <div className="tabs-dnd-story">
+            {/*
+              dnd renders `provided.placeholder` with the same tag as the dragged item.
+              Tab is a button, so the placeholder is a button too and picks up the
+              browser's default button styling (grey box + border) — reset it.
+            */}
+            <style>{`
+                .tabs-dnd-story [data-rfd-placeholder-context-id] {
+                    -webkit-appearance: none;
+                    appearance: none;
+                    border: 0;
+                    background: transparent;
+                    padding: 0;
+                }
+            `}</style>
+            <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable droppableId="tab-list" direction="horizontal">
+                    {(droppableProvided) => (
+                        <TabList
+                            {...args}
+                            ref={droppableProvided.innerRef}
+                            value={value}
+                            onUpdate={setValue}
+                            {...droppableProvided.droppableProps}
+                            renderTabs={(shown) => {
+                                shownValuesRef.current = shown.map(
+                                    (tab) => (tab.props as TabProps).value,
+                                );
+                                return (
+                                    <React.Fragment>
+                                        {shown.map((tab, index) => (
+                                            <Draggable
+                                                key={tab.key ?? index}
+                                                draggableId={String((tab.props as TabProps).value)}
+                                                index={index}
+                                                // Tab renders an interactive button/link, and dnd
+                                                // blocks drag start from interactive elements.
+                                                disableInteractiveElementBlocking
+                                            >
+                                                {(draggableProvided) =>
+                                                    React.cloneElement(tab, {
+                                                        ref: draggableProvided.innerRef,
+                                                        ...draggableProvided.draggableProps,
+                                                        ...draggableProvided.dragHandleProps,
+                                                    } as Partial<TabProps> & React.Attributes)
+                                                }
+                                            </Draggable>
+                                        ))}
+                                        {droppableProvided.placeholder}
+                                    </React.Fragment>
+                                );
+                            }}
+                        >
+                            {tabs.map((tab) => (
+                                <Tab key={tab.value} {...tab} />
+                            ))}
+                        </TabList>
+                    )}
+                </Droppable>
+            </DragDropContext>
+        </div>
+    );
+};
+
+export const DragAndDrop: Story = {
+    render: DragAndDropRender,
+};
+
+export const DragAndDropCollapse: Story = {
+    render: DragAndDropRender,
+    args: {
+        contentOverflow: 'collapse',
+        style: {maxWidth: 400},
+    },
 };
 
 export const Panels: Story = {

--- a/src/components/tabs/__tests__/TabList.test.tsx
+++ b/src/components/tabs/__tests__/TabList.test.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
+
 import userEvent from '@testing-library/user-event';
 
 import {Tab, TabList} from '..';
-import {act, render, screen} from '../../../../test-utils/utils';
+import {act, render, screen, within} from '../../../../test-utils/utils';
 import {KeyCode} from '../../../constants';
 import type {TabSize} from '../types';
 
@@ -405,4 +407,124 @@ test('contentOverflow collapse: with narrow container and single tab does not re
     expect(screen.getByTestId(tab1.qa)).toBeVisible();
 
     spy.mockRestore();
+});
+
+// `renderTabs` wraps only the visible tabs (e.g. for drag-and-drop) while the collapse split
+// still runs on the raw <Tab> children. It appends an extra node (like a dnd placeholder) that
+// must NOT be counted as a tab.
+const withPlaceholder = (tabs: React.ReactElement[]) => (
+    <React.Fragment>
+        {tabs}
+        <button key="__placeholder" data-rfd-placeholder-context-id="test" aria-hidden />
+    </React.Fragment>
+);
+
+test('renderTabs: appended node is not counted, no phantom More when everything fits', () => {
+    const spy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+        this: Element,
+    ) {
+        if (this.classList.contains('g-tab-list')) return makeDOMRect(1000);
+        if (this.classList.contains('g-tab-list-collapse-item')) return makeDOMRect(80);
+        return makeDOMRect(100);
+    });
+
+    render(
+        <TabList contentOverflow="collapse" value={tab1.value} renderTabs={withPlaceholder}>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    expect(screen.queryByRole('button', {name: /more/i})).not.toBeInTheDocument();
+    expect(screen.getByTestId(tab1.qa)).toBeVisible();
+    expect(screen.getByTestId(tab3.qa)).toBeVisible();
+
+    spy.mockRestore();
+});
+
+test('renderTabs: overflow count excludes the appended node and menu keeps collapsed tabs', async () => {
+    const user = userEvent.setup();
+    // Container 280px: More(80) + Tab1(100) + Tab2(100) = 280 fits, Tab3 overflows.
+    const spy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+        this: Element,
+    ) {
+        if (this.classList.contains('g-tab-list')) return makeDOMRect(280);
+        if (this.classList.contains('g-tab-list-collapse-item')) return makeDOMRect(80);
+        return makeDOMRect(100);
+    });
+
+    render(
+        <TabList contentOverflow="collapse" value={tab1.value} renderTabs={withPlaceholder}>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+            <Tab value={tab3.value} qa={tab3.qa}>
+                {tab3.title}
+            </Tab>
+        </TabList>,
+    );
+
+    const trigger = screen.getByRole('button', {name: /more/i});
+    // Only Tab3 is collapsed — the appended placeholder is not counted.
+    expect(within(trigger).getByText('1')).toBeInTheDocument();
+
+    await user.click(trigger);
+    // The collapsed tab is rendered in the menu (raw <Tab> stays reachable through the split).
+    expect(await screen.findByText(tab3.title)).toBeVisible();
+
+    spy.mockRestore();
+});
+
+test('renderTabs: preserves tab a11y (role, aria-selected, roving tabIndex)', () => {
+    render(
+        <TabList value={tab2.value} renderTabs={(tabs) => tabs}>
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+        </TabList>,
+    );
+
+    const t1 = screen.getByTestId(tab1.qa);
+    const t2 = screen.getByTestId(tab2.qa);
+
+    expect(t1).toHaveAttribute('role', 'tab');
+    expect(t2).toHaveAttribute('role', 'tab');
+    expect(t2).toHaveAttribute('aria-selected', 'true');
+    expect(t2).toHaveAttribute('tabindex', '0');
+    expect(t1).toHaveAttribute('tabindex', '-1');
+});
+
+test('renderTabs: warns in dev when a tab is wrapped in extra DOM', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+        <TabList
+            value={tab1.value}
+            renderTabs={(tabs) => tabs.map((tab, i) => <span key={tab.key ?? i}>{tab}</span>)}
+        >
+            <Tab value={tab1.value} qa={tab1.qa}>
+                {tab1.title}
+            </Tab>
+            <Tab value={tab2.value} qa={tab2.qa}>
+                {tab2.title}
+            </Tab>
+        </TabList>,
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('renderTabs'));
+
+    errorSpy.mockRestore();
 });

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -120,6 +120,7 @@ export function useTabList(
         qa: _qa,
         contentOverflow,
         moreLabel: _moreLabel,
+        renderTabs: _renderTabs,
         ...htmlProps
     } = tabListProps;
 

--- a/src/components/tabs/hooks/useTabList.ts
+++ b/src/components/tabs/hooks/useTabList.ts
@@ -121,6 +121,7 @@ export function useTabList(
         contentOverflow,
         moreLabel: _moreLabel,
         renderTabs: _renderTabs,
+        onCollapseUpdate: _onCollapseUpdate,
         ...htmlProps
     } = tabListProps;
 

--- a/src/components/tabs/hooks/useTabListCollapsedChildren.ts
+++ b/src/components/tabs/hooks/useTabListCollapsedChildren.ts
@@ -23,6 +23,9 @@ export const useTabListCollapsedChildren = (
     tabListValue: string | undefined,
     containerRef: React.RefObject<HTMLElement>,
     enabled: boolean,
+    // In `sortable` mode the visible set is a strict prefix (the active tab is NOT force-kept
+    // visible), so a consumer can wrap exactly `slice(0, visibleItemCount)` tabs for drag-and-drop.
+    sortable = false,
 ): UseTabListCollapsedChildrenResult => {
     const collapseItemRef = React.useRef<HTMLButtonElement>(null);
 
@@ -92,7 +95,7 @@ export const useTabListCollapsedChildren = (
         };
     }
 
-    if (visibleChildrenCount === 0) {
+    if (!sortable && visibleChildrenCount === 0) {
         const selectedChild =
             childrenList.find((child) => !isReactNodeCollapsible(child)) ?? childrenList[0];
         const otherChildren = childrenList.filter((c) => c !== selectedChild);
@@ -127,7 +130,9 @@ export const useTabListCollapsedChildren = (
         };
     }
 
-    const notCollapsibleChildren = childrenList.filter((child) => !isReactNodeCollapsible(child));
+    const notCollapsibleChildren = sortable
+        ? []
+        : childrenList.filter((child) => !isReactNodeCollapsible(child));
 
     const shownChildren: typeof childrenList = [];
     const collapsedChildren: typeof childrenList = [];
@@ -135,7 +140,7 @@ export const useTabListCollapsedChildren = (
     let reservedToShowChildrenCount = notCollapsibleChildren.length;
 
     childrenList.forEach((child) => {
-        if (!isReactNodeCollapsible(child)) {
+        if (!sortable && !isReactNodeCollapsible(child)) {
             shownChildren.push(child);
             reservedToShowChildrenCount--;
             return;

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -32,6 +32,13 @@ export interface TabListProps
      * tab (a `.g-tab` must stay a direct child of the list, otherwise overflow measurement breaks).
      */
     renderTabs?: (tabs: React.ReactElement[]) => React.ReactNode;
+    /**
+     * Called when the number of visible (non-collapsed) tabs changes, e.g. on resize. Lets a
+     * consumer wrap only the currently visible tabs into a drag-and-drop library and render the
+     * rest as plain `<Tab>` (which `TabList` collapses into the overflow menu). Only fires when
+     * `contentOverflow="collapse"`.
+     */
+    onCollapseUpdate?: (payload: {visibleItemCount: number}) => void;
 }
 
 interface TabCommonProps extends QAProps, DOMProps {

--- a/src/components/tabs/types.ts
+++ b/src/components/tabs/types.ts
@@ -23,6 +23,15 @@ export interface TabListProps
     moreLabel?: React.ReactNode;
     activateOnFocus?: boolean;
     children?: React.ReactNode;
+    /**
+     * Wraps the already-computed visible tabs, e.g. to enable drag-and-drop with any library.
+     * Called in both `contentOverflow` modes with the post-collapse visible tabs; collapsed tabs
+     * are always rendered as raw `<Tab>` in the overflow menu and are NOT passed here.
+     *
+     * The returned tree MUST preserve each element's `key` and MUST NOT add wrapper DOM around a
+     * tab (a `.g-tab` must stay a direct child of the list, otherwise overflow measurement breaks).
+     */
+    renderTabs?: (tabs: React.ReactElement[]) => React.ReactNode;
 }
 
 interface TabCommonProps extends QAProps, DOMProps {


### PR DESCRIPTION
> 🤖 AI generated

Add a `renderTabs` prop to `TabList` — a small, drag-and-drop-library-agnostic seam that lets consumers wrap the visible tabs in any DnD library, including with `contentOverflow="collapse"`.

### Why
Wrapping tabs in a DnD library externally breaks with `contentOverflow="collapse"`: the collapse split runs on the raw `<Tab>` children, so `<Draggable>` wrappers (which hide the `<Tab>` behind a render function) plus the extra dnd placeholder node get miscounted — phantom "More", wrong collapsed count, and an empty overflow menu.

### Approach
`TabList` keeps computing the shown/collapsed split from the raw `<Tab>` children and hands only the already-computed **visible** tabs to `renderTabs`. Collapsed tabs stay plain `<Tab>` in the overflow menu. No DnD-library types leak into the component.

```ts
renderTabs?: (tabs: React.ReactElement[]) => React.ReactNode;
```

- Works in both `contentOverflow` modes; the collapse **More** menu keeps working.
- Consumer wraps each visible tab in their lib's draggable (no wrapper DOM) and renders the placeholder inside `renderTabs`.
- A dev-only check warns if the result breaks the contract (extra wrapper DOM / dropped tab).
- Tab a11y (role, roving tabIndex, arrow navigation) is preserved; keyboard reordering stays with the DnD library.

Prior art: this mirrors Ant Design's `renderTabBar` escape hatch; no major library bakes DnD into tabs.

Stories `DragAndDrop` / `DragAndDropCollapse` (with `@hello-pangea/dnd`) demonstrate it.

Tests and README docs will follow once the approach is agreed.

## Summary by Sourcery

Add a renderTabs escape hatch to TabList to support library-agnostic wrapping of visible tabs, including under collapsed overflow, with a dev-time contract check and Storybook demos using drag-and-drop.

New Features:
- Introduce an optional renderTabs prop on TabList to allow consumers to wrap the already-computed visible tabs, including when contentOverflow="collapse" is enabled.

Enhancements:
- Add a dev-only DOM-based validation that warns if renderTabs breaks the one-tab-per-child contract required for correct overflow measurement.

Tests:
- Add Storybook examples demonstrating TabList integrated with @hello-pangea/dnd in both normal and contentOverflow="collapse" modes for drag-and-drop reordering of tabs.