### PR TITLE
fix(Select): fix availability of error popover with placement inside

### DIFF
--- a/src/components/Select/__tests__/Select.error.test.tsx
+++ b/src/components/Select/__tests__/Select.error.test.tsx
@@ -1,3 +1,5 @@
+import userEvent from '@testing-library/user-event';
+
 import {render, screen} from '../../../../test-utils/utils';
 import {CONTROL_ERROR_MESSAGE_QA} from '../../controls/utils';
 import {Select} from '../Select';
@@ -81,5 +83,24 @@ describe('Select error', () => {
         render(<Select errorMessage={''} errorPlacement="inside" />);
 
         expect(screen.queryByLabelText('Show popup with error info')).not.toBeInTheDocument();
+    });
+
+    test('opens inside error popover on hover', async () => {
+        const ERROR_MESSAGE = 'Test error message';
+
+        const {findByText, getByRole} = setup();
+        render(
+            <Select
+                validationState="invalid"
+                errorMessage={ERROR_MESSAGE}
+                errorPlacement="inside"
+            />,
+        );
+
+        await userEvent.hover(getByRole('button', {name: 'Show popup with error info'}));
+
+        const popoverElement = await findByText(ERROR_MESSAGE);
+
+        await expect(popoverElement).toBeInTheDocument();
     });
 });

--- a/src/components/Select/components/SelectControl/SelectControl.scss
+++ b/src/components/Select/components/SelectControl/SelectControl.scss
@@ -239,6 +239,7 @@ $blockButton: '.#{variables.$ns}select-control__button';
     &__error-icon {
         @include mixins.button-reset();
         box-sizing: content-box;
+        z-index: 1;
         color: var(--g-color-text-danger);
         padding: var(--_--text-input-error-icon-padding);
         border-radius: var(--g-focus-border-radius);


### PR DESCRIPTION
Closes  #2759

## Summary by Sourcery

Ensure Select shows its inside error popover when hovering the error icon by adjusting stacking and adding a regression test.

Bug Fixes:
- Fix inside-placed Select error icon so its popover opens on hover instead of being blocked by the control’s decorative layer.

Enhancements:
- Document the design rationale and scope for the Select inside error popover stacking fix in a new spec file.

Tests:
- Add a Playwright visual regression test that verifies the inside error popover becomes visible when hovering the Select error icon.