### PR TITLE
feat(stacked-on-2779): add parserless Code Connect pilot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
         run: npm run typecheck
       - name: Test Code Connect validator
         run: npm run code-connect:test
+      - name: Typecheck Code Connect templates
+        run: npx tsc -p tsconfig.figma.json --noEmit
+      - name: Parse Code Connect templates
+        run: >-
+          npx figma connect parse
+          --config figma.config.json
+          --skip-update-check
+          --exit-on-unreadable-files
 
   unit_tests:
     name: Unit Tests

--- a/code-connect/figma.schema.snapshot.json
+++ b/code-connect/figma.schema.snapshot.json
@@ -1,0 +1,203 @@
+{
+  "schemaVersion": 1,
+  "fileKey": "LlrQIz4F2Y06FJRdB4iE9U",
+  "components": [
+    {
+      "component": "Avatar",
+      "nodeId": "53348:563633",
+      "template": "src/components/Avatar/Avatar.figma.ts",
+      "properties": [
+        {
+          "rawKey": "Custom border#60413:26",
+          "name": "Custom border",
+          "type": "BOOLEAN",
+          "defaultValue": false,
+          "enumOptions": []
+        },
+        {
+          "rawKey": "Icon#58291:411",
+          "name": "Icon",
+          "type": "INSTANCE_SWAP",
+          "defaultValue": "53348:563454",
+          "enumOptions": []
+        },
+        {
+          "rawKey": "Size",
+          "name": "Size",
+          "type": "VARIANT",
+          "defaultValue": "M",
+          "enumOptions": ["3XS", "2XS", "XS", "S", "M", "L", "XL"]
+        },
+        {
+          "rawKey": "Theme",
+          "name": "Theme",
+          "type": "VARIANT",
+          "defaultValue": "Brand",
+          "enumOptions": ["Brand", "Normal"]
+        },
+        {
+          "rawKey": "Type",
+          "name": "Type",
+          "type": "VARIANT",
+          "defaultValue": "Icon",
+          "enumOptions": ["Image", "Icon", "Text"]
+        },
+        {
+          "rawKey": "View",
+          "name": "View",
+          "type": "VARIANT",
+          "defaultValue": "Filled",
+          "enumOptions": ["Filled", "Outlined"]
+        },
+        {
+          "rawKey": "↳ Content text#58319:0",
+          "name": "↳ Content text",
+          "type": "TEXT",
+          "defaultValue": "AB",
+          "enumOptions": []
+        }
+      ]
+    },
+    {
+      "component": "Button",
+      "nodeId": "53098:497062",
+      "template": "src/components/Button/Button.figma.ts",
+      "properties": [
+        {
+          "rawKey": " ↳ End icon#2:843",
+          "name": "↳ End icon",
+          "type": "INSTANCE_SWAP",
+          "defaultValue": "45081:496944",
+          "enumOptions": []
+        },
+        {
+          "rawKey": " ↳ Start icon#2:0",
+          "name": "↳ Start icon",
+          "type": "INSTANCE_SWAP",
+          "defaultValue": "48132:444831",
+          "enumOptions": []
+        },
+        {
+          "rawKey": "Content#2:1405",
+          "name": "Content",
+          "type": "TEXT",
+          "defaultValue": "Content",
+          "enumOptions": []
+        },
+        {
+          "rawKey": "End icon#2:562",
+          "name": "End icon",
+          "type": "BOOLEAN",
+          "defaultValue": false,
+          "enumOptions": []
+        },
+        {
+          "rawKey": "Icon only",
+          "name": "Icon only",
+          "type": "VARIANT",
+          "defaultValue": "Off",
+          "enumOptions": ["Off", "On"]
+        },
+        {
+          "rawKey": "Size",
+          "name": "Size",
+          "type": "VARIANT",
+          "defaultValue": "M",
+          "enumOptions": ["XS", "S", "M", "L", "XL"]
+        },
+        {
+          "rawKey": "Start icon#2:281",
+          "name": "Start icon",
+          "type": "BOOLEAN",
+          "defaultValue": true,
+          "enumOptions": []
+        },
+        {
+          "rawKey": "State",
+          "name": "State",
+          "type": "VARIANT",
+          "defaultValue": "Default",
+          "enumOptions": ["Default", "Hover", "Disabled", "Loading", "Selected"]
+        },
+        {
+          "rawKey": "View",
+          "name": "View",
+          "type": "VARIANT",
+          "defaultValue": "Normal",
+          "enumOptions": [
+            "Normal",
+            "Action",
+            "Outline",
+            "Outline-info",
+            "Outlined-success",
+            "Outlined-warning",
+            "Outline-danger",
+            "Outline-utility",
+            "Outlined-action",
+            "Flat",
+            "Flat-info",
+            "Flat-success",
+            "Flat-warning",
+            "Flat-danger",
+            "Flat-utility",
+            "Flat-action",
+            "Flat-secondary",
+            "Raised",
+            "Normal-contrast",
+            "Outline-contrast",
+            "Flat-contrast"
+          ]
+        }
+      ]
+    },
+    {
+      "component": "Checkbox",
+      "nodeId": "53103:9376",
+      "template": "src/components/Checkbox/Checkbox.figma.ts",
+      "properties": [
+        {
+          "rawKey": "Checked",
+          "name": "Checked",
+          "type": "VARIANT",
+          "defaultValue": "Off",
+          "enumOptions": ["Off", "On"]
+        },
+        {
+          "rawKey": "Content#48571:38",
+          "name": "Content",
+          "type": "BOOLEAN",
+          "defaultValue": true,
+          "enumOptions": []
+        },
+        {
+          "rawKey": "Indeterminate",
+          "name": "Indeterminate",
+          "type": "VARIANT",
+          "defaultValue": "Off",
+          "enumOptions": ["On", "Off"]
+        },
+        {
+          "rawKey": "Size",
+          "name": "Size",
+          "type": "VARIANT",
+          "defaultValue": "M",
+          "enumOptions": ["M", "L", "XL"]
+        },
+        {
+          "rawKey": "State",
+          "name": "State",
+          "type": "VARIANT",
+          "defaultValue": "Default",
+          "enumOptions": ["Default", "Hover", "Disabled"]
+        },
+        {
+          "rawKey": "↳ Content text#45013:38",
+          "name": "↳ Content text",
+          "type": "TEXT",
+          "defaultValue": "Content",
+          "enumOptions": []
+        }
+      ]
+    }
+  ]
+}

--- a/code-connect/ignores.json
+++ b/code-connect/ignores.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "ignores": [
+    {
+      "component": "Avatar",
+      "nodeId": "53348:563633",
+      "rawKey": "Custom border#60413:26",
+      "reason": "The Figma boolean does not encode the public borderColor value; visual tokens and styles are outside this contract."
+    },
+    {
+      "component": "Avatar",
+      "nodeId": "53348:563633",
+      "rawKey": "Icon#58291:411",
+      "reason": "Instance-swap mapping requires the separate @gravity-ui/icons Code Connect batch."
+    },
+    {
+      "component": "Button",
+      "nodeId": "53098:497062",
+      "rawKey": " ↳ End icon#2:843",
+      "reason": "Instance-swap mapping requires the separate @gravity-ui/icons Code Connect batch."
+    },
+    {
+      "component": "Button",
+      "nodeId": "53098:497062",
+      "rawKey": " ↳ Start icon#2:0",
+      "reason": "Instance-swap mapping requires the separate @gravity-ui/icons Code Connect batch."
+    }
+  ]
+}

--- a/src/components/Avatar/Avatar.figma.ts
+++ b/src/components/Avatar/Avatar.figma.ts
@@ -1,0 +1,62 @@
+// url=https://www.figma.com/design/LlrQIz4F2Y06FJRdB4iE9U/Gravity-UI-Design-System--Community-?node-id=53348-563633
+// source=https://github.com/gravity-ui/uikit/blob/main/src/components/Avatar/Avatar.tsx
+// component=Avatar
+
+import figma from 'figma';
+
+import type {AvatarProps} from './types/main';
+
+type AvatarImageProps = Extract<AvatarProps, {imgUrl: string}>;
+type AvatarTextProps = Extract<AvatarProps, {text: string}>;
+type AvatarType = 'icon' | 'image' | 'text';
+
+const type = figma.selectedInstance.getEnum('Type', {
+    Image: 'image',
+    Icon: 'icon',
+    Text: 'text',
+} satisfies Record<string, AvatarType>);
+const size = figma.selectedInstance.getEnum('Size', {
+    '3XS': '3xs',
+    '2XS': '2xs',
+    XS: 'xs',
+    S: 's',
+    M: 'm',
+    L: 'l',
+    XL: 'xl',
+} satisfies Record<string, NonNullable<AvatarProps['size']>>);
+const view = figma.selectedInstance.getEnum('View', {
+    Filled: 'filled',
+    Outlined: 'outlined',
+} satisfies Record<string, NonNullable<AvatarProps['view']>>);
+const theme = figma.selectedInstance.getEnum('Theme', {
+    Brand: 'brand',
+    Normal: 'normal',
+} satisfies Record<string, NonNullable<AvatarProps['theme']>>);
+const text = figma.selectedInstance.getString('↳ Content text') satisfies AvatarTextProps['text'];
+const imageUrl = '/path/to/avatar.png' satisfies AvatarImageProps['imgUrl'];
+
+let template;
+if (type === 'text') {
+    template = {
+        example: figma.code`<Avatar${figma.helpers.react.renderProp('size', size)}${figma.helpers.react.renderProp('view', view)}${figma.helpers.react.renderProp('theme', theme)}${figma.helpers.react.renderProp('text', text)} />`,
+        imports: ["import {Avatar} from '@gravity-ui/uikit';"],
+        id: 'Avatar',
+        metadata: {nestable: true},
+    };
+} else if (type === 'image') {
+    template = {
+        example: figma.code`<Avatar${figma.helpers.react.renderProp('size', size)}${figma.helpers.react.renderProp('view', view)}${figma.helpers.react.renderProp('theme', theme)}${figma.helpers.react.renderProp('imgUrl', imageUrl)} />`,
+        imports: ["import {Avatar} from '@gravity-ui/uikit';"],
+        id: 'Avatar',
+        metadata: {nestable: true},
+    };
+} else {
+    template = {
+        example: figma.code`/* Avatar Type=Icon is deferred until @gravity-ui/icons has Code Connect mappings. */`,
+        imports: ["import {Avatar} from '@gravity-ui/uikit';"],
+        id: 'Avatar',
+        metadata: {nestable: true},
+    };
+}
+
+export default template;

--- a/src/components/Button/Button.figma.ts
+++ b/src/components/Button/Button.figma.ts
@@ -1,0 +1,74 @@
+// url=https://www.figma.com/design/LlrQIz4F2Y06FJRdB4iE9U/Gravity-UI-Design-System--Community-?node-id=53098-497062
+// source=https://github.com/gravity-ui/uikit/blob/main/src/components/Button/Button.tsx
+// component=Button
+
+import figma from 'figma';
+
+import type {ButtonProps} from './Button';
+
+type ButtonStateMapping = Pick<ButtonProps, 'disabled' | 'loading' | 'selected'> & {
+    note: string | undefined;
+};
+
+const view = figma.selectedInstance.getEnum('View', {
+    Normal: 'normal',
+    Action: 'action',
+    Outline: 'outlined',
+    'Outline-info': 'outlined-info',
+    'Outlined-success': 'outlined-success',
+    'Outlined-warning': 'outlined-warning',
+    'Outline-danger': 'outlined-danger',
+    'Outline-utility': 'outlined-utility',
+    'Outlined-action': 'outlined-action',
+    Flat: 'flat',
+    'Flat-info': 'flat-info',
+    'Flat-success': 'flat-success',
+    'Flat-warning': 'flat-warning',
+    'Flat-danger': 'flat-danger',
+    'Flat-utility': 'flat-utility',
+    'Flat-action': 'flat-action',
+    'Flat-secondary': 'flat-secondary',
+    Raised: 'raised',
+    'Normal-contrast': 'normal-contrast',
+    'Outline-contrast': 'outlined-contrast',
+    'Flat-contrast': 'flat-contrast',
+} satisfies Record<string, NonNullable<ButtonProps['view']>>);
+const size = figma.selectedInstance.getEnum('Size', {
+    XS: 'xs',
+    S: 's',
+    M: 'm',
+    L: 'l',
+    XL: 'xl',
+} satisfies Record<string, NonNullable<ButtonProps['size']>>);
+const state = figma.selectedInstance.getEnum('State', {
+    Default: {disabled: undefined, loading: undefined, selected: undefined, note: ''},
+    Hover: {
+        disabled: undefined,
+        loading: undefined,
+        selected: undefined,
+        note: '/* Hover is represented by the Figma state and has no separate Button prop. */',
+    },
+    Disabled: {disabled: true, loading: undefined, selected: undefined, note: ''},
+    Loading: {disabled: undefined, loading: true, selected: undefined, note: ''},
+    Selected: {disabled: undefined, loading: undefined, selected: true, note: ''},
+} satisfies Record<string, ButtonStateMapping>);
+const content = figma.selectedInstance.getString('Content');
+const startIcon = figma.selectedInstance.getBoolean('Start icon');
+const endIcon = figma.selectedInstance.getBoolean('End icon');
+const iconOnly = figma.selectedInstance.getEnum('Icon only', {
+    Off: false,
+    On: true,
+} satisfies Record<string, boolean>);
+
+const iconNote =
+    startIcon || endIcon || iconOnly
+        ? '/* Icon rendering is deferred until @gravity-ui/icons has Code Connect mappings. */'
+        : '';
+
+export default {
+    example: figma.code`<Button${figma.helpers.react.renderProp('view', view)}${figma.helpers.react.renderProp('size', size)}${figma.helpers.react.renderProp('disabled', state?.disabled)}${figma.helpers.react.renderProp('loading', state?.loading)}${figma.helpers.react.renderProp('selected', state?.selected)}>${content}</Button>
+${state?.note}${iconNote}`,
+    imports: ["import {Button} from '@gravity-ui/uikit';"],
+    id: 'Button',
+    metadata: {nestable: true},
+};

--- a/src/components/Checkbox/Checkbox.figma.ts
+++ b/src/components/Checkbox/Checkbox.figma.ts
@@ -1,0 +1,42 @@
+// url=https://www.figma.com/design/LlrQIz4F2Y06FJRdB4iE9U/Gravity-UI-Design-System--Community-?node-id=53103-9376
+// source=https://github.com/gravity-ui/uikit/blob/main/src/components/Checkbox/Checkbox.tsx
+// component=Checkbox
+
+import figma from 'figma';
+
+import type {CheckboxProps} from './Checkbox';
+
+type CheckboxStateMapping = Pick<CheckboxProps, 'disabled'> & {note: string | undefined};
+
+const size = figma.selectedInstance.getEnum('Size', {
+    M: 'm',
+    L: 'l',
+    XL: 'xl',
+} satisfies Record<string, NonNullable<CheckboxProps['size']>>);
+const checked = figma.selectedInstance.getEnum('Checked', {
+    Off: false,
+    On: true,
+} satisfies Record<string, NonNullable<CheckboxProps['checked']>>);
+const indeterminate = figma.selectedInstance.getEnum('Indeterminate', {
+    On: true,
+    Off: false,
+} satisfies Record<string, NonNullable<CheckboxProps['indeterminate']>>);
+const state = figma.selectedInstance.getEnum('State', {
+    Default: {disabled: undefined, note: ''},
+    Hover: {
+        disabled: undefined,
+        note: '/* Hover is represented by the Figma state and has no separate Checkbox prop. */',
+    },
+    Disabled: {disabled: true, note: ''},
+} satisfies Record<string, CheckboxStateMapping>);
+const hasContent = figma.selectedInstance.getBoolean('Content');
+const contentText = figma.selectedInstance.getString('↳ Content text');
+const content = hasContent ? contentText : undefined;
+
+export default {
+    example: figma.code`<Checkbox${figma.helpers.react.renderProp('size', size)}${figma.helpers.react.renderProp('checked', checked)}${figma.helpers.react.renderProp('indeterminate', indeterminate)}${figma.helpers.react.renderProp('disabled', state?.disabled)}${figma.helpers.react.renderProp('content', content)} />
+${state?.note}`,
+    imports: ["import {Checkbox} from '@gravity-ui/uikit';"],
+    id: 'Checkbox',
+    metadata: {nestable: true},
+};


### PR DESCRIPTION
Part of #2776. This is PR 3 of 3, stacked on #2779, and supersedes the component implementation in #2742.

> Review this PR against `astandrik.code-connect-contract-tooling`. Its diff is limited to the deterministic schema/ignores, three parserless templates, and their two CI gates.

## What changed

- Add deterministic `code-connect/figma.schema.snapshot.json` for the allowlisted Community file with no timestamp.
- Add `code-connect/ignores.json` containing only reasoned instance-swap/style exceptions.
- Replace the legacy `.figma.tsx`/React parser approach with colocated parserless `.figma.ts` templates.
- Enable Figma template typecheck and parserless parse in normal CI.

## Component mappings

### Button

- Map all 21 `View` values and all `Size`, `State`, `Content`, and icon-state controls.
- Derive `disabled`, `loading`, and `selected` from Figma state.
- Emit an honest deferred note for active icon states instead of substituting an arbitrary icon.
- Defer start/end instance swaps to the separate `@gravity-ui/icons` Code Connect batch.

### Avatar

- Map `Type`, `Size`, `View`, `Theme`, and content.
- Support text and image branches.
- Keep `Type=Icon` deferred without substituting a fixed `FaceRobot`.
- Ignore the icon swap and custom border only with explicit reasons.

### Checkbox

- Map `Size`, `Checked`, `Indeterminate`, `State`, and content.
- Preserve Hover as an explicit Figma state even though it has no separate React prop.

## Validation

- `npm run typecheck`
- `npm run code-connect:test` — 26/26
- `npx tsc -p tsconfig.figma.json --noEmit`
- `npx figma connect parse --config figma.config.json --skip-update-check --exit-on-unreadable-files`
- `git diff --check`

`npm run code-connect:check` completes all local gates and reports `AUTH_BLOCKED / MISSING_FIGMA_TOKEN` at the mandatory live-freshness boundary when no Plan Access Token is present.

No Code Connect mapping was previewed or published while preparing this PR.
