### PR TITLE
fix(Modal): constrain scrollable content to overlay

### DIFF
--- a/src/components/Dialog/__tests__/Dialog.visual.test.tsx
+++ b/src/components/Dialog/__tests__/Dialog.visual.test.tsx
@@ -2,6 +2,7 @@ import {createSmokeScenarios} from '@gravity-ui/playwright-tools/component-tests
 
 import {expect, test} from '~playwright/core';
 
+import {getModalLayoutMetrics} from '../../Modal/__tests__/helpers';
 import {Dialog} from '../Dialog';
 import type {DialogProps} from '../Dialog';
 import type {DialogBodyProps} from '../DialogBody/DialogBody';
@@ -54,34 +55,24 @@ test.describe('Dialog', {tag: '@Dialog'}, () => {
 
         await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
 
-        const getMetrics = () =>
-            overlay.evaluate((overlayElement) => {
-                const alignerElement = overlayElement.querySelector<HTMLElement>(
-                    '.g-modal__content-aligner',
-                );
-                const contentElement =
-                    overlayElement.querySelector<HTMLElement>('.g-modal__content');
+        const wideMetrics = await getModalLayoutMetrics(overlay);
 
-                if (!alignerElement || !contentElement) {
-                    throw new Error('Dialog modal layout elements are missing');
-                }
-
-                return {
-                    overlayClientWidth: overlayElement.clientWidth,
-                    overlayScrollWidth: overlayElement.scrollWidth,
-                    alignerClientWidth: alignerElement.clientWidth,
-                    contentClientWidth: contentElement.clientWidth,
-                };
-            });
-
-        expect((await getMetrics()).contentClientWidth).toBe(720);
+        expect(wideMetrics.contentMaxWidth).toBeGreaterThan(0);
+        expect(wideMetrics.contentClientWidth).toBe(wideMetrics.contentMaxWidth);
 
         await page.setViewportSize({width: 400, height: 600});
 
-        const narrowMetrics = await getMetrics();
+        const narrowMetrics = await getModalLayoutMetrics(overlay);
 
         expect(narrowMetrics.alignerClientWidth).toBe(narrowMetrics.overlayClientWidth);
-        expect(narrowMetrics.contentClientWidth).toBe(360);
+        expect(
+            Math.abs(
+                narrowMetrics.contentClientWidth +
+                    narrowMetrics.contentMarginInlineStart +
+                    narrowMetrics.contentMarginInlineEnd -
+                    narrowMetrics.alignerClientWidth,
+            ),
+        ).toBeLessThanOrEqual(1);
         expect(
             narrowMetrics.overlayScrollWidth - narrowMetrics.overlayClientWidth,
         ).toBeLessThanOrEqual(1);
@@ -114,7 +105,9 @@ test.describe('Dialog', {tag: '@Dialog'}, () => {
 
         await page.setViewportSize({width: 1000, height: 600});
 
-        expect((await getMetrics()).contentClientWidth).toBe(720);
+        expect((await getModalLayoutMetrics(overlay)).contentClientWidth).toBe(
+            wideMetrics.contentClientWidth,
+        );
         await expect(content).toBeVisible();
     });
 

--- a/src/components/Dialog/__tests__/Dialog.visual.test.tsx
+++ b/src/components/Dialog/__tests__/Dialog.visual.test.tsx
@@ -1,6 +1,6 @@
 import {createSmokeScenarios} from '@gravity-ui/playwright-tools/component-tests';
 
-import {test} from '~playwright/core';
+import {expect, test} from '~playwright/core';
 
 import {Dialog} from '../Dialog';
 import type {DialogProps} from '../Dialog';
@@ -40,6 +40,84 @@ interface AllDialogProps {
 }
 
 test.describe('Dialog', {tag: '@Dialog'}, () => {
+    test('keeps full-width dialog inside the overlay on viewport resize', async ({mount, page}) => {
+        await page.setViewportSize({width: 1000, height: 600});
+
+        await mount(
+            <Dialog contentOverflow="auto" fullWidth maxWidth="m" onClose={() => {}} open>
+                <div style={{width: 600}}>Wide dialog content</div>
+            </Dialog>,
+        );
+
+        const overlay = page.locator('.g-modal');
+        const content = overlay.locator('.g-modal__content');
+
+        await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
+
+        const getMetrics = () =>
+            overlay.evaluate((overlayElement) => {
+                const alignerElement = overlayElement.querySelector<HTMLElement>(
+                    '.g-modal__content-aligner',
+                );
+                const contentElement =
+                    overlayElement.querySelector<HTMLElement>('.g-modal__content');
+
+                if (!alignerElement || !contentElement) {
+                    throw new Error('Dialog modal layout elements are missing');
+                }
+
+                return {
+                    overlayClientWidth: overlayElement.clientWidth,
+                    overlayScrollWidth: overlayElement.scrollWidth,
+                    alignerClientWidth: alignerElement.clientWidth,
+                    contentClientWidth: contentElement.clientWidth,
+                };
+            });
+
+        expect((await getMetrics()).contentClientWidth).toBe(720);
+
+        await page.setViewportSize({width: 400, height: 600});
+
+        const narrowMetrics = await getMetrics();
+
+        expect(narrowMetrics.alignerClientWidth).toBe(narrowMetrics.overlayClientWidth);
+        expect(narrowMetrics.contentClientWidth).toBe(360);
+        expect(
+            narrowMetrics.overlayScrollWidth - narrowMetrics.overlayClientWidth,
+        ).toBeLessThanOrEqual(1);
+
+        const scrollOwner = await page
+            .locator('.g-modal__content, .g-dialog')
+            .evaluateAll((items) => {
+                const element = items.find((item) => {
+                    const style = getComputedStyle(item);
+                    return (
+                        item.scrollWidth > item.clientWidth &&
+                        (style.overflowX === 'auto' || style.overflowX === 'scroll')
+                    );
+                });
+
+                if (!element) {
+                    return null;
+                }
+
+                element.scrollLeft = element.scrollWidth;
+
+                return {
+                    className: element.className,
+                    scrollLeft: element.scrollLeft,
+                };
+            });
+
+        expect(scrollOwner).not.toBeNull();
+        expect(scrollOwner?.scrollLeft).toBeGreaterThan(0);
+
+        await page.setViewportSize({width: 1000, height: 600});
+
+        expect((await getMetrics()).contentClientWidth).toBe(720);
+        await expect(content).toBeVisible();
+    });
+
     createSmokeScenarios(
         {
             size: 's',

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -25,6 +25,10 @@ $modal-transform-transition: transform $modal-transition-duration ease-out;
         display: inline-flex;
         align-items: center;
         justify-content: center;
+
+        &_has-scroll {
+            width: 100%;
+        }
     }
 
     &__content {
@@ -42,6 +46,7 @@ $modal-transform-transition: transform $modal-transition-duration ease-out;
         transition: $modal-height-transition;
 
         &_has-scroll {
+            min-width: 0;
             overflow: auto;
             max-width: var(
                 --g-modal-max-width,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -144,6 +144,7 @@ function ModalComponent(rawProps: ModalProps) {
     useLayer({open, type: 'modal'});
     const mobileModals = React.useContext(MobileContext).__experimentalMobileModals ?? false;
     const mobile = useMobile() && mobileModals;
+    const hasScroll = mobile || contentOverflow === 'auto';
 
     const overlayRef = React.useRef<HTMLDivElement>(null);
     const [isVisible, setIsVisible] = React.useState(false);
@@ -298,12 +299,12 @@ function ModalComponent(rawProps: ModalProps) {
                             }
                             restoreFocus={true}
                         >
-                            <div className={b('content-aligner')}>
+                            <div className={b('content-aligner', {'has-scroll': hasScroll})}>
                                 <div
                                     {...filterDOMProps(restProps, {labelable: true})}
                                     className={b(
                                         'content',
-                                        {'has-scroll': mobile ? true : contentOverflow === 'auto'},
+                                        {'has-scroll': hasScroll},
                                         contentClassName,
                                     )}
                                     ref={handleFloatingRef}

--- a/src/components/Modal/__tests__/Modal.visual.test.tsx
+++ b/src/components/Modal/__tests__/Modal.visual.test.tsx
@@ -6,6 +6,7 @@ import {MobileProvider} from '../../mobile';
 import {Modal} from '../Modal';
 
 import {ModalQa} from './constants';
+import {getModalLayoutMetrics} from './helpers';
 
 test.describe('Modal', {tag: '@Modal'}, () => {
     test('smoke', {tag: ['@smoke']}, async ({mount, page, expectScreenshot}) => {
@@ -28,6 +29,8 @@ test.describe('Modal', {tag: '@Modal'}, () => {
     });
 
     test('constrains horizontally overflowing content to the overlay', async ({mount, page}) => {
+        const modalMargin = 24;
+
         await page.setViewportSize({width: 400, height: 500});
 
         await mount(
@@ -35,7 +38,7 @@ test.describe('Modal', {tag: '@Modal'}, () => {
                 open
                 contentOverflow="auto"
                 qa={ModalQa.content}
-                style={{'--g-modal-margin': '24px'} as React.CSSProperties}
+                style={{'--g-modal-margin': `${modalMargin}px`} as React.CSSProperties}
             >
                 <div style={{width: 600}}>Wide modal content</div>
             </Modal>,
@@ -48,27 +51,19 @@ test.describe('Modal', {tag: '@Modal'}, () => {
         await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
         await expect(aligner).toHaveClass(/g-modal__content-aligner_has-scroll/);
 
-        const metrics = await overlay.evaluate((overlayElement) => {
-            const alignerElement = overlayElement.querySelector<HTMLElement>(
-                '.g-modal__content-aligner',
-            );
-            const contentElement = overlayElement.querySelector<HTMLElement>('.g-modal__content');
-
-            if (!alignerElement || !contentElement) {
-                throw new Error('Modal layout elements are missing');
-            }
-
-            return {
-                overlayClientWidth: overlayElement.clientWidth,
-                overlayScrollWidth: overlayElement.scrollWidth,
-                alignerClientWidth: alignerElement.clientWidth,
-                contentClientWidth: contentElement.clientWidth,
-                contentScrollWidth: contentElement.scrollWidth,
-            };
-        });
+        const metrics = await getModalLayoutMetrics(overlay);
 
         expect(metrics.alignerClientWidth).toBe(metrics.overlayClientWidth);
-        expect(metrics.contentClientWidth).toBe(352);
+        expect(metrics.contentMarginInlineStart).toBe(modalMargin);
+        expect(metrics.contentMarginInlineEnd).toBe(modalMargin);
+        expect(
+            Math.abs(
+                metrics.contentClientWidth +
+                    metrics.contentMarginInlineStart +
+                    metrics.contentMarginInlineEnd -
+                    metrics.alignerClientWidth,
+            ),
+        ).toBeLessThanOrEqual(1);
         expect(metrics.contentScrollWidth).toBeGreaterThan(metrics.contentClientWidth);
         expect(metrics.overlayScrollWidth - metrics.overlayClientWidth).toBeLessThanOrEqual(1);
 
@@ -96,20 +91,7 @@ test.describe('Modal', {tag: '@Modal'}, () => {
         await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
         await expect(aligner).not.toHaveClass(/g-modal__content-aligner_has-scroll/);
 
-        const metrics = await overlay.evaluate((overlayElement) => {
-            const alignerElement = overlayElement.querySelector<HTMLElement>(
-                '.g-modal__content-aligner',
-            );
-
-            if (!alignerElement) {
-                throw new Error('Modal content aligner is missing');
-            }
-
-            return {
-                overlayClientWidth: overlayElement.clientWidth,
-                alignerClientWidth: alignerElement.clientWidth,
-            };
-        });
+        const metrics = await getModalLayoutMetrics(overlay);
 
         expect(metrics.alignerClientWidth).toBeGreaterThan(metrics.overlayClientWidth);
     });
@@ -131,22 +113,7 @@ test.describe('Modal', {tag: '@Modal'}, () => {
         await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
         await expect(aligner).toHaveClass(/g-modal__content-aligner_has-scroll/);
 
-        const metrics = await overlay.evaluate((overlayElement) => {
-            const alignerElement = overlayElement.querySelector<HTMLElement>(
-                '.g-modal__content-aligner',
-            );
-            const contentElement = overlayElement.querySelector<HTMLElement>('.g-modal__content');
-
-            if (!alignerElement || !contentElement) {
-                throw new Error('Modal layout elements are missing');
-            }
-
-            return {
-                overlayClientWidth: overlayElement.clientWidth,
-                alignerClientWidth: alignerElement.clientWidth,
-                contentClientWidth: contentElement.clientWidth,
-            };
-        });
+        const metrics = await getModalLayoutMetrics(overlay);
 
         expect(metrics.alignerClientWidth).toBe(metrics.overlayClientWidth);
         expect(metrics.contentClientWidth).toBe(metrics.overlayClientWidth);

--- a/src/components/Modal/__tests__/Modal.visual.test.tsx
+++ b/src/components/Modal/__tests__/Modal.visual.test.tsx
@@ -2,6 +2,7 @@ import {expect} from '@playwright/experimental-ct-react';
 
 import {test} from '~playwright/core';
 
+import {MobileProvider} from '../../mobile';
 import {Modal} from '../Modal';
 
 import {ModalQa} from './constants';
@@ -24,5 +25,130 @@ test.describe('Modal', {tag: '@Modal'}, () => {
         await expectScreenshot({
             locator: page,
         });
+    });
+
+    test('constrains horizontally overflowing content to the overlay', async ({mount, page}) => {
+        await page.setViewportSize({width: 400, height: 500});
+
+        await mount(
+            <Modal
+                open
+                contentOverflow="auto"
+                qa={ModalQa.content}
+                style={{'--g-modal-margin': '24px'} as React.CSSProperties}
+            >
+                <div style={{width: 600}}>Wide modal content</div>
+            </Modal>,
+        );
+
+        const overlay = page.getByTestId(ModalQa.content);
+        const aligner = overlay.locator('.g-modal__content-aligner');
+        const content = overlay.locator('.g-modal__content');
+
+        await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
+        await expect(aligner).toHaveClass(/g-modal__content-aligner_has-scroll/);
+
+        const metrics = await overlay.evaluate((overlayElement) => {
+            const alignerElement = overlayElement.querySelector<HTMLElement>(
+                '.g-modal__content-aligner',
+            );
+            const contentElement = overlayElement.querySelector<HTMLElement>('.g-modal__content');
+
+            if (!alignerElement || !contentElement) {
+                throw new Error('Modal layout elements are missing');
+            }
+
+            return {
+                overlayClientWidth: overlayElement.clientWidth,
+                overlayScrollWidth: overlayElement.scrollWidth,
+                alignerClientWidth: alignerElement.clientWidth,
+                contentClientWidth: contentElement.clientWidth,
+                contentScrollWidth: contentElement.scrollWidth,
+            };
+        });
+
+        expect(metrics.alignerClientWidth).toBe(metrics.overlayClientWidth);
+        expect(metrics.contentClientWidth).toBe(352);
+        expect(metrics.contentScrollWidth).toBeGreaterThan(metrics.contentClientWidth);
+        expect(metrics.overlayScrollWidth - metrics.overlayClientWidth).toBeLessThanOrEqual(1);
+
+        const scrollLeft = await content.evaluate((element) => {
+            const scrollElement = element;
+            scrollElement.scrollLeft = scrollElement.scrollWidth;
+            return scrollElement.scrollLeft;
+        });
+
+        expect(scrollLeft).toBeGreaterThan(0);
+    });
+
+    test('preserves intrinsic width when content overflow is visible', async ({mount, page}) => {
+        await page.setViewportSize({width: 400, height: 500});
+
+        await mount(
+            <Modal open contentOverflow="visible" qa={ModalQa.content}>
+                <div style={{width: 600}}>Wide modal content</div>
+            </Modal>,
+        );
+
+        const overlay = page.getByTestId(ModalQa.content);
+        const aligner = overlay.locator('.g-modal__content-aligner');
+
+        await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
+        await expect(aligner).not.toHaveClass(/g-modal__content-aligner_has-scroll/);
+
+        const metrics = await overlay.evaluate((overlayElement) => {
+            const alignerElement = overlayElement.querySelector<HTMLElement>(
+                '.g-modal__content-aligner',
+            );
+
+            if (!alignerElement) {
+                throw new Error('Modal content aligner is missing');
+            }
+
+            return {
+                overlayClientWidth: overlayElement.clientWidth,
+                alignerClientWidth: alignerElement.clientWidth,
+            };
+        });
+
+        expect(metrics.alignerClientWidth).toBeGreaterThan(metrics.overlayClientWidth);
+    });
+
+    test('constrains mobile modal content to the overlay', async ({mount, page}) => {
+        await page.setViewportSize({width: 390, height: 844});
+
+        await mount(
+            <MobileProvider mobile __experimentalMobileModals>
+                <Modal open qa={ModalQa.content}>
+                    Mobile modal content
+                </Modal>
+            </MobileProvider>,
+        );
+
+        const overlay = page.getByTestId(ModalQa.content);
+        const aligner = overlay.locator('.g-modal__content-aligner');
+
+        await expect(overlay).toHaveAttribute('data-floating-ui-status', 'open');
+        await expect(aligner).toHaveClass(/g-modal__content-aligner_has-scroll/);
+
+        const metrics = await overlay.evaluate((overlayElement) => {
+            const alignerElement = overlayElement.querySelector<HTMLElement>(
+                '.g-modal__content-aligner',
+            );
+            const contentElement = overlayElement.querySelector<HTMLElement>('.g-modal__content');
+
+            if (!alignerElement || !contentElement) {
+                throw new Error('Modal layout elements are missing');
+            }
+
+            return {
+                overlayClientWidth: overlayElement.clientWidth,
+                alignerClientWidth: alignerElement.clientWidth,
+                contentClientWidth: contentElement.clientWidth,
+            };
+        });
+
+        expect(metrics.alignerClientWidth).toBe(metrics.overlayClientWidth);
+        expect(metrics.contentClientWidth).toBe(metrics.overlayClientWidth);
     });
 });

--- a/src/components/Modal/__tests__/helpers.ts
+++ b/src/components/Modal/__tests__/helpers.ts
@@ -1,0 +1,28 @@
+import type {Locator} from '@playwright/test';
+
+export function getModalLayoutMetrics(overlay: Locator) {
+    return overlay.evaluate((overlayElement) => {
+        const alignerElement = overlayElement.querySelector<HTMLElement>(
+            '.g-modal__content-aligner',
+        );
+        const contentElement = overlayElement.querySelector<HTMLElement>('.g-modal__content');
+
+        if (!alignerElement || !contentElement) {
+            throw new Error('Modal layout elements are missing');
+        }
+
+        const contentStyle = getComputedStyle(contentElement);
+        const parsedMaxWidth = Number.parseFloat(contentStyle.maxWidth);
+
+        return {
+            overlayClientWidth: overlayElement.clientWidth,
+            overlayScrollWidth: overlayElement.scrollWidth,
+            alignerClientWidth: alignerElement.clientWidth,
+            contentClientWidth: contentElement.clientWidth,
+            contentScrollWidth: contentElement.scrollWidth,
+            contentMarginInlineStart: Number.parseFloat(contentStyle.marginInlineStart),
+            contentMarginInlineEnd: Number.parseFloat(contentStyle.marginInlineEnd),
+            contentMaxWidth: Number.isNaN(parsedMaxWidth) ? null : parsedMaxWidth,
+        };
+    });
+}


### PR DESCRIPTION
## Summary

Fix horizontal overflow in `Modal` when `contentOverflow="auto"` is used with content whose intrinsic width exceeds the viewport.

Previously, the inline-flex content aligner could grow beyond the overlay width. This allowed wide content, including `Dialog` footers with dynamic actions, to expand the entire modal instead of adapting to the available viewport width.

## Changes

- Reuse a single `hasScroll` flag for mobile modals and `contentOverflow="auto"`.
- Add the `has-scroll` modifier to the modal content aligner.
- Constrain the scrollable aligner to the overlay width.
- Allow modal content to shrink below its min-content width.
- Preserve the existing `contentOverflow="visible"` behavior.
- Add component tests covering:
  - custom modal margins;
  - horizontal scrolling inside the modal;
  - `contentOverflow="visible"` regression behavior;
  - mobile modal width;
  - `Dialog fullWidth maxWidth="m"`;
  - viewport resize from wide to narrow and back;
  - absence of horizontal overflow on the root overlay.

## Testing

- `npm run typecheck`
- `npm test -- --runInBand src/components/Dialog/__tests__/Dialog.test.tsx`
- `npm run build`
- ESLint, Stylelint and Prettier checks
- Targeted Playwright component tests: 4 passed

## Summary by Sourcery

Constrain scrollable modal content to the overlay while preserving visible-overflow sizing behavior.

Bug Fixes:
- Prevent horizontally overflowing modal and dialog content from expanding the root overlay when scrollable overflow is enabled.
- Preserve intrinsic content sizing for modals using visible overflow.

Enhancements:
- Constrain scrollable modal aligners to the overlay width and allow their content to shrink below its minimum intrinsic width.
- Unify scroll-state handling across mobile modals and auto-overflow content.

Tests:
- Add component coverage for modal scrolling, responsive resizing, mobile sizing, custom margins, visible-overflow behavior, and overlay overflow.
- Add regression coverage ensuring full-width dialogs remain constrained across viewport changes.