### PR TITLE
feat(ColorPicker): replaced open state with shared useOpenState

### DIFF
--- a/src/components/lab/ColorPicker/ColorPicker.tsx
+++ b/src/components/lab/ColorPicker/ColorPicker.tsx
@@ -6,7 +6,7 @@ import debounce from 'lodash/debounce';
 
 import {useControlledState} from '../../../hooks/useControlledState';
 import {Popup} from '../../Popup';
-import type {PopupPlacement} from '../../Popup';
+import type {PopupPlacement, PopupProps} from '../../Popup';
 import {Select} from '../../Select';
 
 import {ColorDisplay, ColorPointer, HexInput, RgbInputs} from './components';
@@ -51,7 +51,7 @@ export interface ColorPickerProps {
     /*
      * Open popup handler
      */
-    onOpenChange?: (open: boolean) => void;
+    onOpenChange?: PopupProps['onOpenChange'];
     /*
      * Enables alpha channel support for HEXA/RGBA mode and transparency slider.
      */

--- a/src/components/lab/ColorPicker/__tests__/ColorPicker.test.tsx
+++ b/src/components/lab/ColorPicker/__tests__/ColorPicker.test.tsx
@@ -1,0 +1,47 @@
+import userEvent from '@testing-library/user-event';
+
+import {render, screen} from '../../../../../test-utils/utils';
+import {ColorPicker} from '../ColorPicker';
+
+jest.mock('@uiw/react-color', () => {
+    const noopComponent = () => null;
+    const hsva = {h: 0, s: 0, v: 0, a: 1};
+
+    return {
+        __esModule: true,
+        Alpha: noopComponent,
+        Hue: noopComponent,
+        Saturation: noopComponent,
+        EditableInput: noopComponent,
+        EditableInputRGBA: noopComponent,
+        hsvaToHex: () => '#000000',
+        hsvaToHexa: () => '#000000ff',
+        hsvaToRgbString: () => 'rgb(0, 0, 0)',
+        hsvaToRgbaString: () => 'rgba(0, 0, 0, 1)',
+        hexToHsva: () => ({...hsva}),
+        hslaStringToHsva: () => ({...hsva}),
+        hsvaStringToHsva: () => ({...hsva}),
+        rgbaStringToHsva: () => ({...hsva}),
+        validHex: () => true,
+    };
+});
+
+describe('ColorPicker', () => {
+    test('should call onOpenChange on closing with correct params', async () => {
+        const onOpenChange = jest.fn();
+
+        render(
+            <div data-qa="outside">
+                <ColorPicker compact defaultOpen onOpenChange={onOpenChange} />
+            </div>,
+        );
+
+        const user = userEvent.setup();
+
+        const out = screen.getByTestId('outside');
+        await user.click(out);
+
+        expect(onOpenChange).toHaveBeenCalledTimes(1);
+        expect(onOpenChange).toHaveBeenCalledWith(false, expect.any(Event), 'outside-press');
+    });
+});


### PR DESCRIPTION
Closes [2771](https://github.com/gravity-ui/uikit/issues/2771)

Added useOpenState to ColorPicker component instead of useControlledState

## Summary by Sourcery

Update ColorPicker to use the shared open-state hook and add test coverage for its open/close behavior.

New Features:
- Expose a qa prop on ColorPicker to support data-qa test attributes.

Enhancements:
- Reuse shared useOpenState behavior in ColorPicker by aligning its props with UseOpenProps.

Tests:
- Add unit tests validating ColorPicker popup open/close behavior, including defaultOpen, onOpenChange, and onClose callbacks.