### PR TITLE
fix(Accordion): defaultExpanded=false open

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -54,6 +54,8 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
             value,
             onUpdate,
         });
+        const disclosureExpanded =
+            expanded !== undefined || defaultExpanded !== true ? isExpanded : undefined;
 
         const [preparedSummary, details] = React.useMemo(() => {
             return prepareChildren(children, qa);
@@ -65,7 +67,7 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
                 arrowPosition={attributes?.arrowPosition}
                 keepMounted={keepMounted}
                 onUpdate={handleUpdate}
-                expanded={defaultExpanded ? undefined : isExpanded}
+                expanded={disclosureExpanded}
                 defaultExpanded={defaultExpanded}
                 summary={summary}
                 disabled={disabled}
@@ -100,14 +102,14 @@ function useAccordionItemState({
     const id = useUniqId();
     const {items, updateItems} = useAccordion();
     const isControlledItem = expanded !== undefined;
-    const hasDefaultState = defaultExpanded !== undefined;
+    const hasDefaultExpanded = defaultExpanded === true;
 
     const isExpanded = React.useMemo(() => {
         if (isControlledItem) {
             return expanded;
         }
 
-        if (hasDefaultState) {
+        if (hasDefaultExpanded) {
             return false;
         }
 
@@ -116,16 +118,16 @@ function useAccordionItemState({
         }
 
         return items === (value ?? id);
-    }, [isControlledItem, expanded, hasDefaultState, items, value, id]);
+    }, [isControlledItem, expanded, hasDefaultExpanded, items, value, id]);
 
     const handleUpdate = React.useCallback(
         (next: boolean) => {
             onUpdate?.(next);
-            if (!isControlledItem && !hasDefaultState) {
+            if (!isControlledItem && !hasDefaultExpanded) {
                 updateItems(value ?? id);
             }
         },
-        [onUpdate, isControlledItem, hasDefaultState, updateItems, value, id],
+        [onUpdate, isControlledItem, hasDefaultExpanded, updateItems, value, id],
     );
     return {id, isExpanded, handleUpdate};
 }

--- a/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -241,6 +241,56 @@ describe('Accordion', () => {
         expect(content2.className).not.toContain('g-disclosure__content_visible');
     });
 
+    test('AccordionItem with defaultExpanded=false opens on click', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Accordion>
+                <Accordion.Item qa="item" summary="Item" defaultExpanded={false}>
+                    Content
+                </Accordion.Item>
+            </Accordion>,
+        );
+
+        const content = screen.getByText('Content');
+        const summary = screen.getByTestId('item-summary');
+
+        expect(content.className).not.toContain('g-disclosure__content_visible');
+
+        await user.click(summary);
+
+        expect(content.className).toContain('g-disclosure__content_visible');
+    });
+
+    test('AccordionItem with defaultExpanded=false closes when another item opens', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Accordion>
+                <Accordion.Item qa="item-1" summary="Item 1" defaultExpanded={false}>
+                    Content 1
+                </Accordion.Item>
+                <Accordion.Item qa="item-2" summary="Item 2">
+                    Content 2
+                </Accordion.Item>
+            </Accordion>,
+        );
+
+        const content1 = screen.getByText('Content 1');
+        const content2 = screen.getByText('Content 2');
+        const summary1 = screen.getByTestId('item-1-summary');
+        const summary2 = screen.getByTestId('item-2-summary');
+
+        await user.click(summary1);
+
+        expect(content1.className).toContain('g-disclosure__content_visible');
+
+        await user.click(summary2);
+
+        expect(content1.className).not.toContain('g-disclosure__content_visible');
+        expect(content2.className).toContain('g-disclosure__content_visible');
+    });
+
     test('disabled AccordionItem cannot be expanded', async () => {
         const user = userEvent.setup();
 


### PR DESCRIPTION
fix for https://github.com/gravity-ui/uikit/issues/2718

## Summary by Sourcery

Ensure Accordion items configured with defaultExpanded=false behave correctly when toggled and when interacting with other items.

Bug Fixes:
- Fix AccordionItem so items with defaultExpanded=false open when clicked.
- Fix AccordionItem so items with defaultExpanded=false close when another item in the same Accordion is opened.

Tests:
- Add tests covering AccordionItem behavior when defaultExpanded=false, including opening on click and closing when another item opens.