### PR TITLE
fix(ColorPicker): set a tabIndex so that Safari allows focusing buttons

### DIFF
--- a/src/components/lab/ColorPicker/components/ColorDisplay/ColorDisplay.tsx
+++ b/src/components/lab/ColorPicker/components/ColorDisplay/ColorDisplay.tsx
@@ -41,6 +41,8 @@ export const ColorDisplay = React.forwardRef<HTMLDivElement, ColorDisplayProps>(
             <button
                 type="button"
                 disabled={disabled}
+                // Always set a tabIndex so that Safari allows focusing native buttons
+                tabIndex={disabled ? undefined : 0}
                 className={b('color-swatch', {size, disabled})}
                 onClick={onClick}
                 style={{backgroundColor: hsvaToRgbaString(hsva)}}


### PR DESCRIPTION
🤖 AI generated

## What does this PR do?

Adds an explicit `tabIndex` to the `ColorPicker` swatch button:

```tsx
tabIndex={disabled ? undefined : 0}
```

The enabled swatch remains in the natural tab order, while the disabled swatch does not receive a `tabIndex`.

## Why is this needed?

Safari on macOS does not focus native `<button>` elements on mouse click by default. As a result, the `ColorPicker` swatch did not become `document.activeElement` when clicked.

This caused a problem when a compact `ColorPicker` was rendered inside another control, such as the `startContent` of a `TextInput`.

`TextInput` checks whether the clicked additional content owns focus. If the swatch is not focused, `TextInput` focuses its native input instead. This triggers the input's `onFocus` handler and may open its focus-driven popup at the same time as the `ColorPicker` popup, resulting in two popups being opened from a single click.

Chromium-based browsers focus the swatch on click, so the issue was primarily visible in Safari.

## How is it fixed?

Setting an explicit `tabIndex={0}` makes Safari focus the swatch on mouse click. The surrounding `TextInput` then detects that focus remains inside its `startContent` and does not move focus to the input.

This behavior is consistent with the existing UIKit `Button` implementation, which uses the same workaround for Safari.

For a disabled swatch, `tabIndex` remains unset, preserving the native disabled behavior and keeping it out of the tab order.

## Related PR

  This follows the same Safari focus workaround previously introduced for `Button` in #2440.

## Summary by Sourcery

Bug Fixes:
- Fix ColorPicker focus behavior in Safari so swatch buttons become the active element on click without affecting disabled swatches.