### PR TITLE
fix(Label): type copy + onClick

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -204,7 +204,7 @@ export const Label = React.forwardRef(function Label(
         );
     };
 
-    if (hasCopy && copyText && !hasOnClick) {
+    if (hasCopy && copyText) {
         return (
             <CopyToClipboard text={copyText} onCopy={onCopy} timeout={1000}>
                 {(status) => renderLabel(status)}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix label copy behavior so that copy-to-clipboard works whenever copy text is provided, regardless of onClick usage.