### PR TITLE
chore: self-host star history chart generation

### DIFF
--- a/.github/scripts/star-history.mjs
+++ b/.github/scripts/star-history.mjs
@@ -96,6 +96,7 @@ async function fetchStarDates(repo, token) {
             headers: {
                 Authorization: `bearer ${token}`,
                 'Content-Type': 'application/json',
+                'User-Agent': 'gravity-ui-star-history',
             },
             body: JSON.stringify({query, variables: {owner, name, cursor}}),
         });
@@ -198,8 +199,8 @@ function xTicks(minTime, maxTime) {
 
 const formatCount = (n) => new Intl.NumberFormat('en-US').format(n);
 
-function renderSvg({repo, series, total, updatedAt, theme}) {
-    const t = THEMES[theme];
+/** Turns the series into plot geometry: scales, path coordinates and the end-point anchor. */
+function preparePlot({series, total, updatedAt}) {
     const plotW = WIDTH - MARGIN.left - MARGIN.right;
     const plotH = HEIGHT - MARGIN.top - MARGIN.bottom;
     const baselineY = MARGIN.top + plotH;
@@ -224,30 +225,55 @@ function renderSvg({repo, series, total, updatedAt, theme}) {
         ? `${linePath}L${x(maxTime).toFixed(1)},${baselineY}L${x(minTime).toFixed(1)},${baselineY}Z`
         : '';
 
-    const gridLines = yTicks(yMax)
+    return {
+        plotW,
+        baselineY,
+        minTime,
+        maxTime,
+        yMax,
+        x,
+        y,
+        linePath,
+        areaPath,
+        updatedTime,
+        endX: coords.length ? x(maxTime) : MARGIN.left,
+        endY: coords.length ? y(total) : baselineY,
+    };
+}
+
+function renderGrid({yMax, y, plotW}, theme) {
+    return yTicks(yMax)
         .slice(1)
         .map((tick) => {
             const ty = y(tick).toFixed(1);
             return (
-                `<line x1="${MARGIN.left}" y1="${ty}" x2="${MARGIN.left + plotW}" y2="${ty}" stroke="${t.grid}"/>` +
+                `<line x1="${MARGIN.left}" y1="${ty}" x2="${MARGIN.left + plotW}" y2="${ty}" stroke="${theme.grid}"/>` +
                 `<text x="${MARGIN.left - 8}" y="${ty}" dy="4" text-anchor="end" class="tick">${formatCount(tick)}</text>`
             );
         })
         .join('\n    ');
+}
 
-    const xLabels = xTicks(minTime, maxTime)
+function renderXLabels({minTime, maxTime, x, baselineY}) {
+    return xTicks(minTime, maxTime)
         .map(
             (tick) =>
                 `<text x="${x(tick.time).toFixed(1)}" y="${baselineY + 24}" text-anchor="middle" class="tick">${tick.label}</text>`,
         )
         .join('\n    ');
+}
 
-    const endX = coords.length ? x(maxTime).toFixed(1) : MARGIN.left;
-    const endY = coords.length ? y(total).toFixed(1) : baselineY;
+function renderSvg({repo, series, total, updatedAt, theme}) {
+    const t = THEMES[theme];
+    const plot = preparePlot({series, total, updatedAt});
+    const {plotW, baselineY, linePath, areaPath, endX, endY} = plot;
+
+    const gridLines = renderGrid(plot, t);
+    const xLabels = renderXLabels(plot);
     const updatedLabel = new Intl.DateTimeFormat('en', {
         dateStyle: 'medium',
         timeZone: 'UTC',
-    }).format(new Date(updatedTime));
+    }).format(new Date(plot.updatedTime));
 
     return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}" role="img" aria-label="Star history of ${repo}: ${formatCount(total)} stars">
   <style>
@@ -275,9 +301,9 @@ function renderSvg({repo, series, total, updatedAt, theme}) {
   </g>
   <path d="${areaPath}" fill="url(#area)"/>
   <path d="${linePath}" fill="none" stroke="${t.line}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
-  <circle cx="${endX}" cy="${endY}" r="4" fill="${t.line}"/>
-  <text x="${Number(endX) + 12}" y="${endY}" dy="2" class="end-count">${formatCount(total)}</text>
-  <text x="${Number(endX) + 12}" y="${Number(endY) + 18}" class="end-caption">stars ★</text>
+  <circle cx="${endX.toFixed(1)}" cy="${endY.toFixed(1)}" r="4" fill="${t.line}"/>
+  <text x="${(endX + 12).toFixed(1)}" y="${endY.toFixed(1)}" dy="2" class="end-count">${formatCount(total)}</text>
+  <text x="${(endX + 12).toFixed(1)}" y="${(endY + 18).toFixed(1)}" class="end-caption">stars ★</text>
 </svg>
 `;
 }
@@ -315,6 +341,6 @@ async function main() {
 }
 
 main().catch((error) => {
-    console.error(error.message);
+    console.error(error?.stack ?? error);
     process.exit(1);
 });

--- a/.github/scripts/star-history.mjs
+++ b/.github/scripts/star-history.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * Generates static star history charts (light + dark SVG) for a GitHub repository.
+ *
+ * GitHub restricted the stargazers API (June 2026) to repository admins and
+ * collaborators, which broke third-party live chart embeds (star-history.com).
+ * This script uses the repository's own credentials (GITHUB_TOKEN in Actions)
+ * to fetch star timestamps via GraphQL and render the chart locally.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=<token> node .github/scripts/star-history.mjs [--repo owner/name] [--out dir]
+ *
+ * Options:
+ *   --repo owner/name   Repository to chart (default: $GITHUB_REPOSITORY or gravity-ui/uikit)
+ *   --out dir           Output directory (default: star-history-out)
+ *   --from-json file    Render from a previously dumped JSON instead of fetching
+ *
+ * Output:
+ *   <out>/star-history-light.svg
+ *   <out>/star-history-dark.svg
+ *   <out>/star-history.json (fetched data, for debugging and offline re-render)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WIDTH = 800;
+const HEIGHT = 400;
+const MARGIN = {top: 64, right: 108, bottom: 40, left: 56};
+const MAX_POINTS = 240;
+
+const THEMES = {
+    light: {
+        line: '#bd8e4b',
+        areaFrom: 'rgba(255, 190, 92, 0.25)',
+        areaTo: 'rgba(255, 190, 92, 0)',
+        grid: 'rgba(0, 0, 0, 0.07)',
+        baseline: 'rgba(0, 0, 0, 0.15)',
+        textPrimary: 'rgba(0, 0, 0, 0.85)',
+        textSecondary: 'rgba(0, 0, 0, 0.5)',
+    },
+    dark: {
+        line: '#bc8a2e',
+        areaFrom: 'rgba(255, 190, 92, 0.18)',
+        areaTo: 'rgba(255, 190, 92, 0)',
+        grid: 'rgba(255, 255, 255, 0.1)',
+        baseline: 'rgba(255, 255, 255, 0.2)',
+        textPrimary: 'rgba(255, 255, 255, 0.85)',
+        textSecondary: 'rgba(255, 255, 255, 0.5)',
+    },
+};
+
+function parseArgs(argv) {
+    const args = {
+        repo: process.env.GITHUB_REPOSITORY || 'gravity-ui/uikit',
+        out: 'star-history-out',
+        fromJson: null,
+    };
+    for (let i = 2; i < argv.length; i++) {
+        if (argv[i] === '--repo') args.repo = argv[++i];
+        else if (argv[i] === '--out') args.out = argv[++i];
+        else if (argv[i] === '--from-json') args.fromJson = argv[++i];
+        else throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+    if (!/^[\w.-]+\/[\w.-]+$/.test(args.repo)) {
+        throw new Error(`Invalid --repo value: ${args.repo} (expected owner/name)`);
+    }
+    return args;
+}
+
+async function fetchStarDates(repo, token) {
+    const [owner, name] = repo.split('/');
+    const query = `
+        query ($owner: String!, $name: String!, $cursor: String) {
+            repository(owner: $owner, name: $name) {
+                stargazerCount
+                stargazers(first: 100, after: $cursor, orderBy: {field: STARRED_AT, direction: ASC}) {
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                    edges {
+                        starredAt
+                    }
+                }
+            }
+        }
+    `;
+    const dates = [];
+    let cursor = null;
+    let stargazerCount = 0;
+    let guard = 0;
+    do {
+        const response = await fetch('https://api.github.com/graphql', {
+            method: 'POST',
+            headers: {
+                Authorization: `bearer ${token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({query, variables: {owner, name, cursor}}),
+        });
+        if (!response.ok) {
+            throw new Error(
+                `GitHub API responded with ${response.status}: ${await response.text()}`,
+            );
+        }
+        const {data, errors} = await response.json();
+        if (errors) {
+            throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
+        }
+        if (!data.repository) {
+            throw new Error(`Repository ${repo} not found or not accessible with this token`);
+        }
+        stargazerCount = data.repository.stargazerCount;
+        const {pageInfo, edges} = data.repository.stargazers;
+        for (const edge of edges) {
+            dates.push(edge.starredAt);
+        }
+        cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+        if (++guard > Math.ceil(stargazerCount / 100) + 10) {
+            throw new Error('Pagination guard tripped: too many pages fetched');
+        }
+    } while (cursor);
+
+    if (stargazerCount > 0 && dates.length === 0) {
+        throw new Error(
+            'Stargazer timestamps are empty while stargazerCount > 0. ' +
+                'GitHub restricts star data to repository admins and collaborators — ' +
+                'the provided token has no access to it.',
+        );
+    }
+    return {stargazerCount, dates};
+}
+
+/** Collapses raw ISO timestamps into a per-day cumulative series: [isoDay, total][]. */
+function toDailyCumulative(dates) {
+    const perDay = new Map();
+    for (const iso of dates) {
+        const day = iso.slice(0, 10);
+        perDay.set(day, (perDay.get(day) || 0) + 1);
+    }
+    const days = [...perDay.keys()].sort();
+    const series = [];
+    let total = 0;
+    for (const day of days) {
+        total += perDay.get(day);
+        series.push([day, total]);
+    }
+    return series;
+}
+
+function downsample(series, maxPoints) {
+    if (series.length <= maxPoints) return series;
+    const result = [];
+    for (let i = 0; i < maxPoints - 1; i++) {
+        result.push(series[Math.floor((i * series.length) / (maxPoints - 1))]);
+    }
+    result.push(series[series.length - 1]);
+    return result;
+}
+
+function niceCeil(value) {
+    const power = 10 ** Math.floor(Math.log10(Math.max(value, 1)));
+    for (const step of [1, 1.2, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10]) {
+        if (value <= step * power) return step * power;
+    }
+    return 10 * power;
+}
+
+function yTicks(yMax) {
+    const step = yMax / 4;
+    return [0, step, step * 2, step * 3, yMax];
+}
+
+/** Year boundaries for long ranges, otherwise several evenly spaced dates. */
+function xTicks(minTime, maxTime) {
+    const spanDays = (maxTime - minTime) / 86400000;
+    const ticks = [];
+    if (spanDays > 3 * 365) {
+        const firstYear = new Date(minTime).getUTCFullYear() + 1;
+        const lastYear = new Date(maxTime).getUTCFullYear();
+        for (let year = firstYear; year <= lastYear; year++) {
+            ticks.push({time: Date.UTC(year, 0, 1), label: String(year)});
+        }
+    } else {
+        const format = new Intl.DateTimeFormat('en', {
+            month: 'short',
+            year: spanDays > 300 ? '2-digit' : undefined,
+            timeZone: 'UTC',
+        });
+        for (let i = 0; i <= 4; i++) {
+            const time = minTime + ((maxTime - minTime) * i) / 4;
+            ticks.push({time, label: format.format(new Date(time))});
+        }
+    }
+    return ticks;
+}
+
+const formatCount = (n) => new Intl.NumberFormat('en-US').format(n);
+
+function renderSvg({repo, series, total, updatedAt, theme}) {
+    const t = THEMES[theme];
+    const plotW = WIDTH - MARGIN.left - MARGIN.right;
+    const plotH = HEIGHT - MARGIN.top - MARGIN.bottom;
+    const baselineY = MARGIN.top + plotH;
+
+    const points = downsample(series, MAX_POINTS).map(([day, count]) => [Date.parse(day), count]);
+    // Hold the final value until the generation date so the line reaches "today".
+    const updatedTime = Date.parse(updatedAt);
+    if (points.length > 0 && updatedTime > points[points.length - 1][0]) {
+        points.push([updatedTime, total]);
+    }
+
+    const minTime = points.length ? points[0][0] : updatedTime - 86400000;
+    const maxTime = points.length ? points[points.length - 1][0] : updatedTime;
+    const yMax = niceCeil(Math.max(total, 4));
+
+    const x = (time) => MARGIN.left + ((time - minTime) / Math.max(maxTime - minTime, 1)) * plotW;
+    const y = (count) => baselineY - (count / yMax) * plotH;
+
+    const coords = points.map(([time, count]) => `${x(time).toFixed(1)},${y(count).toFixed(1)}`);
+    const linePath = coords.length ? `M${coords.join('L')}` : '';
+    const areaPath = coords.length
+        ? `${linePath}L${x(maxTime).toFixed(1)},${baselineY}L${x(minTime).toFixed(1)},${baselineY}Z`
+        : '';
+
+    const gridLines = yTicks(yMax)
+        .slice(1)
+        .map((tick) => {
+            const ty = y(tick).toFixed(1);
+            return (
+                `<line x1="${MARGIN.left}" y1="${ty}" x2="${MARGIN.left + plotW}" y2="${ty}" stroke="${t.grid}"/>` +
+                `<text x="${MARGIN.left - 8}" y="${ty}" dy="4" text-anchor="end" class="tick">${formatCount(tick)}</text>`
+            );
+        })
+        .join('\n    ');
+
+    const xLabels = xTicks(minTime, maxTime)
+        .map(
+            (tick) =>
+                `<text x="${x(tick.time).toFixed(1)}" y="${baselineY + 24}" text-anchor="middle" class="tick">${tick.label}</text>`,
+        )
+        .join('\n    ');
+
+    const endX = coords.length ? x(maxTime).toFixed(1) : MARGIN.left;
+    const endY = coords.length ? y(total).toFixed(1) : baselineY;
+    const updatedLabel = new Intl.DateTimeFormat('en', {
+        dateStyle: 'medium',
+        timeZone: 'UTC',
+    }).format(new Date(updatedTime));
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}" role="img" aria-label="Star history of ${repo}: ${formatCount(total)} stars">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; }
+    .title { font-size: 16px; font-weight: 600; fill: ${t.textPrimary}; }
+    .subtitle { font-size: 12px; fill: ${t.textSecondary}; }
+    .tick { font-size: 12px; fill: ${t.textSecondary}; }
+    .end-count { font-size: 18px; font-weight: 600; fill: ${t.textPrimary}; }
+    .end-caption { font-size: 12px; fill: ${t.textSecondary}; }
+  </style>
+  <defs>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="${t.areaFrom}"/>
+      <stop offset="1" stop-color="${t.areaTo}"/>
+    </linearGradient>
+  </defs>
+  <text x="${MARGIN.left}" y="28" class="title">${repo} — GitHub stars</text>
+  <text x="${MARGIN.left}" y="46" class="subtitle">Updated ${updatedLabel}</text>
+  <g>
+    ${gridLines}
+  </g>
+  <line x1="${MARGIN.left}" y1="${baselineY}" x2="${MARGIN.left + plotW}" y2="${baselineY}" stroke="${t.baseline}"/>
+  <g>
+    ${xLabels}
+  </g>
+  <path d="${areaPath}" fill="url(#area)"/>
+  <path d="${linePath}" fill="none" stroke="${t.line}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="${endX}" cy="${endY}" r="4" fill="${t.line}"/>
+  <text x="${Number(endX) + 12}" y="${endY}" dy="2" class="end-count">${formatCount(total)}</text>
+  <text x="${Number(endX) + 12}" y="${Number(endY) + 18}" class="end-caption">stars ★</text>
+</svg>
+`;
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+    let data;
+
+    if (args.fromJson) {
+        data = JSON.parse(fs.readFileSync(args.fromJson, 'utf8'));
+    } else {
+        const token = process.env.GITHUB_TOKEN;
+        if (!token) {
+            throw new Error('GITHUB_TOKEN environment variable is required');
+        }
+        console.log(`Fetching star history for ${args.repo}...`);
+        const {stargazerCount, dates} = await fetchStarDates(args.repo, token);
+        console.log(`Fetched ${dates.length} star timestamps (stargazerCount: ${stargazerCount})`);
+        data = {
+            repo: args.repo,
+            updatedAt: new Date().toISOString(),
+            total: stargazerCount,
+            series: toDailyCumulative(dates),
+        };
+    }
+
+    fs.mkdirSync(args.out, {recursive: true});
+    fs.writeFileSync(path.join(args.out, 'star-history.json'), JSON.stringify(data, null, 2));
+    for (const theme of Object.keys(THEMES)) {
+        const svg = renderSvg({...data, theme});
+        const file = path.join(args.out, `star-history-${theme}.svg`);
+        fs.writeFileSync(file, svg);
+        console.log(`Wrote ${file}`);
+    }
+}
+
+main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+});

--- a/.github/scripts/star-history.mjs
+++ b/.github/scripts/star-history.mjs
@@ -173,31 +173,54 @@ function yTicks(yMax) {
     return [0, step, step * 2, step * 3, yMax];
 }
 
+// Label granularity for short ranges, coarse to fine. Evenly spaced ticks are not
+// calendar-aligned, so a history spanning a single month would otherwise print
+// that month five times over. Escalate the format until every label is distinct.
+const X_LABEL_FORMATS = [
+    {month: 'short'},
+    {month: 'short', year: '2-digit'},
+    {month: 'short', day: 'numeric'},
+    {month: 'short', day: 'numeric', year: '2-digit'},
+];
+
 // Year boundaries for long ranges, otherwise several evenly spaced dates.
 function xTicks(minTime, maxTime) {
     const spanDays = (maxTime - minTime) / 86400000;
-    const ticks = [];
     if (spanDays > 3 * 365) {
         const firstYear = new Date(minTime).getUTCFullYear() + 1;
         const lastYear = new Date(maxTime).getUTCFullYear();
+        const ticks = [];
         for (let year = firstYear; year <= lastYear; year++) {
             ticks.push({time: Date.UTC(year, 0, 1), label: String(year)});
         }
-    } else {
-        const format = new Intl.DateTimeFormat('en', {
-            month: 'short',
-            year: spanDays > 300 ? '2-digit' : undefined,
-            timeZone: 'UTC',
-        });
-        for (let i = 0; i <= 4; i++) {
-            const time = minTime + ((maxTime - minTime) * i) / 4;
-            ticks.push({time, label: format.format(new Date(time))});
-        }
+        return ticks;
     }
-    return ticks;
+
+    const times = [];
+    for (let i = 0; i <= 4; i++) {
+        times.push(minTime + ((maxTime - minTime) * i) / 4);
+    }
+    let ticks = [];
+    for (const options of X_LABEL_FORMATS.slice(spanDays > 300 ? 1 : 0)) {
+        const format = new Intl.DateTimeFormat('en', {...options, timeZone: 'UTC'});
+        ticks = times.map((time) => ({time, label: format.format(new Date(time))}));
+        if (new Set(ticks.map((tick) => tick.label)).size === ticks.length) break;
+    }
+    // A span shorter than the finest granularity repeats no matter the format;
+    // drop the repeats instead of stacking identical labels on the axis.
+    return ticks.filter((tick, i) => i === 0 || tick.label !== ticks[i - 1].label);
 }
 
 const formatCount = (n) => new Intl.NumberFormat('en-US').format(n);
+
+// Y-axis labels switch to compact notation past six figures: "1,200,000" runs off
+// the left edge of the canvas, "1.2M" fits.
+const formatTick = (value, yMax) =>
+    yMax >= 1e6
+        ? new Intl.NumberFormat('en-US', {notation: 'compact', maximumFractionDigits: 1}).format(
+              value,
+          )
+        : formatCount(value);
 
 // Turns the series into plot geometry: scales, path coordinates and the end-point anchor.
 function preparePlot({series, total, updatedAt}) {
@@ -214,7 +237,12 @@ function preparePlot({series, total, updatedAt}) {
 
     const minTime = points.length ? points[0][0] : updatedTime - 86400000;
     const maxTime = points.length ? points[points.length - 1][0] : updatedTime;
-    const yMax = niceCeil(Math.max(total, 4));
+    // The scale has to cover what is actually drawn. stargazerCount and the fetched
+    // timestamps can disagree — an unstar between two pagination requests leaves the
+    // series one ahead of the count — and taking the ceiling from the count alone
+    // lets the line escape the plot area and overdraw the header.
+    const seriesMax = points.reduce((max, [, count]) => Math.max(max, count), 0);
+    const yMax = niceCeil(Math.max(total, seriesMax, 4));
 
     const x = (time) => MARGIN.left + ((time - minTime) / Math.max(maxTime - minTime, 1)) * plotW;
     const y = (count) => baselineY - (count / yMax) * plotH;
@@ -248,7 +276,7 @@ function renderGrid({yMax, y, plotW}, theme) {
             const ty = y(tick).toFixed(1);
             return (
                 `<line x1="${MARGIN.left}" y1="${ty}" x2="${MARGIN.left + plotW}" y2="${ty}" stroke="${theme.grid}"/>` +
-                `<text x="${MARGIN.left - 8}" y="${ty}" dy="4" text-anchor="end" class="tick">${formatCount(tick)}</text>`
+                `<text x="${MARGIN.left - 8}" y="${ty}" dy="4" text-anchor="end" class="tick">${formatTick(tick, yMax)}</text>`
             );
         })
         .join('\n    ');

--- a/.github/scripts/star-history.mjs
+++ b/.github/scripts/star-history.mjs
@@ -133,7 +133,7 @@ async function fetchStarDates(repo, token) {
     return {stargazerCount, dates};
 }
 
-/** Collapses raw ISO timestamps into a per-day cumulative series: [isoDay, total][]. */
+// Collapses raw ISO timestamps into a per-day cumulative series: [isoDay, total][].
 function toDailyCumulative(dates) {
     const perDay = new Map();
     for (const iso of dates) {
@@ -173,7 +173,7 @@ function yTicks(yMax) {
     return [0, step, step * 2, step * 3, yMax];
 }
 
-/** Year boundaries for long ranges, otherwise several evenly spaced dates. */
+// Year boundaries for long ranges, otherwise several evenly spaced dates.
 function xTicks(minTime, maxTime) {
     const spanDays = (maxTime - minTime) / 86400000;
     const ticks = [];
@@ -199,7 +199,7 @@ function xTicks(minTime, maxTime) {
 
 const formatCount = (n) => new Intl.NumberFormat('en-US').format(n);
 
-/** Turns the series into plot geometry: scales, path coordinates and the end-point anchor. */
+// Turns the series into plot geometry: scales, path coordinates and the end-point anchor.
 function preparePlot({series, total, updatedAt}) {
     const plotW = WIDTH - MARGIN.left - MARGIN.right;
     const plotH = HEIGHT - MARGIN.top - MARGIN.bottom;
@@ -319,9 +319,9 @@ async function main() {
         if (!token) {
             throw new Error('GITHUB_TOKEN environment variable is required');
         }
-        console.log(`Fetching star history for ${args.repo}...`);
+        console.info(`Fetching star history for ${args.repo}...`);
         const {stargazerCount, dates} = await fetchStarDates(args.repo, token);
-        console.log(`Fetched ${dates.length} star timestamps (stargazerCount: ${stargazerCount})`);
+        console.info(`Fetched ${dates.length} star timestamps (stargazerCount: ${stargazerCount})`);
         data = {
             repo: args.repo,
             updatedAt: new Date().toISOString(),
@@ -336,7 +336,7 @@ async function main() {
         const svg = renderSvg({...data, theme});
         const file = path.join(args.out, `star-history-${theme}.svg`);
         fs.writeFileSync(file, svg);
-        console.log(`Wrote ${file}`);
+        console.info(`Wrote ${file}`);
     }
 }
 

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Generate charts
         run: node .github/scripts/star-history.mjs --out star-history-out
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       # The charts live in an orphan single-commit branch so the main history
       # stays clean; README references them via raw.githubusercontent.com.
       - name: Publish to star-history-data branch
@@ -33,4 +33,4 @@ jobs:
               commit -qm "chore: update star history chart"
           git push -qf "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" star-history-data
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,36 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: '17 3 * * 1' # weekly, Monday 03:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-chart:
+    runs-on: ubuntu-latest
+    if: github.repository == 'gravity-ui/uikit'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Generate charts
+        run: node .github/scripts/star-history.mjs --out star-history-out
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The charts live in an orphan single-commit branch so the main history
+      # stays clean; README references them via raw.githubusercontent.com.
+      - name: Publish to star-history-data branch
+        working-directory: star-history-out
+        run: |
+          git init -q -b star-history-data
+          git add -A
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -qm "chore: update star history chart"
+          git push -qf "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" star-history-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README-ru.md
+++ b/README-ru.md
@@ -129,9 +129,9 @@ npm run playwright    # визуальные регрессионные тест
 
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline" />
-    <img alt="Star History Chart" width="600" src="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-light.svg" />
+    <img alt="Star History Chart" width="600" src="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-light.svg" />
   </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ Agent-readable documentation for the installed version is located in `node_modul
 
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline" />
-    <img alt="Star History Chart" width="600" src="https://api.star-history.com/svg?repos=gravity-ui/uikit&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-light.svg" />
+    <img alt="Star History Chart" width="600" src="https://raw.githubusercontent.com/gravity-ui/uikit/star-history-data/star-history-light.svg" />
   </picture>
 </div>
 


### PR DESCRIPTION
## Why

GitHub [restricted the stargazers API](https://star-history.com/blog/github-stargazer-api-restriction) (June 2026) to repository admins and collaborators. The live star-history.com embed in our README now renders a "GitHub restricted access to star data" placeholder instead of the chart — for every repository, globally.

## What

Self-host the chart generation using the repository's own credentials:

- **`.github/scripts/star-history.mjs`** — dependency-free Node script: fetches star timestamps via GraphQL (`stargazers` with `starredAt`, paginated), aggregates per day, and renders static light/dark SVG charts. Fails loudly (non-zero exit) if the token has no access to star data, so a broken chart never gets published.
- **`.github/workflows/star-history.yml`** — weekly cron + manual dispatch: generates the charts and force-pushes them as a single-commit orphan branch `star-history-data`, keeping `main` history clean.
- **README.md / README-ru.md** — the `<picture>` block now points to `raw.githubusercontent.com/gravity-ui/uikit/star-history-data/...` (light/dark structure preserved).

Chart colors are taken from the Gravity UI amber ramp (`#ffbe5c` brand yellow in the area fill; line `#bd8e4b` light / `#bc8a2e` dark) and pass contrast/CVD validation on both GitHub backgrounds.

Verified locally against live data (1,029 stars fetched via a collaborator token — collaborator access works under the new API restriction).

| Light | Dark |
|---|---|
| renders on `#ffffff` | renders on `#0d1117` |

## After merge

Until the `star-history-data` branch exists, the README image will 404. **Run the "Star History" workflow once manually** (workflow_dispatch) — it creates the branch and the chart goes live. The first run also confirms that the Actions `GITHUB_TOKEN` passes the stargazers restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Self-host generation and publishing of the repository's GitHub star history chart and update READMEs to reference the new static SVG assets.

Enhancements:
- Add a Node-based script to fetch stargazer data via GitHub GraphQL and render light/dark SVG star history charts.
- Introduce a scheduled GitHub Actions workflow that generates charts and publishes them to a dedicated orphan branch for clean main history.

Documentation:
- Update English and Russian READMEs to load the star history chart from the repository-hosted SVG assets instead of the external star-history.com service.