### PR TITLE
chore(deps): bump ignore to 7.0.6 in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14718,9 +14718,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
🤖 AI generated

## Problem

`npm ci` fails on every branch (including `main`) with:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's ignore@7.0.5 does not satisfy ignore@7.0.6
```

`ignore` is a deduped transitive dependency (pulled in by `stylelint`, `@typescript-eslint/eslint-plugin`, `globby`, all with `^7.0.x` ranges). `ignore@7.0.6` was just published, so when `npm ci` rebuilds the ideal tree it re-resolves `^7.0.x` to the newer 7.0.6 while the lockfile still pins 7.0.5 — the two go out of sync and `npm ci` aborts with EUSAGE. This makes the **Install Packages** step red before lint/tests even run, on `main` and on every open PR.

Reproduces on a clean `main`: `npm ci --dry-run` produces the same error.

## Fix

Surgically bump the deduped top-level `node_modules/ignore` entry in `package-lock.json` from 7.0.5 to 7.0.6 (`version` / `resolved` / `integrity` only). No `npm install`, so nothing else in the lockfile is touched — the diff is exactly 3 lines.

All three dependents keep `ignore@^7.0.5` even in their latest versions, so 7.0.6 satisfies every range; no parent package needs updating for this fix.

## Verification

`npm ci --dry-run` now passes (`exit 0`), the sync error is gone.

## Summary by Sourcery

Build:
- Bump transitive ignore dependency from 7.0.5 to 7.0.6 in package-lock.json to keep the lockfile in sync with resolved versions.