### PR TITLE
fix(Accordion): sync defaultExpanded with shared accordion state

### DIFF
--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -54,8 +54,7 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
             value,
             onUpdate,
         });
-        const disclosureExpanded =
-            expanded !== undefined || defaultExpanded !== true ? isExpanded : undefined;
+        const disclosureExpanded = isExpanded;
 
         const [preparedSummary, details] = React.useMemo(() => {
             return prepareChildren(children, qa);
@@ -68,7 +67,6 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
                 keepMounted={keepMounted}
                 onUpdate={handleUpdate}
                 expanded={disclosureExpanded}
-                defaultExpanded={defaultExpanded}
                 summary={summary}
                 disabled={disabled}
                 qa={qa}
@@ -102,32 +100,53 @@ function useAccordionItemState({
     const id = useUniqId();
     const {items, updateItems} = useAccordion();
     const isControlledItem = expanded !== undefined;
-    const hasDefaultExpanded = defaultExpanded === true;
+    const itemValue = value ?? id;
+    const seededDefaultExpanded = React.useRef(false);
+
+    // Seed defaultExpanded=true into shared accordion state so the item stays
+    // in sync with exclusive open/close (Disclosure alone cannot do that).
+    React.useLayoutEffect(() => {
+        if (seededDefaultExpanded.current || isControlledItem || defaultExpanded !== true) {
+            return;
+        }
+        seededDefaultExpanded.current = true;
+        const alreadyOpen = Array.isArray(items)
+            ? items.includes(itemValue)
+            : items === itemValue;
+        if (!alreadyOpen) {
+            updateItems(itemValue);
+        }
+    }, [isControlledItem, defaultExpanded, itemValue, items, updateItems]);
 
     const isExpanded = React.useMemo(() => {
         if (isControlledItem) {
             return expanded;
         }
 
-        if (hasDefaultExpanded) {
-            return false;
-        }
-
         if (Array.isArray(items)) {
-            return items.includes(value ?? id);
+            return items.includes(itemValue);
         }
 
-        return items === (value ?? id);
-    }, [isControlledItem, expanded, hasDefaultExpanded, items, value, id]);
+        if (items === itemValue) {
+            return true;
+        }
+
+        // Honor defaultExpanded on the first paint before the seed effect runs.
+        if (defaultExpanded === true && !seededDefaultExpanded.current) {
+            return true;
+        }
+
+        return false;
+    }, [isControlledItem, expanded, items, itemValue, defaultExpanded]);
 
     const handleUpdate = React.useCallback(
         (next: boolean) => {
             onUpdate?.(next);
-            if (!isControlledItem && !hasDefaultExpanded) {
-                updateItems(value ?? id);
+            if (!isControlledItem) {
+                updateItems(itemValue);
             }
         },
-        [onUpdate, isControlledItem, hasDefaultExpanded, updateItems, value, id],
+        [onUpdate, isControlledItem, updateItems, itemValue],
     );
     return {id, isExpanded, handleUpdate};
 }

--- a/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -291,6 +291,38 @@ describe('Accordion', () => {
         expect(content2.className).toContain('g-disclosure__content_visible');
     });
 
+    test('AccordionItem with defaultExpanded=true closes when another item opens', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Accordion>
+                <Accordion.Item qa="item-1" summary="Item 1" defaultExpanded>
+                    Content 1
+                </Accordion.Item>
+                <Accordion.Item qa="item-2" summary="Item 2">
+                    Content 2
+                </Accordion.Item>
+            </Accordion>,
+        );
+
+        const content1 = screen.getByText('Content 1');
+        const content2 = screen.getByText('Content 2');
+        const summary1 = screen.getByTestId('item-1-summary');
+        const summary2 = screen.getByTestId('item-2-summary');
+
+        expect(content1.className).toContain('g-disclosure__content_visible');
+
+        await user.click(summary2);
+
+        expect(content1.className).not.toContain('g-disclosure__content_visible');
+        expect(content2.className).toContain('g-disclosure__content_visible');
+
+        await user.click(summary1);
+
+        expect(content1.className).toContain('g-disclosure__content_visible');
+        expect(content2.className).not.toContain('g-disclosure__content_visible');
+    });
+
     test('disabled AccordionItem cannot be expanded', async () => {
         const user = userEvent.setup();
 


### PR DESCRIPTION
﻿## Summary
- Seed `defaultExpanded={true}` into shared accordion `items` so Disclosure stays controlled by accordion state
- Always pass `expanded={isExpanded}` (stop leaving Disclosure uncontrolled when `defaultExpanded` is true)
- Add a regression test: a `defaultExpanded` item closes when another item opens, and can reopen

Closes #2718

## Test plan
- [ ] Accordion unit tests for `defaultExpanded` (existing + new exclusive-open test)

## Summary by Sourcery

Synchronize AccordionItem defaultExpanded behavior with shared accordion state so items remain controlled and exclusive, and add coverage for the default-expanded exclusive-open scenario.

Bug Fixes:
- Ensure Accordion items with defaultExpanded=true stay in sync with shared accordion state and close when other items open.

Tests:
- Add a regression test verifying a defaultExpanded item closes when another item opens and can be reopened.