### PR TITLE
test(Menu): stabilize keyboard navigation

### DIFF
--- a/src/components/lab/Menu/__tests__/Menu.test.tsx
+++ b/src/components/lab/Menu/__tests__/Menu.test.tsx
@@ -164,6 +164,9 @@ describe('Menu', () => {
 
         const items = screen.getAllByRole('menuitem');
 
+        await waitFor(() => {
+            expect(items[0]).toHaveFocus();
+        });
         expect(items[0]).toHaveClass(/active/);
         await user.keyboard('{ArrowDown}');
         expect(items[1]).toHaveClass(/active/);


### PR DESCRIPTION
Wait for the first menu item to receive focus before sending ArrowDown. Floating UI schedules the initial focus via requestAnimationFrame, so waiting only for menu visibility could race under CI load.

Tests:
- `npm test -- --runInBand --silent src/components/lab/Menu/__tests__/Menu.test.tsx`
- 30 repeated isolated runs of the keyboard navigation test
- `npx eslint src/components/lab/Menu/__tests__/Menu.test.tsx`