### PR TITLE
feat(ScrollShadow): add experimental component

### DIFF
--- a/src/components/lab/ScrollShadow/README.md
+++ b/src/components/lab/ScrollShadow/README.md
@@ -1,0 +1,62 @@
+# unstable_ScrollShadow
+
+> The `unstable_ScrollShadow` component is experimental. Its API can change in a minor or patch release.
+
+`ScrollShadow` is a native scroll container that adds shadows only at the edges where more content is available. It can track the block axis, the inline axis, or both logical axes and therefore adapts to RTL layouts.
+
+## Basic usage
+
+Set a constrained block or inline size on the component so its content can overflow:
+
+```tsx
+import {unstable_ScrollShadow as ScrollShadow} from '@gravity-ui/uikit/unstable';
+
+<ScrollShadow style={{maxBlockSize: 320}}>
+  <LongContent />
+</ScrollShadow>;
+```
+
+`ScrollShadow` itself is the element with native scrolling. You do not need to add another element with `overflow: auto`.
+It is keyboard-focusable by default so that keyboard users can scroll it; pass another `tabIndex` when an application needs different focus behavior.
+
+## Axes and positions
+
+The API uses logical directions. The default `axis="block"` works for vertically scrolling content. Use the inline axis for horizontal content, or both axes for a large two-dimensional surface:
+
+```tsx
+<ScrollShadow axis="inline">...</ScrollShadow>
+<ScrollShadow axis="both">...</ScrollShadow>
+```
+
+`position` limits shadows to the logical start, logical end, or both edges. A shadow is still hidden when the scroll position has reached that edge:
+
+```tsx
+<ScrollShadow position="end">...</ScrollShadow>
+```
+
+## CSS API
+
+The shadow size and color are customized with CSS variables:
+
+```css
+.custom-scroll-shadow {
+  --g-scroll-shadow-size: 40px;
+  --g-scroll-shadow-color: rgba(61, 152, 255, 0.35);
+}
+```
+
+| Variable                  | Description  | Default                |
+| :------------------------ | :----------- | :--------------------- |
+| `--g-scroll-shadow-size`  | Shadow depth | `24px`                 |
+| `--g-scroll-shadow-color` | Shadow color | `--g-color-sfx-shadow` |
+
+## Properties
+
+`ScrollShadow` accepts native `div` attributes, including `className`, `style`, `onScroll`, and ARIA attributes.
+
+| Name       | Description                                              | Type                            | Default   |
+| :--------- | :------------------------------------------------------- | :------------------------------ | :-------- |
+| `axis`     | Logical scroll axis to observe                           | `"block" \| "inline" \| "both"` | `"block"` |
+| `position` | Logical edges where a shadow can appear                  | `"start" \| "end" \| "both"`    | `"both"`  |
+| `disabled` | Hides all shadows while keeping native scrolling enabled | `boolean`                       | `false`   |
+| `children` | Scrollable content                                       | `React.ReactNode`               |           |

--- a/src/components/lab/ScrollShadow/README.md
+++ b/src/components/lab/ScrollShadow/README.md
@@ -36,7 +36,7 @@ The API uses logical directions. The default `axis="block"` works for vertically
 
 ## CSS API
 
-The shadow size and color are customized with CSS variables:
+The shadow depth and edge fade color are customized with CSS variables:
 
 ```css
 .custom-scroll-shadow {
@@ -45,10 +45,10 @@ The shadow size and color are customized with CSS variables:
 }
 ```
 
-| Variable                  | Description  | Default                |
-| :------------------------ | :----------- | :--------------------- |
-| `--g-scroll-shadow-size`  | Shadow depth | `24px`                 |
-| `--g-scroll-shadow-color` | Shadow color | `--g-color-sfx-shadow` |
+| Variable                  | Description     | Default                                                            |
+| :------------------------ | :-------------- | :----------------------------------------------------------------- |
+| `--g-scroll-shadow-size`  | Shadow depth    | `24px`                                                             |
+| `--g-scroll-shadow-color` | Edge fade color | `--g-color-sfx-shadow` (light), `--g-color-base-background` (dark) |
 
 ## Properties
 

--- a/src/components/lab/ScrollShadow/ScrollShadow.scss
+++ b/src/components/lab/ScrollShadow/ScrollShadow.scss
@@ -2,10 +2,24 @@
 @use '../../../../styles/mixins';
 
 $block: '.#{variables.$ns}scroll-shadow';
+$root: '.#{variables.$ns}root';
+
+#{$root}_theme_light,
+#{$root}_theme_light-hc {
+    --_--scroll-shadow-default-color: var(--g-color-sfx-shadow);
+}
+
+#{$root}_theme_dark,
+#{$root}_theme_dark-hc {
+    --_--scroll-shadow-default-color: var(--g-color-base-background);
+}
 
 #{$block} {
     --_--size: var(--g-scroll-shadow-size, 24px);
-    --_--color: var(--g-scroll-shadow-color, var(--g-color-sfx-shadow));
+    --_--color: var(
+        --g-scroll-shadow-color,
+        var(--_--scroll-shadow-default-color, var(--g-color-sfx-shadow))
+    );
     --_--top-color: transparent;
     --_--right-color: transparent;
     --_--bottom-color: transparent;

--- a/src/components/lab/ScrollShadow/ScrollShadow.scss
+++ b/src/components/lab/ScrollShadow/ScrollShadow.scss
@@ -1,0 +1,49 @@
+@use '../../variables';
+@use '../../../../styles/mixins';
+
+$block: '.#{variables.$ns}scroll-shadow';
+
+#{$block} {
+    --_--size: var(--g-scroll-shadow-size, 24px);
+    --_--color: var(--g-scroll-shadow-color, var(--g-color-sfx-shadow));
+    --_--top-color: transparent;
+    --_--right-color: transparent;
+    --_--bottom-color: transparent;
+    --_--left-color: transparent;
+
+    overflow: auto;
+    box-shadow:
+        inset 0 var(--_--size) var(--_--size) calc(var(--_--size) * -1) var(--_--top-color),
+        inset calc(var(--_--size) * -1) 0 var(--_--size) calc(var(--_--size) * -1)
+            var(--_--right-color),
+        inset 0 calc(var(--_--size) * -1) var(--_--size) calc(var(--_--size) * -1)
+            var(--_--bottom-color),
+        inset var(--_--size) 0 var(--_--size) calc(var(--_--size) * -1) var(--_--left-color);
+    transition: box-shadow 0.15s ease-out;
+
+    &:focus-visible {
+        @include mixins.focus-outline();
+    }
+
+    &[data-scroll-shadow-top] {
+        --_--top-color: var(--_--color);
+    }
+
+    &[data-scroll-shadow-right] {
+        --_--right-color: var(--_--color);
+    }
+
+    &[data-scroll-shadow-bottom] {
+        --_--bottom-color: var(--_--color);
+    }
+
+    &[data-scroll-shadow-left] {
+        --_--left-color: var(--_--color);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #{$block} {
+        transition: none;
+    }
+}

--- a/src/components/lab/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/lab/ScrollShadow/ScrollShadow.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react';
+
+import {useForkRef, useLayoutEffect} from '../../../hooks';
+import {block} from '../../utils/cn';
+
+import './ScrollShadow.scss';
+
+const b = block('scroll-shadow');
+const SCROLL_THRESHOLD = 1;
+
+export type ScrollShadowAxis = 'block' | 'inline' | 'both';
+export type ScrollShadowPosition = 'start' | 'end' | 'both';
+
+type PhysicalEdge = 'top' | 'right' | 'bottom' | 'left';
+type EdgeVisibility = Record<PhysicalEdge, boolean>;
+
+const EMPTY_EDGE_VISIBILITY: EdgeVisibility = {
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+};
+
+export interface ScrollShadowProps extends React.HTMLAttributes<HTMLDivElement> {
+    /**
+     * Logical axis whose scroll state controls the shadows.
+     * @default 'block'
+     */
+    axis?: ScrollShadowAxis;
+    /**
+     * Logical edge on the selected axis where shadows can appear.
+     * @default 'both'
+     */
+    position?: ScrollShadowPosition;
+    /** Disables the shadows without disabling native scrolling. */
+    disabled?: boolean;
+}
+
+interface LogicalAxisState {
+    start: boolean;
+    end: boolean;
+}
+
+interface FlowInfo {
+    isRtl: boolean;
+    isVertical: boolean;
+    isVerticalLr: boolean;
+}
+
+function getLogicalAxisState(
+    offset: number,
+    scrollSize: number,
+    clientSize: number,
+    reverse: boolean,
+) {
+    const maxOffset = Math.max(scrollSize - clientSize, 0);
+    const normalizedOffset = reverse ? Math.abs(offset) : offset;
+
+    return {
+        start: normalizedOffset > SCROLL_THRESHOLD,
+        end: normalizedOffset < maxOffset - SCROLL_THRESHOLD,
+    };
+}
+
+function withAxisVisibility(
+    result: EdgeVisibility,
+    state: LogicalAxisState,
+    startEdge: PhysicalEdge,
+    endEdge: PhysicalEdge,
+    position: ScrollShadowPosition,
+) {
+    return {
+        ...result,
+        ...(position !== 'end' && {[startEdge]: state.start}),
+        ...(position !== 'start' && {[endEdge]: state.end}),
+    };
+}
+
+function getEdgeVisibility(
+    element: HTMLDivElement,
+    axis: ScrollShadowAxis,
+    position: ScrollShadowPosition,
+    flowInfo: FlowInfo,
+): EdgeVisibility {
+    let result = {...EMPTY_EDGE_VISIBILITY};
+    const {isRtl, isVertical, isVerticalLr} = flowInfo;
+
+    const verticalState = getLogicalAxisState(
+        element.scrollTop,
+        element.scrollHeight,
+        element.clientHeight,
+        isVertical && isRtl,
+    );
+    const horizontalState = getLogicalAxisState(
+        element.scrollLeft,
+        element.scrollWidth,
+        element.clientWidth,
+        isVertical ? !isVerticalLr : isRtl,
+    );
+
+    if (axis === 'block' || axis === 'both') {
+        if (isVertical) {
+            result = withAxisVisibility(
+                result,
+                horizontalState,
+                isVerticalLr ? 'left' : 'right',
+                isVerticalLr ? 'right' : 'left',
+                position,
+            );
+        } else {
+            result = withAxisVisibility(result, verticalState, 'top', 'bottom', position);
+        }
+    }
+
+    if (axis === 'inline' || axis === 'both') {
+        if (isVertical) {
+            result = withAxisVisibility(
+                result,
+                verticalState,
+                isRtl ? 'bottom' : 'top',
+                isRtl ? 'top' : 'bottom',
+                position,
+            );
+        } else {
+            result = withAxisVisibility(
+                result,
+                horizontalState,
+                isRtl ? 'right' : 'left',
+                isRtl ? 'left' : 'right',
+                position,
+            );
+        }
+    }
+
+    return result;
+}
+
+function getFlowInfo(element: HTMLDivElement): FlowInfo {
+    const {direction, writingMode} = window.getComputedStyle(element);
+
+    return {
+        isRtl: direction === 'rtl' || (!direction && Boolean(element.closest('[dir="rtl"]'))),
+        isVertical: writingMode.startsWith('vertical') || writingMode.startsWith('sideways'),
+        isVerticalLr: writingMode === 'vertical-lr',
+    };
+}
+
+function isSameVisibility(first: EdgeVisibility, second: EdgeVisibility) {
+    return (
+        first.top === second.top &&
+        first.right === second.right &&
+        first.bottom === second.bottom &&
+        first.left === second.left
+    );
+}
+
+export const ScrollShadow = React.forwardRef<HTMLDivElement, ScrollShadowProps>(
+    function ScrollShadow(
+        {
+            axis = 'block',
+            position = 'both',
+            disabled = false,
+            className,
+            children,
+            onScroll,
+            tabIndex = 0,
+            ...restProps
+        },
+        forwardedRef,
+    ) {
+        const innerRef = React.useRef<HTMLDivElement>(null);
+        const flowInfoRef = React.useRef<FlowInfo | null>(null);
+        const ref = useForkRef(innerRef, forwardedRef);
+        const [edgeVisibility, setEdgeVisibility] = React.useState(EMPTY_EDGE_VISIBILITY);
+
+        const updateEdgeVisibility = React.useCallback(
+            (refreshFlowInfo = false) => {
+                const element = innerRef.current;
+                let nextVisibility = EMPTY_EDGE_VISIBILITY;
+
+                if (!disabled && element) {
+                    if (!flowInfoRef.current || refreshFlowInfo) {
+                        flowInfoRef.current = getFlowInfo(element);
+                    }
+                    nextVisibility = getEdgeVisibility(
+                        element,
+                        axis,
+                        position,
+                        flowInfoRef.current,
+                    );
+                }
+
+                setEdgeVisibility((currentVisibility) =>
+                    isSameVisibility(currentVisibility, nextVisibility)
+                        ? currentVisibility
+                        : nextVisibility,
+                );
+            },
+            [axis, disabled, position],
+        );
+
+        useLayoutEffect(() => updateEdgeVisibility(true));
+
+        useLayoutEffect(() => {
+            const element = innerRef.current;
+            if (!element || disabled) {
+                return undefined;
+            }
+
+            const resizeObserver =
+                typeof ResizeObserver === 'undefined'
+                    ? undefined
+                    : new ResizeObserver(() => updateEdgeVisibility());
+            const observedChildren = new Set<Element>();
+            const handleWindowResize = () => updateEdgeVisibility();
+            const observeChildren = () => {
+                const currentChildren = new Set(Array.from(element.children));
+
+                observedChildren.forEach((child) => {
+                    if (!currentChildren.has(child)) {
+                        resizeObserver?.unobserve(child);
+                        observedChildren.delete(child);
+                    }
+                });
+                currentChildren.forEach((child) => {
+                    if (!observedChildren.has(child)) {
+                        resizeObserver?.observe(child);
+                        observedChildren.add(child);
+                    }
+                });
+            };
+
+            resizeObserver?.observe(element);
+            observeChildren();
+            if (!resizeObserver) {
+                window.addEventListener('resize', handleWindowResize);
+            }
+
+            const mutationObserver = new MutationObserver(() => {
+                observeChildren();
+                updateEdgeVisibility();
+            });
+            mutationObserver.observe(element, {
+                childList: true,
+                subtree: true,
+                characterData: true,
+            });
+
+            return () => {
+                resizeObserver?.disconnect();
+                mutationObserver.disconnect();
+                window.removeEventListener('resize', handleWindowResize);
+            };
+        }, [disabled, updateEdgeVisibility]);
+
+        const handleScroll = React.useCallback<React.UIEventHandler<HTMLDivElement>>(
+            (event) => {
+                updateEdgeVisibility();
+                onScroll?.(event);
+            },
+            [onScroll, updateEdgeVisibility],
+        );
+
+        return (
+            <div
+                {...restProps}
+                ref={ref}
+                className={b(null, className)}
+                data-scroll-shadow-top={edgeVisibility.top || undefined}
+                data-scroll-shadow-right={edgeVisibility.right || undefined}
+                data-scroll-shadow-bottom={edgeVisibility.bottom || undefined}
+                data-scroll-shadow-left={edgeVisibility.left || undefined}
+                tabIndex={tabIndex}
+                onScroll={handleScroll}
+            >
+                {children}
+            </div>
+        );
+    },
+);
+
+ScrollShadow.displayName = 'ScrollShadow';

--- a/src/components/lab/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/lab/ScrollShadow/ScrollShadow.tsx
@@ -51,10 +51,10 @@ function getLogicalAxisState(
     offset: number,
     scrollSize: number,
     clientSize: number,
-    reverse: boolean,
+    hasNegativeOffset: boolean,
 ) {
     const maxOffset = Math.max(scrollSize - clientSize, 0);
-    const normalizedOffset = reverse ? Math.abs(offset) : offset;
+    const normalizedOffset = Math.min(maxOffset, Math.max(0, hasNegativeOffset ? -offset : offset));
 
     return {
         start: normalizedOffset > SCROLL_THRESHOLD,
@@ -212,7 +212,18 @@ export const ScrollShadow = React.forwardRef<HTMLDivElement, ScrollShadowProps>(
                     ? undefined
                     : new ResizeObserver(() => updateEdgeVisibility());
             const observedChildren = new Set<Element>();
+            let animationFrameId: number | undefined;
             const handleWindowResize = () => updateEdgeVisibility();
+            const scheduleUpdateEdgeVisibility = () => {
+                if (animationFrameId !== undefined) {
+                    return;
+                }
+
+                animationFrameId = requestAnimationFrame(() => {
+                    animationFrameId = undefined;
+                    updateEdgeVisibility();
+                });
+            };
             const observeChildren = () => {
                 const currentChildren = new Set(Array.from(element.children));
 
@@ -236,9 +247,15 @@ export const ScrollShadow = React.forwardRef<HTMLDivElement, ScrollShadowProps>(
                 window.addEventListener('resize', handleWindowResize);
             }
 
-            const mutationObserver = new MutationObserver(() => {
-                observeChildren();
-                updateEdgeVisibility();
+            const mutationObserver = new MutationObserver((mutations) => {
+                if (
+                    mutations.some(
+                        (mutation) => mutation.type === 'childList' && mutation.target === element,
+                    )
+                ) {
+                    observeChildren();
+                }
+                scheduleUpdateEdgeVisibility();
             });
             mutationObserver.observe(element, {
                 childList: true,
@@ -247,6 +264,9 @@ export const ScrollShadow = React.forwardRef<HTMLDivElement, ScrollShadowProps>(
             });
 
             return () => {
+                if (animationFrameId !== undefined) {
+                    cancelAnimationFrame(animationFrameId);
+                }
                 resizeObserver?.disconnect();
                 mutationObserver.disconnect();
                 window.removeEventListener('resize', handleWindowResize);

--- a/src/components/lab/ScrollShadow/__stories__/Docs.mdx
+++ b/src/components/lab/ScrollShadow/__stories__/Docs.mdx
@@ -1,0 +1,8 @@
+import {Markdown, Meta} from '@storybook/addon-docs';
+
+import Readme from '../README.md?raw';
+import * as Stories from './ScrollShadow.stories';
+
+<Meta of={Stories} />
+
+<Markdown>{Readme}</Markdown>

--- a/src/components/lab/ScrollShadow/__stories__/ScrollShadow.stories.scss
+++ b/src/components/lab/ScrollShadow/__stories__/ScrollShadow.stories.scss
@@ -1,0 +1,67 @@
+.scroll-shadow-stories {
+    &__vertical,
+    &__horizontal,
+    &__both {
+        border: 1px solid var(--g-color-line-generic);
+        border-radius: 8px;
+        background: var(--g-color-base-background);
+    }
+
+    &__vertical {
+        inline-size: 320px;
+        max-block-size: 240px;
+    }
+
+    &__list {
+        padding: 8px;
+    }
+
+    &__item {
+        padding: 10px 12px;
+        border-block-end: 1px solid var(--g-color-line-generic);
+    }
+
+    &__horizontal {
+        inline-size: 420px;
+        padding: 12px;
+    }
+
+    &__row {
+        display: flex;
+        inline-size: max-content;
+        gap: 8px;
+    }
+
+    &__card {
+        display: grid;
+        flex: 0 0 100px;
+        block-size: 80px;
+        place-items: center;
+        border-radius: 6px;
+        background: var(--g-color-base-generic);
+    }
+
+    &__both {
+        inline-size: 360px;
+        max-block-size: 240px;
+    }
+
+    &__grid {
+        display: grid;
+        inline-size: max-content;
+        grid-template-columns: repeat(8, 80px);
+    }
+
+    &__cell {
+        display: grid;
+        block-size: 52px;
+        place-items: center;
+        border-inline-end: 1px solid var(--g-color-line-generic);
+        border-block-end: 1px solid var(--g-color-line-generic);
+    }
+
+    &__custom {
+        --g-scroll-shadow-size: 40px;
+        --g-scroll-shadow-color: var(--g-color-line-brand);
+    }
+}

--- a/src/components/lab/ScrollShadow/__stories__/ScrollShadow.stories.tsx
+++ b/src/components/lab/ScrollShadow/__stories__/ScrollShadow.stories.tsx
@@ -1,0 +1,105 @@
+import type {Meta, StoryObj} from '@storybook/react-webpack5';
+
+import {ScrollShadow} from '../ScrollShadow';
+
+import './ScrollShadow.stories.scss';
+
+const meta = {
+    title: 'Lab/ScrollShadow',
+    component: ScrollShadow,
+    args: {
+        axis: 'block',
+        position: 'both',
+        disabled: false,
+    },
+    parameters: {
+        layout: 'centered',
+    },
+} satisfies Meta<typeof ScrollShadow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function VerticalContent() {
+    return (
+        <div className="scroll-shadow-stories__list">
+            {Array.from({length: 20}, (_, index) => (
+                <div className="scroll-shadow-stories__item" key={index}>
+                    Item {index + 1}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export const Default: Story = {
+    render: (args) => (
+        <ScrollShadow
+            {...args}
+            className="scroll-shadow-stories__vertical"
+            aria-label="Scrollable list"
+            data-qa="scroll-shadow-story"
+            role="region"
+        >
+            <VerticalContent />
+        </ScrollShadow>
+    ),
+};
+
+export const InlineAxis: Story = {
+    args: {
+        axis: 'inline',
+    },
+    render: (args) => (
+        <ScrollShadow
+            {...args}
+            className="scroll-shadow-stories__horizontal"
+            aria-label="Horizontal list"
+            role="region"
+        >
+            <div className="scroll-shadow-stories__row">
+                {Array.from({length: 10}, (_, index) => (
+                    <div className="scroll-shadow-stories__card" key={index}>
+                        Item {index + 1}
+                    </div>
+                ))}
+            </div>
+        </ScrollShadow>
+    ),
+};
+
+export const BothAxes: Story = {
+    args: {
+        axis: 'both',
+    },
+    render: (args) => (
+        <ScrollShadow
+            {...args}
+            className="scroll-shadow-stories__both"
+            aria-label="Scrollable grid"
+            role="region"
+        >
+            <div className="scroll-shadow-stories__grid">
+                {Array.from({length: 64}, (_, index) => (
+                    <div className="scroll-shadow-stories__cell" key={index}>
+                        {index + 1}
+                    </div>
+                ))}
+            </div>
+        </ScrollShadow>
+    ),
+};
+
+export const CustomCssApi: Story = {
+    render: (args) => (
+        <ScrollShadow
+            {...args}
+            className="scroll-shadow-stories__vertical scroll-shadow-stories__custom"
+            aria-label="Scrollable list with custom shadow"
+            role="region"
+        >
+            <VerticalContent />
+        </ScrollShadow>
+    ),
+};

--- a/src/components/lab/ScrollShadow/__tests__/ScrollShadow.test.tsx
+++ b/src/components/lab/ScrollShadow/__tests__/ScrollShadow.test.tsx
@@ -169,7 +169,19 @@ describe('ScrollShadow', () => {
         expect(element).toHaveAttribute('data-scroll-shadow-left', 'true');
         expect(element).not.toHaveAttribute('data-scroll-shadow-right');
 
-        setScrollMetrics(element, {scrollLeft: -200});
+        setScrollMetrics(element, {scrollLeft: 5});
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-left', 'true');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-right');
+
+        setScrollMetrics(element, {scrollLeft: -80});
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-left', 'true');
+        expect(element).toHaveAttribute('data-scroll-shadow-right', 'true');
+
+        setScrollMetrics(element, {scrollLeft: -205});
         fireEvent.scroll(element);
 
         expect(element).not.toHaveAttribute('data-scroll-shadow-left');

--- a/src/components/lab/ScrollShadow/__tests__/ScrollShadow.test.tsx
+++ b/src/components/lab/ScrollShadow/__tests__/ScrollShadow.test.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+
+import {fireEvent, render, screen} from '../../../../../test-utils/utils';
+import {ScrollShadow} from '../ScrollShadow';
+
+const qa = 'scroll-shadow';
+
+interface ScrollMetrics {
+    clientHeight?: number;
+    clientWidth?: number;
+    scrollHeight?: number;
+    scrollLeft?: number;
+    scrollTop?: number;
+    scrollWidth?: number;
+}
+
+function setScrollMetrics(element: HTMLElement, metrics: ScrollMetrics) {
+    for (const [name, value] of Object.entries(metrics)) {
+        Object.defineProperty(element, name, {
+            configurable: true,
+            writable: true,
+            value,
+        });
+    }
+}
+
+function getScrollShadow() {
+    return screen.getByTestId(qa);
+}
+
+describe('ScrollShadow', () => {
+    test('renders a native scroll container and forwards div props and ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+
+        render(
+            <ScrollShadow
+                ref={ref}
+                data-qa={qa}
+                className="custom-class"
+                style={{maxHeight: 120}}
+                aria-label="Updates"
+            >
+                Content
+            </ScrollShadow>,
+        );
+
+        const element = getScrollShadow();
+        expect(element).toBe(ref.current);
+        expect(element).toHaveClass('g-scroll-shadow', 'custom-class');
+        expect(element).toHaveStyle({maxHeight: '120px'});
+        expect(element).toHaveAttribute('aria-label', 'Updates');
+        expect(element).toHaveAttribute('tabindex', '0');
+        expect(element).toHaveTextContent('Content');
+    });
+
+    test('does not show shadows without overflow', () => {
+        render(<ScrollShadow data-qa={qa}>Content</ScrollShadow>);
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientHeight: 100,
+            scrollHeight: 100,
+            scrollTop: 0,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).not.toHaveAttribute('data-scroll-shadow-top');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-bottom');
+    });
+
+    test('shows only the block-end shadow at the initial scroll position by default', () => {
+        render(<ScrollShadow data-qa={qa}>Content</ScrollShadow>);
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientHeight: 100,
+            scrollHeight: 300,
+            scrollTop: 0,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).not.toHaveAttribute('data-scroll-shadow-top');
+        expect(element).toHaveAttribute('data-scroll-shadow-bottom', 'true');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-left');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-right');
+    });
+
+    test('updates block shadows while scrolling', () => {
+        render(<ScrollShadow data-qa={qa}>Content</ScrollShadow>);
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientHeight: 100,
+            scrollHeight: 300,
+            scrollTop: 80,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-top', 'true');
+        expect(element).toHaveAttribute('data-scroll-shadow-bottom', 'true');
+
+        setScrollMetrics(element, {scrollTop: 200});
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-top', 'true');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-bottom');
+    });
+
+    test('respects inline axis and position', () => {
+        render(
+            <ScrollShadow data-qa={qa} axis="inline" position="end">
+                Content
+            </ScrollShadow>,
+        );
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientWidth: 100,
+            scrollLeft: 40,
+            scrollWidth: 300,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).not.toHaveAttribute('data-scroll-shadow-left');
+        expect(element).toHaveAttribute('data-scroll-shadow-right', 'true');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-top');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-bottom');
+    });
+
+    test('supports both logical axes', () => {
+        render(
+            <ScrollShadow data-qa={qa} axis="both">
+                Content
+            </ScrollShadow>,
+        );
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientHeight: 100,
+            clientWidth: 100,
+            scrollHeight: 300,
+            scrollWidth: 300,
+            scrollTop: 50,
+            scrollLeft: 50,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-top', 'true');
+        expect(element).toHaveAttribute('data-scroll-shadow-right', 'true');
+        expect(element).toHaveAttribute('data-scroll-shadow-bottom', 'true');
+        expect(element).toHaveAttribute('data-scroll-shadow-left', 'true');
+    });
+
+    test('maps inline start and end to physical edges in RTL', () => {
+        render(
+            <ScrollShadow data-qa={qa} axis="inline" dir="rtl">
+                Content
+            </ScrollShadow>,
+        );
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientWidth: 100,
+            scrollLeft: 0,
+            scrollWidth: 300,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).toHaveAttribute('data-scroll-shadow-left', 'true');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-right');
+
+        setScrollMetrics(element, {scrollLeft: -200});
+        fireEvent.scroll(element);
+
+        expect(element).not.toHaveAttribute('data-scroll-shadow-left');
+        expect(element).toHaveAttribute('data-scroll-shadow-right', 'true');
+    });
+
+    test('does not show shadows when disabled', () => {
+        render(
+            <ScrollShadow data-qa={qa} axis="both" disabled>
+                Content
+            </ScrollShadow>,
+        );
+        const element = getScrollShadow();
+
+        setScrollMetrics(element, {
+            clientHeight: 100,
+            clientWidth: 100,
+            scrollHeight: 300,
+            scrollWidth: 300,
+            scrollTop: 50,
+            scrollLeft: 50,
+        });
+        fireEvent.scroll(element);
+
+        expect(element).not.toHaveAttribute('data-scroll-shadow-top');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-right');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-bottom');
+        expect(element).not.toHaveAttribute('data-scroll-shadow-left');
+    });
+
+    test('calls onScroll', () => {
+        const onScroll = jest.fn();
+        render(
+            <ScrollShadow data-qa={qa} onScroll={onScroll}>
+                Content
+            </ScrollShadow>,
+        );
+
+        fireEvent.scroll(getScrollShadow());
+
+        expect(onScroll).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/lab/ScrollShadow/index.ts
+++ b/src/components/lab/ScrollShadow/index.ts
@@ -1,0 +1,6 @@
+export {
+    ScrollShadow,
+    type ScrollShadowAxis,
+    type ScrollShadowPosition,
+    type ScrollShadowProps,
+} from './ScrollShadow';

--- a/src/unstable.ts
+++ b/src/unstable.ts
@@ -59,6 +59,13 @@ export {
 } from './components/lab/FileDropZone';
 
 export {
+    ScrollShadow as unstable_ScrollShadow,
+    type ScrollShadowAxis as unstable_ScrollShadowAxis,
+    type ScrollShadowPosition as unstable_ScrollShadowPosition,
+    type ScrollShadowProps as unstable_ScrollShadowProps,
+} from './components/lab/ScrollShadow';
+
+export {
     type UseDropZoneEventHandler,
     type UseDropZoneParams,
     type UseDropZoneDroppableProps,


### PR DESCRIPTION
#2780

## Summary by Sourcery

Introduce the experimental ScrollShadow component and expose it through the unstable API.

New Features:
- Add an experimental ScrollShadow component for native scroll containers with edge shadows based on available content.

Enhancements:
- Support logical block, inline, and both-axis scrolling with configurable shadow positions, RTL and vertical writing modes, disabled shadows, and CSS customization.

Documentation:
- Document the experimental component’s usage, properties, axes, positions, and CSS customization API.

Tests:
- Add coverage for rendering, scrolling behavior, logical direction mapping, disabled state, and scroll callbacks.