### PR TITLE
feat(lab): add useListState headless core

### DIFF
--- a/src/components/lab/List/core/README.md
+++ b/src/components/lab/List/core/README.md
@@ -7,8 +7,9 @@ component API.
 ## useListState
 
 Normalizes `items` (objects or plain strings) into a flat structural index — id, level, parent,
-children ids and disabled state per node — and derives the ordered `visibleIds` slice from the
-current expansion. Expansion is controlled when `expandedIds` is passed, uncontrolled otherwise.
+children ids, disabled state and structural type (`item` / `section`) per node — and derives the
+ordered `visibleIds` slice from the current expansion. Expansion is controlled when `expandedIds` is
+passed, uncontrolled otherwise.
 
 The index is rebuilt on each new `items` reference, reusing unchanged subtrees so getters run
 only for changed nodes. Structural getters must be pure functions of the item — pass a new
@@ -26,6 +27,7 @@ only for changed nodes. Structural getters must be pure functions of the item �
 | getItemDisabled      | Derives disabled state                      | `(item: T) => boolean`                        | `(i) => Boolean(i.disabled)` |
 | getItemId            | Derives a node id                           | `(item: T) => string`                         | `(i) => i.id`                |
 | getItemTextValue     | Text value for typeahead and screen readers | `(item: T) => string`                         | content, if a plain string   |
+| getItemType          | Structural role — `item` or `section` label | `(item: T) => 'item' \| 'section'`            | `(i) => 'item'`              |
 | items                | Source data — objects or plain strings      | `T[]`                                         |                              |
 | onExpandedUpdate     | Called when expansion changes               | `(ids: string[]) => void`                     |                              |
 
@@ -44,6 +46,7 @@ and screen readers have no text to work with.
 | getChildrenIds   | Loaded child ids (`[]` empty folder, `undefined` leaf or unloaded) | `(id: string) => string[] \| undefined`          |
 | getChildrenState | Async subtree state                                                | `(id: string) => ListChildrenState \| undefined` |
 | getItemById      | Source item for an id                                              | `(id: string) => T \| undefined`                 |
+| getItemType      | Structural role — `item` or non-interactive `section` label        | `(id: string) => 'item' \| 'section'`            |
 | getLevel         | Nesting depth (`0` for roots)                                      | `(id: string) => number`                         |
 | getParentId      | Parent id, or `undefined` for roots                                | `(id: string) => string \| undefined`            |
 | isDisabled       | Whether a node is disabled                                         | `(id: string) => boolean`                        |

--- a/src/components/lab/List/core/README.md
+++ b/src/components/lab/List/core/README.md
@@ -1,0 +1,52 @@
+# List core (headless)
+
+Headless building blocks of the `List` / `TreeList` / `GridList` family — state, selection and
+behavior hooks for component authors (Select, custom assemblies). Regular consumers use the
+component API.
+
+## useListState
+
+Normalizes `items` (objects or plain strings) into a flat structural index — id, level, parent,
+children ids and disabled state per node — and derives the ordered `visibleIds` slice from the
+current expansion. Expansion is controlled when `expandedIds` is passed, uncontrolled otherwise.
+
+The index is rebuilt on each new `items` reference, reusing unchanged subtrees so getters run
+only for changed nodes. Structural getters must be pure functions of the item — pass a new
+`items` reference to apply data changes.
+
+### Properties
+
+| Name                 | Description                                 | Type                                          | Default                      |
+| :------------------- | :------------------------------------------ | :-------------------------------------------- | :--------------------------- |
+| defaultExpandedIds   | Initially expanded node ids (uncontrolled)  | `string[]`                                    | `[]`                         |
+| expandedIds          | Expanded node ids (controlled)              | `string[]`                                    |                              |
+| getItemChildren      | Derives child nodes                         | `(item: T) => T[] \| undefined`               | `(i) => i.children`          |
+| getItemChildrenState | Derives async subtree state                 | `(item: T) => ListChildrenState \| undefined` | `(i) => i.childrenState`     |
+| getItemContent       | Renderable content for a node               | `(item: T) => C`                              |                              |
+| getItemDisabled      | Derives disabled state                      | `(item: T) => boolean`                        | `(i) => Boolean(i.disabled)` |
+| getItemId            | Derives a node id                           | `(item: T) => string`                         | `(i) => i.id`                |
+| getItemTextValue     | Text value for typeahead and screen readers | `(item: T) => string`                         | content, if a plain string   |
+| items                | Source data — objects or plain strings      | `T[]`                                         |                              |
+| onExpandedUpdate     | Called when expansion changes               | `(ids: string[]) => void`                     |                              |
+
+For primitive string items every default closes over the string itself (id, text and content),
+so no getters are needed; strings must be unique, otherwise `getItemId` is required.
+`getItemTextValue` falls back to the item content only when that content is a plain string —
+provide it explicitly when the content is richer, otherwise there is no default and typeahead
+and screen readers have no text to work with.
+
+### Returns
+
+`useListState` returns a `ListState<T>` object:
+
+| Name             | Description                                                        | Type                                             |
+| :--------------- | :----------------------------------------------------------------- | :----------------------------------------------- |
+| getChildrenIds   | Loaded child ids (`[]` empty folder, `undefined` leaf or unloaded) | `(id: string) => string[] \| undefined`          |
+| getChildrenState | Async subtree state                                                | `(id: string) => ListChildrenState \| undefined` |
+| getItemById      | Source item for an id                                              | `(id: string) => T \| undefined`                 |
+| getLevel         | Nesting depth (`0` for roots)                                      | `(id: string) => number`                         |
+| getParentId      | Parent id, or `undefined` for roots                                | `(id: string) => string \| undefined`            |
+| isDisabled       | Whether a node is disabled                                         | `(id: string) => boolean`                        |
+| isExpanded       | Whether a node is expanded                                         | `(id: string) => boolean`                        |
+| setExpanded      | Expands or collapses a node; emits `onExpandedUpdate`              | `(id: string, expanded: boolean) => void`        |
+| visibleIds       | Ordered ids of the currently visible (expanded) nodes              | `string[]`                                       |

--- a/src/components/lab/List/core/index.ts
+++ b/src/components/lab/List/core/index.ts
@@ -1,0 +1,3 @@
+export {useListState} from './useListState';
+export type {ListState, UseListStateProps} from './useListState';
+export type {ListChildrenState, ListItemGetters} from './types';

--- a/src/components/lab/List/core/index.ts
+++ b/src/components/lab/List/core/index.ts
@@ -1,3 +1,3 @@
 export {useListState} from './useListState';
 export type {ListState, UseListStateProps} from './useListState';
-export type {ListChildrenState, ListItemGetters} from './types';
+export type {ListChildrenState, ListItemGetters, ListItemType} from './types';

--- a/src/components/lab/List/core/types.ts
+++ b/src/components/lab/List/core/types.ts
@@ -1,0 +1,53 @@
+/**
+ * State of an asynchronous subtree. Resolves the ambiguity of `getItemChildren` returning
+ * `undefined` — a tree leaf versus a folder whose children are not loaded yet.
+ *
+ * - `lazy` — children exist but are not loaded; the first expand triggers a load;
+ * - `loading` — children are being loaded (placeholders + `aria-busy`);
+ * - `loaded` — the default; synchronous trees never need it;
+ * - `canLoadMore` — children are partially loaded (a load-more sentinel).
+ *
+ * Lives in consumer data (`item.childrenState` by default): load status is inseparable from the
+ * consumer's fetches / cache / errors, so the core only reads it.
+ */
+export type ListChildrenState = 'loaded' | 'loading' | 'lazy' | 'canLoadMore';
+
+/**
+ * Data getters. Each has a "read from the item" default, so the minimal case needs none of them;
+ * for primitive string items the defaults close over the string itself.
+ */
+export interface ListItemGetters<T, C = unknown> {
+    /**
+     * Derives a stable, unique id for an item.
+     * @default (item) => item.id — a string item is its own id
+     */
+    getItemId?: (item: T) => string;
+    /**
+     * Derives the child items of a node. Read together with `childrenState`: `undefined` is a
+     * leaf or an unloaded folder, `[]` is a loaded empty folder.
+     * @default (item) => item.children
+     */
+    getItemChildren?: (item: T) => T[] | undefined;
+    /**
+     * Derives whether an item is disabled.
+     * @default (item) => Boolean(item.disabled)
+     */
+    getItemDisabled?: (item: T) => boolean;
+    /**
+     * Derives the async subtree state of an item.
+     * @default (item) => item.childrenState
+     */
+    getItemChildrenState?: (item: T) => ListChildrenState | undefined;
+    /**
+     * Derives the text value used for typeahead and screen-reader announcements. Defaults to the
+     * item content only when that content is a plain string; there is no default for richer
+     * content, so provide this getter when the content is not plain text.
+     * @default the item content, when it is a plain string
+     */
+    getItemTextValue?: (item: T) => string;
+    /**
+     * Derives the renderable content of an item. The only getter without a default, so data
+     * fields never leak into rendering implicitly; `C` is inferred from the return value.
+     */
+    getItemContent?: (item: T) => C;
+}

--- a/src/components/lab/List/core/types.ts
+++ b/src/components/lab/List/core/types.ts
@@ -13,6 +13,19 @@
 export type ListChildrenState = 'loaded' | 'loading' | 'lazy' | 'canLoadMore';
 
 /**
+ * Structural role of a node.
+ *
+ * - `item` — a selectable, navigable row (the default);
+ * - `section` — a non-interactive group label: skipped by selection and keyboard navigation, but
+ * its children are laid out and expand like any other node.
+ *
+ * Marked explicitly by the list author (`getItemType`) rather than inferred, so the selection layer
+ * stays role-independent — a "leaf is an option, node with children is a section header" rule holds
+ * only for `listbox`, and would misclassify a `tree` folder.
+ */
+export type ListItemType = 'item' | 'section';
+
+/**
  * Data getters. Each has a "read from the item" default, so the minimal case needs none of them;
  * for primitive string items the defaults close over the string itself.
  */
@@ -45,6 +58,15 @@ export interface ListItemGetters<T, C = unknown> {
      * @default the item content, when it is a plain string
      */
     getItemTextValue?: (item: T) => string;
+    /**
+     * Derives the structural role of an item: a selectable, navigable `item` (the default) or a
+     * non-interactive `section` label. Governs selection and keyboard navigation — not disclosure:
+     * a `section` may still hold children and expand like any other node. Lets a list author mark
+     * group headers explicitly, so selection stays role-independent (a leaf-vs-header rule would be
+     * `listbox`-only, and the selection layer has no role).
+     * @default (item) => 'item'
+     */
+    getItemType?: (item: T) => ListItemType;
     /**
      * Derives the renderable content of an item. The only getter without a default, so data
      * fields never leak into rendering implicitly; `C` is inferred from the return value.

--- a/src/components/lab/List/core/useListState/__tests__/useListState.test.tsx
+++ b/src/components/lab/List/core/useListState/__tests__/useListState.test.tsx
@@ -5,6 +5,7 @@ import {useListState} from '../useListState';
 interface Node {
     id: string;
     disabled?: boolean;
+    group?: boolean;
     children?: Node[];
     childrenState?: ListChildrenState;
 }
@@ -56,6 +57,59 @@ describe('lab/List core: useListState', () => {
             expect(result.current.visibleIds).toEqual(['x', 'y']);
             expect(result.current.isDisabled('x')).toBe(true);
             expect(result.current.isDisabled('y')).toBe(false);
+        });
+    });
+
+    describe('item type (item / section)', () => {
+        it('defaults every node to item', () => {
+            const {result} = renderHook(() => useListState({items: tree}));
+            expect(result.current.getItemType('root')).toBe('item');
+            expect(result.current.getItemType('c1')).toBe('item');
+        });
+
+        it('defaults to item for primitive string items and unknown ids', () => {
+            const {result} = renderHook(() => useListState({items: ['Apple']}));
+            expect(result.current.getItemType('Apple')).toBe('item');
+            expect(result.current.getItemType('missing')).toBe('item');
+        });
+
+        it('honors a custom getItemType', () => {
+            const items: Node[] = [
+                {id: 'sec', group: true, children: [{id: 'opt'}]},
+                {id: 'plain'},
+            ];
+            const {result} = renderHook(() =>
+                useListState({
+                    items,
+                    defaultExpandedIds: ['sec'],
+                    getItemType: (node) => (node.group ? 'section' : 'item'),
+                }),
+            );
+
+            // A section keeps its structure and expansion — only its role differs.
+            expect(result.current.getItemType('sec')).toBe('section');
+            expect(result.current.getItemType('opt')).toBe('item');
+            expect(result.current.getItemType('plain')).toBe('item');
+            expect(result.current.getChildrenIds('sec')).toEqual(['opt']);
+            expect(result.current.visibleIds).toEqual(['sec', 'opt', 'plain']);
+        });
+
+        it('reuses type on an unchanged subtree without recomputing', () => {
+            const stable: Node = {id: 'sec', group: true, children: [{id: 'opt'}]};
+            const getItemType = jest.fn(
+                (node: Node) => (node.group ? 'section' : 'item') as 'item' | 'section',
+            );
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items, getItemType}),
+                {initialProps: {items: [stable, {id: 'x'}] as Node[]}},
+            );
+
+            const callsAfterMount = getItemType.mock.calls.length;
+            rerender({items: [stable, {id: 'y'}]});
+
+            expect(result.current.getItemType('sec')).toBe('section');
+            // Only the new node `y` is rebuilt; the stable section subtree is copied by reference.
+            expect(getItemType.mock.calls.length - callsAfterMount).toBe(1);
         });
     });
 

--- a/src/components/lab/List/core/useListState/__tests__/useListState.test.tsx
+++ b/src/components/lab/List/core/useListState/__tests__/useListState.test.tsx
@@ -1,0 +1,391 @@
+import {act, renderHook} from '../../../../../../../test-utils/utils';
+import type {ListChildrenState} from '../../types';
+import {useListState} from '../useListState';
+
+interface Node {
+    id: string;
+    disabled?: boolean;
+    children?: Node[];
+    childrenState?: ListChildrenState;
+}
+
+const tree: Node[] = [
+    {
+        id: 'root',
+        children: [{id: 'c1'}, {id: 'c2', children: [{id: 'gc1'}]}],
+    },
+    {id: 'sibling'},
+];
+
+describe('lab/List core: useListState', () => {
+    describe('normalization', () => {
+        it('handles primitive string items with zero getters', () => {
+            const {result} = renderHook(() => useListState({items: ['Apple', 'Pear', 'Plum']}));
+
+            expect(result.current.visibleIds).toEqual(['Apple', 'Pear', 'Plum']);
+            expect(result.current.getItemById('Apple')).toBe('Apple');
+            expect(result.current.getLevel('Apple')).toBe(0);
+            expect(result.current.getParentId('Apple')).toBeUndefined();
+            expect(result.current.getChildrenIds('Apple')).toBeUndefined();
+            expect(result.current.isDisabled('Apple')).toBe(false);
+        });
+
+        it('reads object defaults (id, disabled) from the item', () => {
+            const items: Node[] = [{id: 'a'}, {id: 'b', disabled: true}];
+            const {result} = renderHook(() => useListState({items}));
+
+            expect(result.current.visibleIds).toEqual(['a', 'b']);
+            expect(result.current.getItemById('b')).toBe(items[1]);
+            expect(result.current.isDisabled('a')).toBe(false);
+            expect(result.current.isDisabled('b')).toBe(true);
+        });
+
+        it('honors custom getters', () => {
+            const items = [
+                {key: 'x', off: true},
+                {key: 'y', off: false},
+            ];
+            const {result} = renderHook(() =>
+                useListState({
+                    items,
+                    getItemId: (i) => i.key,
+                    getItemDisabled: (i) => i.off,
+                }),
+            );
+
+            expect(result.current.visibleIds).toEqual(['x', 'y']);
+            expect(result.current.isDisabled('x')).toBe(true);
+            expect(result.current.isDisabled('y')).toBe(false);
+        });
+    });
+
+    describe('structure indexes', () => {
+        it('computes level / parentId / childrenIds', () => {
+            const {result} = renderHook(() => useListState({items: tree}));
+
+            expect(result.current.getLevel('root')).toBe(0);
+            expect(result.current.getLevel('c2')).toBe(1);
+            expect(result.current.getLevel('gc1')).toBe(2);
+
+            expect(result.current.getParentId('root')).toBeUndefined();
+            expect(result.current.getParentId('c2')).toBe('root');
+            expect(result.current.getParentId('gc1')).toBe('c2');
+
+            expect(result.current.getChildrenIds('root')).toEqual(['c1', 'c2']);
+            expect(result.current.getChildrenIds('c2')).toEqual(['gc1']);
+            expect(result.current.getChildrenIds('c1')).toBeUndefined();
+        });
+    });
+
+    describe('visibleIds & expansion', () => {
+        it('shows only roots when collapsed', () => {
+            const {result} = renderHook(() => useListState({items: tree}));
+            expect(result.current.visibleIds).toEqual(['root', 'sibling']);
+        });
+
+        it('expands and collapses (uncontrolled)', () => {
+            const {result} = renderHook(() => useListState({items: tree, defaultExpandedIds: []}));
+
+            act(() => result.current.setExpanded('root', true));
+            expect(result.current.visibleIds).toEqual(['root', 'c1', 'c2', 'sibling']);
+
+            act(() => result.current.setExpanded('c2', true));
+            expect(result.current.visibleIds).toEqual(['root', 'c1', 'c2', 'gc1', 'sibling']);
+
+            act(() => result.current.setExpanded('root', false));
+            expect(result.current.visibleIds).toEqual(['root', 'sibling']);
+        });
+
+        it('starts expanded from defaultExpandedIds', () => {
+            const {result} = renderHook(() =>
+                useListState({items: tree, defaultExpandedIds: ['root']}),
+            );
+            expect(result.current.visibleIds).toEqual(['root', 'c1', 'c2', 'sibling']);
+            expect(result.current.isExpanded('root')).toBe(true);
+            expect(result.current.isExpanded('c2')).toBe(false);
+        });
+
+        it('setExpanded is a no-op when already in the requested state', () => {
+            const onExpandedUpdate = jest.fn();
+            const {result} = renderHook(() =>
+                useListState({items: tree, defaultExpandedIds: ['root'], onExpandedUpdate}),
+            );
+
+            act(() => result.current.setExpanded('root', true));
+            act(() => result.current.setExpanded('c1', false));
+            expect(onExpandedUpdate).not.toHaveBeenCalled();
+        });
+
+        it('is controlled: emits onExpandedUpdate, reflects the prop', () => {
+            const onExpandedUpdate = jest.fn();
+            const {result, rerender} = renderHook(
+                ({expandedIds}: {expandedIds: string[]}) =>
+                    useListState({items: tree, expandedIds, onExpandedUpdate}),
+                {initialProps: {expandedIds: [] as string[]}},
+            );
+
+            expect(result.current.visibleIds).toEqual(['root', 'sibling']);
+
+            act(() => result.current.setExpanded('root', true));
+            expect(onExpandedUpdate).toHaveBeenCalledWith(['root']);
+            // Controlled: nothing changes until the prop is updated by the owner.
+            expect(result.current.visibleIds).toEqual(['root', 'sibling']);
+
+            rerender({expandedIds: ['root']});
+            expect(result.current.visibleIds).toEqual(['root', 'c1', 'c2', 'sibling']);
+        });
+    });
+
+    describe('async subtree (ListChildrenState)', () => {
+        it('outcome A — lazy load returned no children: loaded empty folder', () => {
+            const items: Node[] = [{id: 'folder', children: [], childrenState: 'loaded'}];
+            const {result} = renderHook(() =>
+                useListState({items, defaultExpandedIds: ['folder']}),
+            );
+
+            // Expandable (chevron stays), but the group is empty.
+            expect(result.current.getChildrenIds('folder')).toEqual([]);
+            expect(result.current.getChildrenState('folder')).toBe('loaded');
+            expect(result.current.isExpanded('folder')).toBe(true);
+            expect(result.current.visibleIds).toEqual(['folder']);
+        });
+
+        it('outcome B — lazy load returned no children: node became a leaf', () => {
+            const items: Node[] = [{id: 'leaf', childrenState: undefined}];
+            const {result} = renderHook(() => useListState({items, defaultExpandedIds: ['leaf']}));
+
+            expect(result.current.getChildrenIds('leaf')).toBeUndefined();
+            expect(result.current.getChildrenState('leaf')).toBeUndefined();
+            expect(result.current.visibleIds).toEqual(['leaf']);
+        });
+
+        it('lazy folder: children unloaded but expandable via childrenState', () => {
+            const items: Node[] = [{id: 'lazy', childrenState: 'lazy'}];
+            const {result} = renderHook(() => useListState({items}));
+
+            // No loaded children, yet the behavior layer can tell it apart from a leaf.
+            expect(result.current.getChildrenIds('lazy')).toBeUndefined();
+            expect(result.current.getChildrenState('lazy')).toBe('lazy');
+        });
+    });
+
+    describe('memoization', () => {
+        it('does not rebuild the index when only expansion changes', () => {
+            const getItemChildren = jest.fn((node: Node) => node.children);
+            const {result} = renderHook(() => useListState({items: tree, getItemChildren}));
+
+            const callsAfterMount = getItemChildren.mock.calls.length;
+            const rootItemBefore = result.current.getItemById('root');
+
+            act(() => result.current.setExpanded('root', true));
+
+            // The structural index (which is what calls getItemChildren) is untouched.
+            expect(getItemChildren).toHaveBeenCalledTimes(callsAfterMount);
+            expect(result.current.getItemById('root')).toBe(rootItemBefore);
+        });
+
+        it('keeps index accessors and setExpanded referentially stable across expansion', () => {
+            const {result} = renderHook(() => useListState({items: tree, defaultExpandedIds: []}));
+
+            const getItemByIdBefore = result.current.getItemById;
+            const getChildrenIdsBefore = result.current.getChildrenIds;
+            const setExpandedBefore = result.current.setExpanded;
+
+            act(() => result.current.setExpanded('root', true));
+
+            expect(result.current.getItemById).toBe(getItemByIdBefore);
+            expect(result.current.getChildrenIds).toBe(getChildrenIdsBefore);
+            expect(result.current.setExpanded).toBe(setExpandedBefore);
+        });
+    });
+
+    describe('incremental reconciliation (transitions)', () => {
+        it('lazy folder → loaded with children, reusing the untouched sibling subtree', () => {
+            const folderA: Node = {id: 'A', children: [{id: 'A1'}, {id: 'A2'}]};
+            const getItemDisabled = jest.fn((node: Node) => Boolean(node.disabled));
+
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items, getItemDisabled}),
+                {initialProps: {items: [folderA, {id: 'B', childrenState: 'lazy'}] as Node[]}},
+            );
+
+            expect(result.current.getChildrenState('B')).toBe('lazy');
+            expect(result.current.getChildrenIds('B')).toBeUndefined();
+
+            const callsAfterMount = getItemDisabled.mock.calls.length;
+
+            // Patch only B; folderA keeps its reference.
+            rerender({
+                items: [folderA, {id: 'B', children: [{id: 'B1'}], childrenState: 'loaded'}],
+            });
+
+            expect(result.current.getChildrenState('B')).toBe('loaded');
+            expect(result.current.getChildrenIds('B')).toEqual(['B1']);
+            // Only B and B1 are (re)built — the unchanged folderA subtree is skipped entirely.
+            expect(getItemDisabled.mock.calls.length - callsAfterMount).toBe(2);
+        });
+
+        it('lazy folder → leaf', () => {
+            const folderA: Node = {id: 'A', children: [{id: 'A1'}]};
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items}),
+                {initialProps: {items: [folderA, {id: 'B', childrenState: 'lazy'}] as Node[]}},
+            );
+
+            rerender({items: [folderA, {id: 'B'}]});
+
+            expect(result.current.getChildrenIds('B')).toBeUndefined();
+            expect(result.current.getChildrenState('B')).toBeUndefined();
+        });
+
+        it('removes children and prunes their subtrees from the index', () => {
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items, defaultExpandedIds: ['P']}),
+                {
+                    initialProps: {
+                        items: [
+                            {
+                                id: 'P',
+                                children: [{id: 'c1', children: [{id: 'gc1'}]}, {id: 'c2'}],
+                                childrenState: 'loaded',
+                            },
+                        ] as Node[],
+                    },
+                },
+            );
+
+            expect(result.current.visibleIds).toEqual(['P', 'c1', 'c2']);
+            expect(result.current.getItemById('gc1')).toBeDefined();
+
+            rerender({items: [{id: 'P', children: [], childrenState: 'loaded'}]});
+
+            expect(result.current.getChildrenIds('P')).toEqual([]);
+            expect(result.current.visibleIds).toEqual(['P']);
+            // Removed descendants are gone from the index, not just hidden.
+            expect(result.current.getItemById('c1')).toBeUndefined();
+            expect(result.current.getItemById('c2')).toBeUndefined();
+            expect(result.current.getItemById('gc1')).toBeUndefined();
+        });
+
+        it('prunes a removed root', () => {
+            const keep: Node = {id: 'X'};
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items}),
+                {initialProps: {items: [keep, {id: 'Y'}] as Node[]}},
+            );
+
+            expect(result.current.visibleIds).toEqual(['X', 'Y']);
+
+            rerender({items: [keep]});
+
+            expect(result.current.visibleIds).toEqual(['X']);
+            expect(result.current.getItemById('Y')).toBeUndefined();
+        });
+
+        it('moves a node (same reference) between two rebuilt parents', () => {
+            const moved: Node = {id: 'M'};
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) =>
+                    useListState({items, defaultExpandedIds: ['P1', 'P2']}),
+                {
+                    initialProps: {
+                        items: [
+                            {id: 'P1', children: [moved], childrenState: 'loaded'},
+                            {id: 'P2', children: [], childrenState: 'loaded'},
+                        ] as Node[],
+                    },
+                },
+            );
+
+            expect(result.current.visibleIds).toEqual(['P1', 'M', 'P2']);
+            expect(result.current.getParentId('M')).toBe('P1');
+
+            // M keeps its reference but moves from P1 to P2 (both parents get new references).
+            rerender({
+                items: [
+                    {id: 'P1', children: [], childrenState: 'loaded'},
+                    {id: 'P2', children: [moved], childrenState: 'loaded'},
+                ],
+            });
+
+            expect(result.current.getParentId('M')).toBe('P2');
+            expect(result.current.getLevel('M')).toBe(1);
+            expect(result.current.getItemById('M')).toBe(moved);
+            expect(result.current.visibleIds).toEqual(['P1', 'P2', 'M']);
+        });
+
+        it('reorders siblings (same references) and updates order', () => {
+            const a: Node = {id: 'a'};
+            const b: Node = {id: 'b'};
+            const getItemDisabled = jest.fn((node: Node) => Boolean(node.disabled));
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items, getItemDisabled}),
+                {initialProps: {items: [a, b]}},
+            );
+
+            const callsAfterMount = getItemDisabled.mock.calls.length;
+
+            rerender({items: [b, a]});
+
+            expect(result.current.visibleIds).toEqual(['b', 'a']);
+            // Both are reused (unchanged reference and position), so no getters re-run.
+            expect(getItemDisabled.mock.calls.length).toBe(callsAfterMount);
+        });
+
+        it('recomputes on a new-but-equal items array (memoize-by-reference contract)', () => {
+            const {result, rerender} = renderHook(
+                ({items}: {items: Node[]}) => useListState({items}),
+                {initialProps: {items: [{id: 'a'}] as Node[]}},
+            );
+
+            const getItemByIdBefore = result.current.getItemById;
+
+            rerender({items: [{id: 'a'}]});
+
+            expect(result.current.visibleIds).toEqual(['a']);
+            expect(result.current.getItemById).not.toBe(getItemByIdBefore);
+        });
+
+        it('warns on duplicate ids (dev)', () => {
+            const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+            renderHook(() => useListState({items: [{id: 'dup'}, {id: 'dup'}] as Node[]}));
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Duplicate item id "dup"'),
+            );
+
+            errorSpy.mockRestore();
+        });
+    });
+
+    describe('bench-smoke: expand on a 50k tree does not walk hidden nodes', () => {
+        it('expanding one folder does not re-traverse the forest', () => {
+            const FOLDERS = 1000;
+            const CHILDREN = 50; // 1000 folders * 50 = 50_000 leaves
+
+            const forest: Node[] = [];
+            for (let f = 0; f < FOLDERS; f++) {
+                const children: Node[] = [];
+                for (let c = 0; c < CHILDREN; c++) {
+                    children.push({id: `f${f}-c${c}`});
+                }
+                forest.push({id: `f${f}`, children});
+            }
+
+            const getItemChildren = jest.fn((node: Node) => node.children);
+            const {result} = renderHook(() => useListState({items: forest, getItemChildren}));
+
+            // All folders collapsed: only the top level is visible.
+            expect(result.current.visibleIds).toHaveLength(FOLDERS);
+
+            const callsAfterMount = getItemChildren.mock.calls.length;
+
+            act(() => result.current.setExpanded('f500', true));
+
+            // No full pass: expansion recomputes visibleIds from the prebuilt index only.
+            expect(getItemChildren).toHaveBeenCalledTimes(callsAfterMount);
+            expect(result.current.visibleIds).toHaveLength(FOLDERS + CHILDREN);
+        });
+    });
+});

--- a/src/components/lab/List/core/useListState/index.ts
+++ b/src/components/lab/List/core/useListState/index.ts
@@ -1,0 +1,2 @@
+export {useListState} from './useListState';
+export type {ListState, UseListStateProps} from './types';

--- a/src/components/lab/List/core/useListState/listStateIndex.ts
+++ b/src/components/lab/List/core/useListState/listStateIndex.ts
@@ -1,11 +1,22 @@
 import type {ListChildrenState, ListItemGetters} from '../types';
 
+/** A single node record in the structural index. Treated as immutable once created. */
+export interface ListNode<T> {
+    item: T;
+    level: number;
+    parentId: string | undefined;
+    /** `undefined` = leaf or unloaded folder; `[]` = loaded empty folder */
+    childrenIds: string[] | undefined;
+    childrenState: ListChildrenState | undefined;
+    disabled: boolean;
+}
+
 /**
- * Precomputed structural index of the item forest. All per-node maps are keyed by item id.
+ * Precomputed structural index of the item forest — one `ListNode` record per id.
  * `visibleIds` is derived from this index plus the expansion set (see `computeVisibleIds`)
  * without touching the getters, so expanding a node never re-traverses the forest.
  *
- * The index is rebuilt into **fresh maps** on every `items` reference (see
+ * The index is rebuilt into a **fresh map** on every `items` reference (see
  * `reconcileListStateIndex`) — it never mutates a previously produced index, so it is safe to
  * compute during render under React concurrent mode. The previous index is used only as a
  * read-only source to reuse unchanged subtrees, which keeps *getter* work proportional to the
@@ -16,13 +27,7 @@ export interface ListStateIndex<T> {
     sourceItems: T[];
     /** Top-level item ids in order */
     rootIds: string[];
-    itemById: Map<string, T>;
-    levelById: Map<string, number>;
-    parentById: Map<string, string | undefined>;
-    /** `undefined` = leaf or unloaded folder; `[]` = loaded empty folder */
-    childrenIdsById: Map<string, string[] | undefined>;
-    childrenStateById: Map<string, ListChildrenState | undefined>;
-    disabledById: Map<string, boolean>;
+    nodeById: Map<string, ListNode<T>>;
 }
 
 type StructuralGetters<T> = Required<
@@ -58,18 +63,19 @@ function resolveStructuralGetters<T>(getters: ListItemGetters<T>): StructuralGet
 }
 
 /**
- * Rebuilds the structural index for a new `items` reference into fresh maps, reusing the
+ * Rebuilds the structural index for a new `items` reference into a fresh map, reusing the
  * previous index where possible:
  *
  * - a node whose item **reference** and position (`level`, `parentId`) are unchanged has its
- *   whole subtree copied over from `previous` — no getters are called for it;
+ *   whole subtree copied over from `previous` — the immutable node records are reused by
+ *   reference and no getters are called for it;
  * - a changed / new / moved node is rebuilt from its getters and its children reconciled
  *   recursively.
  *
- * Because the result is always a brand-new index (fresh maps, fresh wrapper), the previous
+ * Because the result is always a brand-new index (fresh map, fresh wrapper), the previous
  * index is never mutated: the function is a pure function of `items`/`getters`, and `previous`
  * only affects how much work is reused, never the result. Removed nodes simply never make it
- * into the new maps — no pruning step is needed. Reconciling the same `items` reference is a
+ * into the new map — no pruning step is needed. Reconciling the same `items` reference is a
  * no-op that returns `previous` unchanged.
  */
 export function reconcileListStateIndex<T>(
@@ -84,12 +90,7 @@ export function reconcileListStateIndex<T>(
     const {getItemId, getItemChildren, getItemDisabled, getItemChildrenState} =
         resolveStructuralGetters(getters);
 
-    const itemById = new Map<string, T>();
-    const levelById = new Map<string, number>();
-    const parentById = new Map<string, string | undefined>();
-    const childrenIdsById = new Map<string, string[] | undefined>();
-    const childrenStateById = new Map<string, ListChildrenState | undefined>();
-    const disabledById = new Map<string, boolean>();
+    const nodeById = new Map<string, ListNode<T>>();
 
     const seen = process.env.NODE_ENV === 'production' ? null : new Set<string>();
     const markSeen = (id: string) => {
@@ -103,21 +104,18 @@ export function reconcileListStateIndex<T>(
         }
     };
 
-    // Copies a whole unchanged subtree from `previous` into the fresh maps without calling any
-    // getters. `previous` is guaranteed non-null here (only reached from the reuse fast-path).
+    // Copies a whole unchanged subtree from `previous`, reusing its immutable node records by
+    // reference — no getters are called.
     const copyReusedSubtree = (id: string) => {
-        const prev = previous as ListStateIndex<T>;
+        const node = previous?.nodeById.get(id);
+        if (!node) {
+            return;
+        }
         markSeen(id);
-        itemById.set(id, prev.itemById.get(id) as T);
-        levelById.set(id, prev.levelById.get(id) as number);
-        parentById.set(id, prev.parentById.get(id));
-        childrenStateById.set(id, prev.childrenStateById.get(id));
-        disabledById.set(id, prev.disabledById.get(id) as boolean);
-        const childIds = prev.childrenIdsById.get(id);
-        childrenIdsById.set(id, childIds);
-        if (childIds) {
-            for (let i = 0; i < childIds.length; i++) {
-                copyReusedSubtree(childIds[i]);
+        nodeById.set(id, node);
+        if (node.childrenIds) {
+            for (let i = 0; i < node.childrenIds.length; i++) {
+                copyReusedSubtree(node.childrenIds[i]);
             }
         }
     };
@@ -126,22 +124,18 @@ export function reconcileListStateIndex<T>(
         const id = getItemId(item);
 
         // Unchanged reference at the same position ⇒ the whole subtree is intact; copy it over.
+        const prevNode = previous?.nodeById.get(id);
         if (
-            previous &&
-            previous.itemById.get(id) === item &&
-            previous.levelById.get(id) === level &&
-            previous.parentById.get(id) === parentId
+            prevNode &&
+            prevNode.item === item &&
+            prevNode.level === level &&
+            prevNode.parentId === parentId
         ) {
             copyReusedSubtree(id);
             return id;
         }
 
         markSeen(id);
-        itemById.set(id, item);
-        levelById.set(id, level);
-        parentById.set(id, parentId);
-        disabledById.set(id, getItemDisabled(item));
-        childrenStateById.set(id, getItemChildrenState(item));
 
         const childItems = getItemChildren(item);
         let childIds: string[] | undefined;
@@ -153,23 +147,22 @@ export function reconcileListStateIndex<T>(
                 childIds[i] = reconcileNode(childItems[i], level + 1, id);
             }
         }
-        childrenIdsById.set(id, childIds);
+
+        nodeById.set(id, {
+            item,
+            level,
+            parentId,
+            childrenIds: childIds,
+            childrenState: getItemChildrenState(item),
+            disabled: getItemDisabled(item),
+        });
 
         return id;
     };
 
     const rootIds = items.map((item) => reconcileNode(item, 0, undefined));
 
-    return {
-        sourceItems: items,
-        rootIds,
-        itemById,
-        levelById,
-        parentById,
-        childrenIdsById,
-        childrenStateById,
-        disabledById,
-    };
+    return {sourceItems: items, rootIds, nodeById};
 }
 
 /**
@@ -188,7 +181,7 @@ export function computeVisibleIds<T>(
             const id = ids[i];
             result.push(id);
 
-            const childIds = index.childrenIdsById.get(id);
+            const childIds = index.nodeById.get(id)?.childrenIds;
             if (childIds !== undefined && childIds.length > 0 && expandedIds.has(id)) {
                 walk(childIds);
             }

--- a/src/components/lab/List/core/useListState/listStateIndex.ts
+++ b/src/components/lab/List/core/useListState/listStateIndex.ts
@@ -1,4 +1,4 @@
-import type {ListChildrenState, ListItemGetters} from '../types';
+import type {ListChildrenState, ListItemGetters, ListItemType} from '../types';
 
 /** A single node record in the structural index. Treated as immutable once created. */
 export interface ListNode<T> {
@@ -9,6 +9,7 @@ export interface ListNode<T> {
     childrenIds: string[] | undefined;
     childrenState: ListChildrenState | undefined;
     disabled: boolean;
+    type: ListItemType;
 }
 
 /**
@@ -33,7 +34,7 @@ export interface ListStateIndex<T> {
 type StructuralGetters<T> = Required<
     Pick<
         ListItemGetters<T>,
-        'getItemId' | 'getItemChildren' | 'getItemDisabled' | 'getItemChildrenState'
+        'getItemId' | 'getItemChildren' | 'getItemDisabled' | 'getItemChildrenState' | 'getItemType'
     >
 >;
 
@@ -59,6 +60,7 @@ function resolveStructuralGetters<T>(getters: ListItemGetters<T>): StructuralGet
                 isString(item)
                     ? undefined
                     : (item as {childrenState?: ListChildrenState}).childrenState),
+        getItemType: getters.getItemType ?? (() => 'item'),
     };
 }
 
@@ -87,7 +89,7 @@ export function reconcileListStateIndex<T>(
         return previous;
     }
 
-    const {getItemId, getItemChildren, getItemDisabled, getItemChildrenState} =
+    const {getItemId, getItemChildren, getItemDisabled, getItemChildrenState, getItemType} =
         resolveStructuralGetters(getters);
 
     const nodeById = new Map<string, ListNode<T>>();
@@ -155,6 +157,7 @@ export function reconcileListStateIndex<T>(
             childrenIds: childIds,
             childrenState: getItemChildrenState(item),
             disabled: getItemDisabled(item),
+            type: getItemType(item),
         });
 
         return id;

--- a/src/components/lab/List/core/useListState/listStateIndex.ts
+++ b/src/components/lab/List/core/useListState/listStateIndex.ts
@@ -1,0 +1,201 @@
+import type {ListChildrenState, ListItemGetters} from '../types';
+
+/**
+ * Precomputed structural index of the item forest. All per-node maps are keyed by item id.
+ * `visibleIds` is derived from this index plus the expansion set (see `computeVisibleIds`)
+ * without touching the getters, so expanding a node never re-traverses the forest.
+ *
+ * The index is rebuilt into **fresh maps** on every `items` reference (see
+ * `reconcileListStateIndex`) — it never mutates a previously produced index, so it is safe to
+ * compute during render under React concurrent mode. The previous index is used only as a
+ * read-only source to reuse unchanged subtrees, which keeps *getter* work proportional to the
+ * change; the map allocation itself is O(total nodes) of cheap `Map.set` calls.
+ */
+export interface ListStateIndex<T> {
+    /** The `items` reference this index was reconciled from — used to short-circuit rebuilds */
+    sourceItems: T[];
+    /** Top-level item ids in order */
+    rootIds: string[];
+    itemById: Map<string, T>;
+    levelById: Map<string, number>;
+    parentById: Map<string, string | undefined>;
+    /** `undefined` = leaf or unloaded folder; `[]` = loaded empty folder */
+    childrenIdsById: Map<string, string[] | undefined>;
+    childrenStateById: Map<string, ListChildrenState | undefined>;
+    disabledById: Map<string, boolean>;
+}
+
+type StructuralGetters<T> = Required<
+    Pick<
+        ListItemGetters<T>,
+        'getItemId' | 'getItemChildren' | 'getItemDisabled' | 'getItemChildrenState'
+    >
+>;
+
+const isString = (value: unknown): value is string => typeof value === 'string';
+
+/**
+ * Resolves the structural getters `useListState` consumes, applying the "read from the item"
+ * defaults. Content/textValue getters are view/behavior concerns and are not resolved here.
+ */
+function resolveStructuralGetters<T>(getters: ListItemGetters<T>): StructuralGetters<T> {
+    return {
+        getItemId:
+            getters.getItemId ?? ((item) => (isString(item) ? item : (item as {id: string}).id)),
+        getItemChildren:
+            getters.getItemChildren ??
+            ((item) => (isString(item) ? undefined : (item as {children?: T[]}).children)),
+        getItemDisabled:
+            getters.getItemDisabled ??
+            ((item) => (isString(item) ? false : Boolean((item as {disabled?: boolean}).disabled))),
+        getItemChildrenState:
+            getters.getItemChildrenState ??
+            ((item) =>
+                isString(item)
+                    ? undefined
+                    : (item as {childrenState?: ListChildrenState}).childrenState),
+    };
+}
+
+/**
+ * Rebuilds the structural index for a new `items` reference into fresh maps, reusing the
+ * previous index where possible:
+ *
+ * - a node whose item **reference** and position (`level`, `parentId`) are unchanged has its
+ *   whole subtree copied over from `previous` — no getters are called for it;
+ * - a changed / new / moved node is rebuilt from its getters and its children reconciled
+ *   recursively.
+ *
+ * Because the result is always a brand-new index (fresh maps, fresh wrapper), the previous
+ * index is never mutated: the function is a pure function of `items`/`getters`, and `previous`
+ * only affects how much work is reused, never the result. Removed nodes simply never make it
+ * into the new maps — no pruning step is needed. Reconciling the same `items` reference is a
+ * no-op that returns `previous` unchanged.
+ */
+export function reconcileListStateIndex<T>(
+    items: T[],
+    getters: ListItemGetters<T>,
+    previous: ListStateIndex<T> | null,
+): ListStateIndex<T> {
+    if (previous && previous.sourceItems === items) {
+        return previous;
+    }
+
+    const {getItemId, getItemChildren, getItemDisabled, getItemChildrenState} =
+        resolveStructuralGetters(getters);
+
+    const itemById = new Map<string, T>();
+    const levelById = new Map<string, number>();
+    const parentById = new Map<string, string | undefined>();
+    const childrenIdsById = new Map<string, string[] | undefined>();
+    const childrenStateById = new Map<string, ListChildrenState | undefined>();
+    const disabledById = new Map<string, boolean>();
+
+    const seen = process.env.NODE_ENV === 'production' ? null : new Set<string>();
+    const markSeen = (id: string) => {
+        if (process.env.NODE_ENV !== 'production' && seen) {
+            if (seen.has(id)) {
+                console.error(
+                    `[useListState] Duplicate item id "${id}". Item ids must be unique — pass getItemId to derive stable, unique ids.`,
+                );
+            }
+            seen.add(id);
+        }
+    };
+
+    // Copies a whole unchanged subtree from `previous` into the fresh maps without calling any
+    // getters. `previous` is guaranteed non-null here (only reached from the reuse fast-path).
+    const copyReusedSubtree = (id: string) => {
+        const prev = previous as ListStateIndex<T>;
+        markSeen(id);
+        itemById.set(id, prev.itemById.get(id) as T);
+        levelById.set(id, prev.levelById.get(id) as number);
+        parentById.set(id, prev.parentById.get(id));
+        childrenStateById.set(id, prev.childrenStateById.get(id));
+        disabledById.set(id, prev.disabledById.get(id) as boolean);
+        const childIds = prev.childrenIdsById.get(id);
+        childrenIdsById.set(id, childIds);
+        if (childIds) {
+            for (let i = 0; i < childIds.length; i++) {
+                copyReusedSubtree(childIds[i]);
+            }
+        }
+    };
+
+    const reconcileNode = (item: T, level: number, parentId: string | undefined): string => {
+        const id = getItemId(item);
+
+        // Unchanged reference at the same position ⇒ the whole subtree is intact; copy it over.
+        if (
+            previous &&
+            previous.itemById.get(id) === item &&
+            previous.levelById.get(id) === level &&
+            previous.parentById.get(id) === parentId
+        ) {
+            copyReusedSubtree(id);
+            return id;
+        }
+
+        markSeen(id);
+        itemById.set(id, item);
+        levelById.set(id, level);
+        parentById.set(id, parentId);
+        disabledById.set(id, getItemDisabled(item));
+        childrenStateById.set(id, getItemChildrenState(item));
+
+        const childItems = getItemChildren(item);
+        let childIds: string[] | undefined;
+        if (childItems === undefined) {
+            childIds = undefined;
+        } else {
+            childIds = new Array<string>(childItems.length);
+            for (let i = 0; i < childItems.length; i++) {
+                childIds[i] = reconcileNode(childItems[i], level + 1, id);
+            }
+        }
+        childrenIdsById.set(id, childIds);
+
+        return id;
+    };
+
+    const rootIds = items.map((item) => reconcileNode(item, 0, undefined));
+
+    return {
+        sourceItems: items,
+        rootIds,
+        itemById,
+        levelById,
+        parentById,
+        childrenIdsById,
+        childrenStateById,
+        disabledById,
+    };
+}
+
+/**
+ * Flattens the visible nodes in display order. Only descends into expanded subtrees, so the
+ * cost is O(visible nodes): expanding a node in a large mostly-collapsed forest never walks
+ * the hidden nodes (the L1.1 bench-smoke invariant).
+ */
+export function computeVisibleIds<T>(
+    index: ListStateIndex<T>,
+    expandedIds: ReadonlySet<string>,
+): string[] {
+    const result: string[] = [];
+
+    const walk = (ids: string[]) => {
+        for (let i = 0; i < ids.length; i++) {
+            const id = ids[i];
+            result.push(id);
+
+            const childIds = index.childrenIdsById.get(id);
+            if (childIds !== undefined && childIds.length > 0 && expandedIds.has(id)) {
+                walk(childIds);
+            }
+        }
+    };
+
+    walk(index.rootIds);
+
+    return result;
+}

--- a/src/components/lab/List/core/useListState/types.ts
+++ b/src/components/lab/List/core/useListState/types.ts
@@ -1,4 +1,4 @@
-import type {ListChildrenState, ListItemGetters} from '../types';
+import type {ListChildrenState, ListItemGetters, ListItemType} from '../types';
 
 export interface UseListStateProps<T> extends ListItemGetters<T> {
     /** The single source of data; the core never mutates it. */
@@ -37,6 +37,11 @@ export interface ListState<T> {
     isExpanded(id: string): boolean;
     /** Returns whether a node is disabled. */
     isDisabled(id: string): boolean;
+    /**
+     * Returns the structural role of a node — a selectable, navigable `item` or a non-interactive
+     * `section` label; `item` for unknown ids.
+     */
+    getItemType(id: string): ListItemType;
     /**
      * Expands or collapses a node and emits `onExpandedUpdate`; a no-op when the node is already
      * in the requested state.

--- a/src/components/lab/List/core/useListState/types.ts
+++ b/src/components/lab/List/core/useListState/types.ts
@@ -1,0 +1,45 @@
+import type {ListChildrenState, ListItemGetters} from '../types';
+
+export interface UseListStateProps<T> extends ListItemGetters<T> {
+    /** The single source of data; the core never mutates it. */
+    items: T[];
+    /** Expanded node ids (controlled). Expansion drives `visibleIds`. */
+    expandedIds?: string[];
+    /** Initially expanded node ids (uncontrolled). */
+    defaultExpandedIds?: string[];
+    /** Called with the next expanded node ids whenever expansion changes. */
+    onExpandedUpdate?: (ids: string[]) => void;
+}
+
+export interface ListState<T> {
+    /**
+     * Flat slice of the visible (expanded) nodes in display order — the single source of truth
+     * for rendering, keyboard navigation and virtualization.
+     */
+    visibleIds: string[];
+    /** Returns the source item for an id, or `undefined` if the id is unknown. */
+    getItemById(id: string): T | undefined;
+    /** Returns the nesting depth of a node (`0` for roots). */
+    getLevel(id: string): number;
+    /** Returns the parent id of a node, or `undefined` for roots. */
+    getParentId(id: string): string | undefined;
+    /**
+     * Returns the loaded child ids in order: `[]` is a loaded empty folder, `undefined` is a leaf
+     * or an unloaded folder (use `getChildrenState` to tell them apart).
+     */
+    getChildrenIds(id: string): string[] | undefined;
+    /**
+     * Returns the async subtree state of a node — distinguishes a leaf from an unloaded `lazy`
+     * folder (both report `undefined` children) for chevron / `aria-expanded` / `aria-busy`.
+     */
+    getChildrenState(id: string): ListChildrenState | undefined;
+    /** Returns whether a node is expanded. */
+    isExpanded(id: string): boolean;
+    /** Returns whether a node is disabled. */
+    isDisabled(id: string): boolean;
+    /**
+     * Expands or collapses a node and emits `onExpandedUpdate`; a no-op when the node is already
+     * in the requested state.
+     */
+    setExpanded(id: string, expanded: boolean): void;
+}

--- a/src/components/lab/List/core/useListState/useListState.ts
+++ b/src/components/lab/List/core/useListState/useListState.ts
@@ -70,6 +70,7 @@ export function useListState<T>(props: UseListStateProps<T>): ListState<T> {
             getChildrenIds: (id: string) => index.nodeById.get(id)?.childrenIds,
             getChildrenState: (id: string) => index.nodeById.get(id)?.childrenState,
             isDisabled: (id: string) => index.nodeById.get(id)?.disabled ?? false,
+            getItemType: (id: string) => index.nodeById.get(id)?.type ?? 'item',
         }),
         [index],
     );

--- a/src/components/lab/List/core/useListState/useListState.ts
+++ b/src/components/lab/List/core/useListState/useListState.ts
@@ -64,12 +64,12 @@ export function useListState<T>(props: UseListStateProps<T>): ListState<T> {
     // Depend on `index` alone so these accessors stay stable across expansion changes.
     const accessors = React.useMemo(
         () => ({
-            getItemById: (id: string) => index.itemById.get(id),
-            getLevel: (id: string) => index.levelById.get(id) ?? 0,
-            getParentId: (id: string) => index.parentById.get(id),
-            getChildrenIds: (id: string) => index.childrenIdsById.get(id),
-            getChildrenState: (id: string) => index.childrenStateById.get(id),
-            isDisabled: (id: string) => index.disabledById.get(id) ?? false,
+            getItemById: (id: string) => index.nodeById.get(id)?.item,
+            getLevel: (id: string) => index.nodeById.get(id)?.level ?? 0,
+            getParentId: (id: string) => index.nodeById.get(id)?.parentId,
+            getChildrenIds: (id: string) => index.nodeById.get(id)?.childrenIds,
+            getChildrenState: (id: string) => index.nodeById.get(id)?.childrenState,
+            isDisabled: (id: string) => index.nodeById.get(id)?.disabled ?? false,
         }),
         [index],
     );

--- a/src/components/lab/List/core/useListState/useListState.ts
+++ b/src/components/lab/List/core/useListState/useListState.ts
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+import {useControlledState} from '../../../../../hooks/useControlledState';
+import type {ListItemGetters} from '../types';
+
+import type {ListStateIndex} from './listStateIndex';
+import {computeVisibleIds, reconcileListStateIndex} from './listStateIndex';
+import type {ListState, UseListStateProps} from './types';
+
+const EMPTY_IDS: string[] = [];
+
+/**
+ * Headless state for a data-driven list or tree: normalizes `items` into a flat index and derives
+ * the ordered ids of the currently visible nodes from the expansion state.
+ *
+ * Structural getters must be pure functions of the item — pass a new `items` reference to apply
+ * data changes. Expansion is controlled when `expandedIds` is passed, uncontrolled otherwise.
+ */
+export function useListState<T>(props: UseListStateProps<T>): ListState<T> {
+    const {items, expandedIds, defaultExpandedIds, onExpandedUpdate, ...getters} = props;
+
+    // Getters are read through a ref so the index reconciles on the `items` reference only.
+    const gettersRef = React.useRef<ListItemGetters<T>>(getters);
+    gettersRef.current = getters;
+
+    // The previous index is passed back as a reuse hint; reconciliation is pure and never mutates it.
+    const indexRef = React.useRef<ListStateIndex<T> | null>(null);
+    const index = React.useMemo(() => {
+        indexRef.current = reconcileListStateIndex(items, gettersRef.current, indexRef.current);
+        return indexRef.current;
+    }, [items]);
+
+    const [currentExpandedIds, setExpandedIds] = useControlledState(
+        expandedIds,
+        defaultExpandedIds ?? EMPTY_IDS,
+        onExpandedUpdate,
+    );
+
+    const expandedSet = React.useMemo(() => new Set(currentExpandedIds), [currentExpandedIds]);
+
+    // Refs keep `setExpanded` referentially stable while reading the latest expansion and setter.
+    const expandedIdsRef = React.useRef(currentExpandedIds);
+    expandedIdsRef.current = currentExpandedIds;
+    const expandedSetRef = React.useRef(expandedSet);
+    expandedSetRef.current = expandedSet;
+    const setExpandedIdsRef = React.useRef(setExpandedIds);
+    setExpandedIdsRef.current = setExpandedIds;
+
+    const setExpanded = React.useCallback((id: string, expanded: boolean) => {
+        if (expandedSetRef.current.has(id) === expanded) {
+            return;
+        }
+        const next = expanded
+            ? [...expandedIdsRef.current, id]
+            : expandedIdsRef.current.filter((expandedId) => expandedId !== id);
+        setExpandedIdsRef.current(next);
+    }, []);
+
+    const visibleIds = React.useMemo(
+        () => computeVisibleIds(index, expandedSet),
+        [index, expandedSet],
+    );
+
+    // Depend on `index` alone so these accessors stay stable across expansion changes.
+    const accessors = React.useMemo(
+        () => ({
+            getItemById: (id: string) => index.itemById.get(id),
+            getLevel: (id: string) => index.levelById.get(id) ?? 0,
+            getParentId: (id: string) => index.parentById.get(id),
+            getChildrenIds: (id: string) => index.childrenIdsById.get(id),
+            getChildrenState: (id: string) => index.childrenStateById.get(id),
+            isDisabled: (id: string) => index.disabledById.get(id) ?? false,
+        }),
+        [index],
+    );
+
+    return React.useMemo<ListState<T>>(
+        () => ({
+            ...accessors,
+            visibleIds,
+            isExpanded: (id) => expandedSet.has(id),
+            setExpanded,
+        }),
+        [accessors, visibleIds, expandedSet, setExpanded],
+    );
+}


### PR DESCRIPTION
🤖 _AI generated_

Adds `useListState` and the initial `lab/List/core` module — the headless state layer of a new List / TreeList / GridList family. Development happens in `lab`; nothing is wired into a public entry point yet.

## What's inside

- **`useListState`** — normalizes `items` (objects or plain strings) into a flat index (id / level / parent / children / childrenState / disabled / type) and derives the ordered `visibleIds` slice from expansion. Expansion is controlled via `expandedIds` or uncontrolled via `defaultExpandedIds` + `onExpandedUpdate`.
- **Incremental reconciliation** — the index is rebuilt into fresh maps on each new `items` reference, reusing unchanged-by-reference subtrees so getters run only for changed nodes. It never mutates a previously produced index, so it is render-pure and safe under React concurrent mode.
- **`ListChildrenState`** — async-subtree state that disambiguates `getItemChildren` returning `undefined`: a tree leaf vs an unloaded (`lazy`) folder, plus a loaded empty folder (`[]`).
- **`getItemType` (`item` / `section`)** — structural role of a node, so a later layer can tell a selectable row from a non-interactive group label. See below.
- **Types** — `ListChildrenState`, `ListItemGetters`, `ListItemType`, `UseListStateProps`, `ListState`.

## Structural item type (`item` / `section`) — why & how it's used

Adds `getItemType?: (item) => 'item' | 'section'` (default `'item'`) and a `getItemType(id)` accessor on `ListState`.

### Why it lives in the data, not inferred by role

The selection hook layered on top of this state (next PR) needs a **role-independent** way to tell a selectable row from a non-interactive group label — it has no `role` and is created before the behavior layer. Inferring "a node with children is a section header" only holds for a `listbox`; in a `tree` a node with children is a selectable folder, so that rule can't live in a role-agnostic layer. Marking the role explicitly in the data (as react-aria collections do via node types) keeps selection role-agnostic.

It also **decouples two axes** the inference rule conflated: **disclosure** (expand / collapse) and **selectability**. A `section` still holds children and expands like any other node; and a node with children can be marked `'item'` to act as a *selectable group* — even in a flat list. The type governs selection and keyboard navigation only, not disclosure; keeping a section always-open is a controlled-expansion concern (`expandedIds`).

### How the components will use it

```tsx
// List (listbox): a node with children is a non-interactive section header;
// leaves are options. Selection and keyboard nav skip the header row.
<List
  items={items}
  getItemType={(i) => (i.children ? 'section' : 'item')}
  selectionMode="multiple"
/>

// TreeList (tree): a folder IS a selectable, navigable treeitem — the default
// type, so no getItemType is needed.
<TreeList items={fsNodes} selectionMode="multiple" />

// "Clickable group" in a flat list: opt a parent row into being selectable
// while it still groups its children (impossible with the leaf-vs-header rule).
<List
  items={items}
  getItemType={(i) => (i.selectableGroup || !i.children ? 'item' : 'section')}
/>
```

```ts
// The selection layer then reads it with no role of its own:
const canSelect = (id: string) =>
  state.getItemType(id) === 'item' && !state.isDisabled(id);
```

## Summary by Sourcery

Introduce a headless List core state layer with a new useListState hook that normalizes list/tree data into a structural index and derives visibleIds from expansion.

New Features:
- Add useListState hook and ListState/UseListStateProps types for headless list and tree state management, including controlled/uncontrolled expansion.
- Support structural item typing (item vs section), async children state, and accessors for levels, parents, children, disabled state, and expansion.
- Expose lab List core entrypoint that re-exports useListState and related types for internal consumption.

Enhancements:
- Implement an incremental, render-pure list state index with reconciliation and memoization to reuse unchanged subtrees and avoid recomputing getters on expansion.
- Add performance safeguards ensuring expansion cost scales with visible nodes only and validating duplicate ids in development.
- Document the List core module and useListState API, including getters, async subtree semantics, and returned state shape.

Tests:
- Add comprehensive tests covering normalization, structural indexes, item type handling, expansion behavior, async subtree states, memoization, reconciliation scenarios, duplicate id warnings, and large-tree performance smoke checks.
