### PR TITLE
fix(Alert): pass `qa` attribute for `theme=clear`

### DIFF
--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -87,7 +87,7 @@ describe('Alert', () => {
     });
 
     test('pass `qa` attribute correctly w/ theme="clear"', async () => {
-        render(<Alert qa="test" message="Test message" />);
+        render(<Alert theme="clear" qa="test" message="Test message" />);
 
         expect(screen.getByTestId('test')).toHaveTextContent('Test message');
     });

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -85,4 +85,10 @@ describe('Alert', () => {
 
         expect(await screen.findByText(customIconText)).toBeInTheDocument();
     });
+
+    test('pass `qa` attribute correctly w/ theme="clear"', async () => {
+        render(<Alert qa="test" message="Test message" />);
+
+        expect(screen.getByTestId('test')).toHaveTextContent('Test message');
+    });
 });

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -49,7 +49,6 @@ export const Alert = (rawProps: AlertProps) => {
     const commonProps = {
         style,
         className: bAlert({corners, size, align: align}, className),
-        ...(theme === 'clear' ? {'data-qa': qa} : {qa}),
     };
 
     const {t} = i18n.useTranslation();
@@ -110,9 +109,11 @@ export const Alert = (rawProps: AlertProps) => {
     return (
         <AlertContextProvider layout={layout} view={view} size={size} actionsLayout={actionsLayout}>
             {theme === 'clear' ? (
-                <div {...commonProps}>{content}</div>
+                <div {...commonProps} data-qa={qa}>
+                    {content}
+                </div>
             ) : (
-                <Card {...commonProps} theme={theme} view={view}>
+                <Card {...commonProps} qa={qa} theme={theme} view={view}>
                     {content}
                 </Card>
             )}

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -49,7 +49,7 @@ export const Alert = (rawProps: AlertProps) => {
     const commonProps = {
         style,
         className: bAlert({corners, size, align: align}, className),
-        qa,
+        ...(theme === 'clear' ? {'data-qa': qa} : {qa}),
     };
 
     const {t} = i18n.useTranslation();


### PR DESCRIPTION
## Summary by Sourcery

Adjust Alert qa attribute handling for clear theme and add test coverage for the behavior.

Bug Fixes:
- Ensure the Alert component passes the qa attribute via data-qa when using the clear theme.

Tests:
- Add a test verifying that the qa attribute is correctly applied for Alert with theme="clear".