### PR TITLE
feat!: add virtualizer and hello-pangea-dnd entry points

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -73,6 +73,25 @@ import '@gravity-ui/uikit/styles/styles.css';
 - [Серверный рендеринг (SSR)](docs/server-side-rendering-ru.md) — генерация корневого CSS-класса на сервере
 - [Интернационализация (I18N)](docs/i18n-ru.md) — язык встроенных текстов компонентов
 
+### Точки входа
+
+| Точка входа                           | Что там                                     | Когда брать                                                                          |
+| :------------------------------------ | :------------------------------------------ | :----------------------------------------------------------------------------------- |
+| `@gravity-ui/uikit`                   | Компоненты, хуки и утилиты                  | Всегда — это и есть пакет                                                            |
+| `@gravity-ui/uikit/styles/*`          | Глобальные CSS и SCSS-миксины               | Один раз в точке входа приложения, см. [Стили](#стили)                               |
+| `@gravity-ui/uikit/i18n`              | `addLanguageKeysets`, `addComponentKeysets` | Добавить или переопределить встроенные тексты компонентов                            |
+| `@gravity-ui/uikit/server`            | `getRootClassName`                          | Сгенерировать корневой класс на сервере, см. [SSR](docs/server-side-rendering-ru.md) |
+| `@gravity-ui/uikit/toaster-singleton` | Готовый инстанс `Toaster`                   | Показывать тосты вне дерева React                                                    |
+| `@gravity-ui/uikit/virtualizer`       | `Virtualizer`, `ListVirtualizer`            | Рендерить только видимое окно длинного списка                                        |
+| `@gravity-ui/uikit/hello-pangea-dnd`  | `useListHelloPangeaDnd`                     | Переупорядочивать строки списка через `@hello-pangea/dnd`                            |
+| `@gravity-ui/uikit/unstable`          | Компоненты, чей API ещё меняется            | На свой риск — они ломаются и вне мажорных релизов                                   |
+| `@gravity-ui/uikit/legacy`            | Компоненты, которые больше не развиваются   | Только пока мигрируете с них                                                         |
+
+`@tanstack/react-virtual` — опциональная peer-зависимость точки входа `/virtualizer`: поставьте её
+рядом с пакетом, если импортируете оттуда. Всё остальное этим точкам входа приносит сам пакет.
+`ListVirtualizer` и `useListHelloPangeaDnd` работают с `unstable_List` и наследуют его
+стабильность; отдельно стоящий `Virtualizer` — нет.
+
 ## Разработка
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Read more:
 - [Server-side rendering](docs/server-side-rendering.md) — generate the root CSS class on the server
 - [Internationalization](docs/i18n.md) — set the built-in component language
 
+### Entry points
+
+| Entry point                           | What is there                               | When to use                                                                       |
+| :------------------------------------ | :------------------------------------------ | :-------------------------------------------------------------------------------- |
+| `@gravity-ui/uikit`                   | Components, hooks and utilities             | Always — this is the package                                                      |
+| `@gravity-ui/uikit/styles/*`          | The global CSS and the SCSS mixins          | Once at the entry point of the app, see [Styles](#styles)                         |
+| `@gravity-ui/uikit/i18n`              | `addLanguageKeysets`, `addComponentKeysets` | Adding or overriding the built-in component strings                               |
+| `@gravity-ui/uikit/server`            | `getRootClassName`                          | Generating the root class on the server, see [SSR](docs/server-side-rendering.md) |
+| `@gravity-ui/uikit/toaster-singleton` | A ready-made `Toaster` instance             | Showing toasts outside of the React tree                                          |
+| `@gravity-ui/uikit/virtualizer`       | `Virtualizer`, `ListVirtualizer`            | Rendering only the visible window of a long list                                  |
+| `@gravity-ui/uikit/hello-pangea-dnd`  | `useListHelloPangeaDnd`                     | Reordering the rows of a list with `@hello-pangea/dnd`                            |
+| `@gravity-ui/uikit/unstable`          | Components whose API is still moving        | At your own risk — these break outside of major releases                          |
+| `@gravity-ui/uikit/legacy`            | Components that are no longer developed     | Only while migrating away from them                                               |
+
+`@tanstack/react-virtual` is an optional peer dependency of the `/virtualizer` entry point:
+install it next to the package when you import from there. Everything else these entry points
+need comes with the package itself. `ListVirtualizer` and `useListHelloPangeaDnd` work with the
+`unstable_List` and follow its stability; the standalone `Virtualizer` does not.
+
 ## Development
 
 ```shell

--- a/contribute/architecture-ru.md
+++ b/contribute/architecture-ru.md
@@ -18,6 +18,8 @@ UIKit — единый публикуемый пакет `@gravity-ui/uikit`. В
 | `@gravity-ui/uikit/toaster-singleton` | `src/toaster-singleton.ts` | Интеграция синглтона тостера                                                    |
 | `@gravity-ui/uikit/i18n`              | `src/i18n/index.ts`        | I18n-утилиты и ресурсы                                                          |
 | `@gravity-ui/uikit/server`            | `src/server.ts`            | Безопасные для сервера утилиты, сейчас — генератор корневого класса темы        |
+| `@gravity-ui/uikit/virtualizer`       | `src/virtualizer.ts`       | Виртуализация рендеринга; нужен опциональный peer `@tanstack/react-virtual`     |
+| `@gravity-ui/uikit/hello-pangea-dnd`  | `src/hello-pangea-dnd.ts`  | Интеграция списка с `@hello-pangea/dnd`                                         |
 | `@gravity-ui/uikit/legacy`            | `src/legacy.ts`            | Поверхность совместимости со старыми компонентами; не использовать в новом коде |
 | `@gravity-ui/uikit/unstable`          | `src/unstable.ts`          | Экспериментальная поверхность без гарантий стабильной точки входа               |
 | `@gravity-ui/uikit/styles/*`          | `styles/*`                 | Глобальные CSS/SCSS, шрифты, миксины и темы                                     |

--- a/contribute/architecture.md
+++ b/contribute/architecture.md
@@ -18,6 +18,8 @@ ESM and CommonJS builds with matching TypeScript declarations.
 | `@gravity-ui/uikit/toaster-singleton` | `src/toaster-singleton.ts` | Toaster singleton integration                                                |
 | `@gravity-ui/uikit/i18n`              | `src/i18n/index.ts`        | I18n helpers and resources                                                   |
 | `@gravity-ui/uikit/server`            | `src/server.ts`            | Server-safe helpers, currently the root theme class generator                |
+| `@gravity-ui/uikit/virtualizer`       | `src/virtualizer.ts`       | Virtualized rendering; needs the optional peer `@tanstack/react-virtual`     |
+| `@gravity-ui/uikit/hello-pangea-dnd`  | `src/hello-pangea-dnd.ts`  | List integration with `@hello-pangea/dnd`                                    |
 | `@gravity-ui/uikit/legacy`            | `src/legacy.ts`            | Compatibility surface for legacy components; avoid for new work              |
 | `@gravity-ui/uikit/unstable`          | `src/unstable.ts`          | Experimental surface without the stability guarantees of the root entrypoint |
 | `@gravity-ui/uikit/styles/*`          | `styles/*`                 | Global CSS/SCSS, fonts, mixins, and themes                                   |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,12 @@ import storybookPlugin from 'eslint-plugin-storybook';
 import testingLibraryPlugin from 'eslint-plugin-testing-library';
 import globals from 'globals';
 
+const TANSTACK_MESSAGE =
+    'Belongs to the @gravity-ui/uikit/virtualizer entry point. Every other import needs an eslint-disable with a reason.';
+
+const DND_MESSAGE =
+    'Belongs to the @gravity-ui/uikit/hello-pangea-dnd entry point. Every other import needs an eslint-disable with a reason.';
+
 export default defineConfig([
     ...baseConfig,
     ...clientConfig,
@@ -96,6 +102,27 @@ export default defineConfig([
                 ...globals.node,
                 ...globals.jest,
             },
+        },
+    },
+    // The packages of the dedicated entry points are restricted everywhere: an import outside of
+    // them is an explicit eslint-disable, so the places that carry one are easy to list.
+    // `paths` matches the exact specifier, `patterns` the deep imports of the same package.
+    {
+        files: ['src/**/*.{ts,tsx}'],
+        rules: {
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        {name: '@tanstack/react-virtual', message: TANSTACK_MESSAGE},
+                        {name: '@hello-pangea/dnd', message: DND_MESSAGE},
+                    ],
+                    patterns: [
+                        {group: ['@tanstack/react-virtual/*'], message: TANSTACK_MESSAGE},
+                        {group: ['@hello-pangea/dnd/*'], message: DND_MESSAGE},
+                    ],
+                },
+            ],
         },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@gravity-ui/i18n": "^1.8.0",
         "@gravity-ui/icons": "^2.16.0",
         "@hello-pangea/dnd": "^18.0.1",
-        "@tanstack/react-virtual": "^3.13.12",
         "@uiw/react-color": "^2.9.2",
         "blueimp-md5": "^2.19.0",
         "lodash": "^4.17.21",
@@ -54,6 +53,7 @@
         "@storybook/cli": "^9.0.5",
         "@storybook/react-webpack5": "^9.0.5",
         "@storybook/test-runner": "^0.23.0",
+        "@tanstack/react-virtual": "^3.13.12",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -107,11 +107,15 @@
         "yarn": "Please use npm instead of yarn to install dependencies"
       },
       "peerDependencies": {
+        "@tanstack/react-virtual": "^3",
         "@types/react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@tanstack/react-virtual": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }
@@ -6627,6 +6631,7 @@
       "version": "3.13.12",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
       "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/virtual-core": "3.13.12"
@@ -6644,6 +6649,7 @@
       "version": "3.13.12",
       "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
       "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,26 @@
         "default": "./build/cjs/server.js"
       }
     },
+    "./virtualizer": {
+      "import": {
+        "types": "./build/esm/virtualizer.d.ts",
+        "default": "./build/esm/virtualizer.js"
+      },
+      "require": {
+        "types": "./build/cjs/virtualizer.d.ts",
+        "default": "./build/cjs/virtualizer.js"
+      }
+    },
+    "./hello-pangea-dnd": {
+      "import": {
+        "types": "./build/esm/hello-pangea-dnd.d.ts",
+        "default": "./build/esm/hello-pangea-dnd.js"
+      },
+      "require": {
+        "types": "./build/cjs/hello-pangea-dnd.d.ts",
+        "default": "./build/cjs/hello-pangea-dnd.js"
+      }
+    },
     "./styles/*": "./styles/*"
   },
   "main": "./build/cjs/index.js",
@@ -131,7 +151,6 @@
     "@gravity-ui/i18n": "^1.8.0",
     "@gravity-ui/icons": "^2.16.0",
     "@hello-pangea/dnd": "^18.0.1",
-    "@tanstack/react-virtual": "^3.13.12",
     "@uiw/react-color": "^2.9.2",
     "blueimp-md5": "^2.19.0",
     "lodash": "^4.17.21",
@@ -171,6 +190,7 @@
     "@storybook/cli": "^9.0.5",
     "@storybook/react-webpack5": "^9.0.5",
     "@storybook/test-runner": "^0.23.0",
+    "@tanstack/react-virtual": "^3.13.12",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -218,11 +238,15 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "@tanstack/react-virtual": "^3",
     "@types/react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@tanstack/react-virtual": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     }

--- a/src/__tests__/entry-isolation.test.ts
+++ b/src/__tests__/entry-isolation.test.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * The packages of the dedicated entry points must not leak into the other ones: a consumer that
+ * installs @gravity-ui/uikit alone does not have @tanstack/react-virtual on disk.
+ *
+ * Two graphs are walked separately. The runtime one skips `import type`/`export type` (they are
+ * erased from the emit), the type one keeps them: without the package installed, the .d.ts of a
+ * consumer with `skipLibCheck: false` must not reference its types either.
+ */
+
+const SRC = path.resolve(__dirname, '..');
+
+/**
+ * Packages that must stay out of the main entry.
+ *
+ * `@hello-pangea/dnd` is not on the list: it is a plain dependency of the package, imported by the
+ * `List` and the `TableColumnSetup` of the main entry.
+ */
+const FORBIDDEN_IN_MAIN = ['@tanstack/react-virtual'];
+
+const ENTRY_ONLY_DIRS = [
+    path.join(SRC, 'components', 'Virtualizer'),
+    path.join(SRC, 'components', 'HelloPangeaDnd'),
+];
+
+interface Specifier {
+    source: string;
+    typeOnly: boolean;
+}
+
+/**
+ * Strips block comments and whole-line comments — a commented-out import always starts its line, so
+ * this is enough to keep it out of the graph. Not string-aware: a `/*` inside a string literal
+ * would swallow the code after it — no file reachable from an entry point has one (`'image/*'`
+ * lives in the FileDropZone tests and stories, which the walk never enters).
+ */
+function stripComments(code: string) {
+    return code
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .filter((line) => !/^\s*(\/\/|\*)/.test(line))
+        .join('\n');
+}
+
+/**
+ * `import ... from '…'` / `export ... from '…'` (multiline included — the clause matches across
+ * newlines but not across a `;` or a quote, so statements cannot be glued together), plus
+ * side-effect imports, `import('…')` and `require('…')`.
+ */
+function parseSpecifiers(code: string): Specifier[] {
+    const source = stripComments(code);
+    const found: Specifier[] = [];
+
+    const fromRe = /\b(?:import|export)\b(\s+type\b)?[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/g;
+    for (let m = fromRe.exec(source); m; m = fromRe.exec(source)) {
+        found.push({source: m[2], typeOnly: Boolean(m[1])});
+    }
+
+    const bareRe = /\bimport\s*['"]([^'"]+)['"]/g;
+    for (let m = bareRe.exec(source); m; m = bareRe.exec(source)) {
+        found.push({source: m[1], typeOnly: false});
+    }
+
+    const callRe = /\b(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+    for (let m = callRe.exec(source); m; m = callRe.exec(source)) {
+        found.push({source: m[1], typeOnly: false});
+    }
+
+    return found;
+}
+
+/** `@scope/name/deep` → `@scope/name`, `name/deep` → `name`. */
+function packageName(source: string) {
+    const parts = source.split('/');
+    return source.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
+
+function resolveRelative(source: string, importer: string) {
+    const base = path.resolve(path.dirname(importer), source);
+    const candidates = [
+        `${base}.ts`,
+        `${base}.tsx`,
+        path.join(base, 'index.ts'),
+        path.join(base, 'index.tsx'),
+    ];
+    return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function walk(entry: string, options: {types: boolean}) {
+    const packages = new Set<string>();
+    const files = new Set<string>();
+    const queue = [path.resolve(entry)];
+
+    while (queue.length > 0) {
+        const file = queue.pop() as string;
+        if (files.has(file)) {
+            continue;
+        }
+        files.add(file);
+
+        for (const {source, typeOnly} of parseSpecifiers(fs.readFileSync(file, 'utf8'))) {
+            if (typeOnly && !options.types) {
+                continue;
+            }
+            if (!source.startsWith('.')) {
+                packages.add(packageName(source));
+                continue;
+            }
+            // A relative specifier that resolves to nothing is an asset (.scss, .json, `?raw`)
+            const resolved = resolveRelative(source, file);
+            if (resolved) {
+                queue.push(resolved);
+            }
+        }
+    }
+
+    return {packages, files};
+}
+
+const GRAPHS = [
+    ['runtime', {types: false}],
+    ['types', {types: true}],
+] as const;
+
+/** Every JavaScript entry point except the two dedicated ones (see the exports of package.json) */
+const SHARED_ENTRIES = [
+    'index.ts',
+    'unstable.ts',
+    'legacy.ts',
+    'server.ts',
+    'toaster-singleton.ts',
+    path.join('i18n', 'index.ts'),
+];
+
+describe('entry point isolation', () => {
+    describe.each(GRAPHS)('%s graph', (_name, options) => {
+        test.each(SHARED_ENTRIES)('%s does not reach the entry-only packages', (entry) => {
+            const {packages} = walk(path.join(SRC, entry), options);
+
+            expect([...packages].filter((name) => FORBIDDEN_IN_MAIN.includes(name))).toEqual([]);
+        });
+
+        test.each(SHARED_ENTRIES)(
+            '%s does not reach the directories of the dedicated entry points',
+            (entry) => {
+                const {files} = walk(path.join(SRC, entry), options);
+
+                const leaked = [...files].filter((file) =>
+                    ENTRY_ONLY_DIRS.some((dir) => file.startsWith(`${dir}${path.sep}`)),
+                );
+                expect(leaked).toEqual([]);
+            },
+        );
+
+        test('the virtualizer entry reaches @tanstack/react-virtual', () => {
+            const {packages} = walk(path.join(SRC, 'virtualizer.ts'), options);
+
+            expect(packages).toContain('@tanstack/react-virtual');
+        });
+
+        test('the hello-pangea-dnd entry does not reach @tanstack/react-virtual', () => {
+            const {packages} = walk(path.join(SRC, 'hello-pangea-dnd.ts'), options);
+
+            expect(packages).not.toContain('@tanstack/react-virtual');
+        });
+
+        // Without this the whole suite would pass on a parser that silently finds nothing
+        test('the walk of the main entry is not empty', () => {
+            const {packages, files} = walk(path.join(SRC, 'index.ts'), options);
+
+            expect(packages).toContain('react');
+            expect(files.size).toBeGreaterThan(100);
+        });
+    });
+});

--- a/src/components/HelloPangeaDnd/README.md
+++ b/src/components/HelloPangeaDnd/README.md
@@ -1,0 +1,74 @@
+<!--GITHUB_BLOCK-->
+
+# HelloPangeaDnd
+
+<!--/GITHUB_BLOCK-->
+
+The entry point that integrates the [List](../lab/List/README.md) with `@hello-pangea/dnd`, the recommended drag-and-drop library.
+
+```tsx
+import {useListHelloPangeaDnd} from '@gravity-ui/uikit/hello-pangea-dnd';
+```
+
+`@hello-pangea/dnd` ships as a dependency of the package, so there is nothing extra to install.
+
+The wrappers of the library cannot be expressed by the adapter contract of the list, so the integration is compositional: `DragDropContext` and `Droppable` go around the list, the row wraps itself in `Draggable` inside `renderItem`, and this hook carries the state half — `draggingId` for the `dnd` prop of the list together with the handlers of the `DragDropContext`. It also translates the `destination.index` of the library into the `{toId, position}` pair of `moveItem`.
+
+```tsx
+import {DragDropContext, Droppable} from '@hello-pangea/dnd';
+import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable';
+import {useListHelloPangeaDnd} from '@gravity-ui/uikit/hello-pangea-dnd';
+
+function SortableList({items, setItems}) {
+  const {draggingId, onDragStart, onDragEnd} = useListHelloPangeaDnd({
+    ids: items.map((item) => item.id),
+    onDrop: (fromId, toId, position) => setItems(moveItem(items, fromId, toId, position)),
+  });
+
+  return (
+    <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
+      <Droppable droppableId="order">
+        {(provided) => (
+          <List
+            // role="grid": the drag handle of the library is a focusable button, and
+            // interactive content inside a row is valid in the grid role model only
+            role="grid"
+            aria-label="Order"
+            items={items}
+            dnd={{
+              draggingId,
+              getContainerDndProps: () => ({
+                ref: provided.innerRef,
+                ...provided.droppableProps,
+              }),
+            }}
+            // renderDraggableRow wraps the row in <Draggable>, see the List documentation
+            renderItem={renderDraggableRow}
+          />
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}
+```
+
+The complete example, including `renderItem` and the placement of the drag handle, is in the [Drag and drop](../lab/List/README.md#drag-and-drop) section of the List.
+
+## Properties
+
+### useListHelloPangeaDnd
+
+The props:
+
+| Name   | Description                                                                                           |                                  Type                                   |
+| :----- | :---------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------: |
+| ids    | The ids of the rows in the order of the list — `destination.index` of the library is translated by it |                           `readonly string[]`                           |
+| onDrop | The drop — pair it with `moveItem(items, fromId, toId, position)`                                     | `(fromId: string, toId: string, position: 'before' \| 'after') => void` |
+
+What it returns:
+
+| Name        | Description                                                  |              Type              |
+| :---------- | :----------------------------------------------------------- | :----------------------------: |
+| draggingId  | What is being dragged — goes into the `dnd` prop of the list |        `string \| null`        |
+| onDragStart | For the `DragDropContext`                                    |  `(start: DragStart) => void`  |
+| onDragEnd   | For the `DragDropContext`; calls `onDrop` on a real move     | `(result: DropResult) => void` |

--- a/src/components/HelloPangeaDnd/__tests__/useListHelloPangeaDnd.test.ts
+++ b/src/components/HelloPangeaDnd/__tests__/useListHelloPangeaDnd.test.ts
@@ -1,7 +1,8 @@
+// eslint-disable-next-line no-restricted-imports
 import type {DragStart, DropResult} from '@hello-pangea/dnd';
 
-import {act, renderHook} from '../../../../../test-utils/utils';
-import {moveItem} from '../moveItem';
+import {act, renderHook} from '../../../../test-utils/utils';
+import {moveItem} from '../../lab/List/moveItem';
 import {useListHelloPangeaDnd} from '../useListHelloPangeaDnd';
 
 const ids = ['a', 'b', 'c', 'd', 'e'];

--- a/src/components/HelloPangeaDnd/index.ts
+++ b/src/components/HelloPangeaDnd/index.ts
@@ -1,0 +1,5 @@
+export {useListHelloPangeaDnd} from './useListHelloPangeaDnd';
+export type {
+    UseListHelloPangeaDndProps,
+    UseListHelloPangeaDndResult,
+} from './useListHelloPangeaDnd';

--- a/src/components/HelloPangeaDnd/useListHelloPangeaDnd.ts
+++ b/src/components/HelloPangeaDnd/useListHelloPangeaDnd.ts
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import type {DragStart, DropResult} from '@hello-pangea/dnd';
 
-export interface UseListHelloPangeaDndOptions {
+export interface UseListHelloPangeaDndProps {
     /** Row ids in list order — `destination.index` is translated into `{toId, position}` by it */
     ids: readonly string[];
     /** The drop — pair it with `moveItem(items, fromId, toId, position)` */
@@ -31,7 +32,7 @@ export interface UseListHelloPangeaDndResult {
 export function useListHelloPangeaDnd({
     ids,
     onDrop,
-}: UseListHelloPangeaDndOptions): UseListHelloPangeaDndResult {
+}: UseListHelloPangeaDndProps): UseListHelloPangeaDndResult {
     const [draggingId, setDraggingId] = React.useState<string | null>(null);
 
     const idsRef = React.useRef(ids);

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import type {
     DraggableProvided,
     DraggableRubric,
@@ -9,6 +10,7 @@ import type {
     DropResult,
     DroppableProvided,
 } from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';

--- a/src/components/List/components/ListItem.tsx
+++ b/src/components/List/components/ListItem.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import type {DraggableProvided} from '@hello-pangea/dnd';
 
 import {Icon} from '../../Icon';

--- a/src/components/List/components/SimpleContainer.tsx
+++ b/src/components/List/components/SimpleContainer.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import type {DroppableProvided} from '@hello-pangea/dnd';
 
 import type {ListItem} from './ListItem';

--- a/src/components/List/types.ts
+++ b/src/components/List/types.ts
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import type {DraggableProvided} from '@hello-pangea/dnd';
 
 import type {TextInputSize} from '../controls';

--- a/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
+++ b/src/components/Table/hoc/withTableSettings/TableColumnSetup/TableColumnSetup.tsx
@@ -3,7 +3,9 @@
 import * as React from 'react';
 
 import {Gear, Grip, Lock} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import type {
     DraggableChildrenFn,
     DraggableProvided,

--- a/src/components/TreeList/__stories__/stories/WithDndListStory.tsx
+++ b/src/components/TreeList/__stories__/stories/WithDndListStory.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import type {
     DraggableProvided,
     DraggableRubric,

--- a/src/components/TreeSelect/__stories__/components/WithDndListExample.tsx
+++ b/src/components/TreeSelect/__stories__/components/WithDndListExample.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import type {
     DraggableProvided,
     DraggableRubric,

--- a/src/components/Virtualizer/ListVirtualizer.tsx
+++ b/src/components/Virtualizer/ListVirtualizer.tsx
@@ -2,12 +2,12 @@
 
 import * as React from 'react';
 
-import {ListVirtualizationContext} from '../List/VirtualizationContext';
+import {ListVirtualizationContext} from '../lab/List/VirtualizationContext';
 import type {
     ListEstimateItemSize,
     ListVirtualizationContextValue,
     ListVirtualizedRootProps,
-} from '../List/VirtualizationContext';
+} from '../lab/List/VirtualizationContext';
 
 import {Virtualizer} from './Virtualizer';
 

--- a/src/components/Virtualizer/README.md
+++ b/src/components/Virtualizer/README.md
@@ -1,0 +1,94 @@
+<!--GITHUB_BLOCK-->
+
+# Virtualizer
+
+<!--/GITHUB_BLOCK-->
+
+The Virtualizer renders only the window of rows that is currently visible, which is what makes lists of tens of thousands of items affordable.
+
+```tsx
+import {ListVirtualizer, Virtualizer} from '@gravity-ui/uikit/virtualizer';
+```
+
+This entry point needs `@tanstack/react-virtual`: it is an optional peer dependency, so install it next to `@gravity-ui/uikit`.
+
+Two things live here. `Virtualizer` is the engine — a scroll container that positions and measures rows you render yourself. `ListVirtualizer` is the virtualization layer of the [List](../lab/List/README.md): it wraps a `<List>`, and the list renders through the engine without any other change.
+
+## Virtualizer
+
+The element the component renders is the scroll container itself, so its height has to be limited. `getItemSize` is the estimate used before a row is rendered; unless `measure` is off, the measured height of a top-level row replaces it after mount, which is why rows of variable height need no configuration.
+
+```tsx
+import {Virtualizer} from '@gravity-ui/uikit/virtualizer';
+
+const ROW_HEIGHT = 32;
+
+function Log({records}) {
+  return (
+    <Virtualizer
+      style={{height: 400}}
+      count={records.length}
+      getItemSize={() => ROW_HEIGHT}
+      getItemKey={(index) => records[index].id}
+      renderRow={({index}) => <div style={{height: ROW_HEIGHT}}>{records[index].message}</div>}
+    />
+  );
+}
+```
+
+## ListVirtualizer
+
+The wrapper is the only thing that changes — the list inside stays as it was. All of its configuration props are optional: without `estimateItemSize` the row heights come from the `size` of the list.
+
+```tsx
+import {unstable_List as List} from '@gravity-ui/uikit/unstable';
+import {ListVirtualizer} from '@gravity-ui/uikit/virtualizer';
+
+function TrackList({tracks}) {
+  return (
+    <ListVirtualizer estimateItemSize={28}>
+      <List
+        aria-label="Archive"
+        style={{maxHeight: 480}}
+        items={tracks}
+        getItemContent={(track) => track.title}
+      />
+    </ListVirtualizer>
+  );
+}
+```
+
+The root of the `List` becomes the scroll container, so limiting its height is up to you — otherwise the window degenerates into the full list. The details of the layer are in the [Virtualization](../lab/List/README.md#virtualization) section of the List.
+
+> [!NOTE]
+> A virtualized list is empty in server-rendered HTML: there is no viewport to measure against, so the rows appear only after hydration. Leave a list unvirtualized when its content has to be in the markup itself.
+
+## Properties
+
+### Virtualizer
+
+The rest of the props go to the scroll container element.
+
+| Name                  | Description                                                                                      |                          Type                          | Default |
+| :-------------------- | :----------------------------------------------------------------------------------------------- | :----------------------------------------------------: | :-----: |
+| count                 | The number of first level items in the list                                                      |                        `number`                        |         |
+| getItemSize           | The height of an item, including its children; children arrive with the `parentKey`              |            `(index, parentKey?) => number`             |         |
+| getItemKey            | The key of an item; children arrive with the `parentKey`                                         |              `(index, parentKey?) => Key`              |         |
+| renderRow             | Renders a row: the item, the key of its parent and a callback rendering its children             | `(item, parentKey, renderChildren) => React.ReactNode` |         |
+| measure               | Measure the actual heights of the top-level rows after mount instead of trusting `getItemSize`   |                       `boolean`                        | `true`  |
+| overscan              | The number of rows rendered above and below the visible window                                   |                        `number`                        |   `0`   |
+| disableVirtualization | Render every row; useful for a list known to be small                                            |                       `boolean`                        |         |
+| persistedIndexes      | Rows kept in the window even when scrolled out; each entry is a path of indexes in the hierarchy |                   `Array<number[]>`                    |         |
+| loading               | Whether more items are loading: until it turns back to `false`, `onLoadMore` is not called again |                       `boolean`                        |         |
+| onLoadMore            | Called when the scroll gets near the end                                                         |                      `() => void`                      |         |
+| apiRef                | Ref to the imperative API: `scrollToIndex`, `scrollToOffset`, `scrollOffset`, `scrollRect`       |              `React.Ref<VirtualizerApi>`               |         |
+| containerRef          | Ref of the scroll container element                                                              |                `React.Ref<HTMLElement>`                |         |
+
+### ListVirtualizer
+
+| Name             | Description                                                                                      |            Type             |          Default          |
+| :--------------- | :----------------------------------------------------------------------------------------------- | :-------------------------: | :-----------------------: |
+| children         | The `<List>` inside                                                                              |         `ReactNode`         |                           |
+| estimateItemSize | The height estimate of a row before it is rendered — a constant or a function of the row context | `number \| (ctx) => number` | by the `size` of the list |
+| measure          | Measure the actual heights of the rows after mount (rows of variable height out of the box)      |          `boolean`          |          `true`           |
+| overscan         | The buffer of rows outside of the visible window                                                 |          `number`           |            `5`            |

--- a/src/components/Virtualizer/Virtualizer.tsx
+++ b/src/components/Virtualizer/Virtualizer.tsx
@@ -2,25 +2,27 @@
 
 import * as React from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import type {
     Range,
     Rect,
     VirtualItem,
     Virtualizer as VirtualizerInstance,
 } from '@tanstack/react-virtual';
+// eslint-disable-next-line no-restricted-imports
 import {
     defaultRangeExtractor,
     measureElement as measureElementDefault,
     useVirtualizer,
 } from '@tanstack/react-virtual';
 
-import {useForkRef} from '../../../hooks';
-import type {Key} from '../../types';
+import {useForkRef} from '../../hooks/useForkRef';
+import type {Key} from '../types';
 
-import {useLoadMore} from './useLoadMore';
 import type {Loadable} from './useLoadMore';
+import {useLoadMore} from './useLoadMore';
 
-type Item = {index: number; key: Key};
+export type VirtualizerItem = {index: number; key: Key};
 
 export type ScrollAlignment = 'start' | 'center' | 'end' | 'auto';
 
@@ -31,7 +33,7 @@ export interface VirtualizerApi {
     scrollRect: Rect | null;
 }
 
-interface VirtualizerProps extends Loadable, React.HTMLAttributes<HTMLDivElement> {
+export interface VirtualizerProps extends Loadable, React.HTMLAttributes<HTMLDivElement> {
     /** The ref of the virtualizer api. */
     apiRef?: React.Ref<VirtualizerApi>;
     /** The ref of the scroll container element. */
@@ -58,7 +60,7 @@ interface VirtualizerProps extends Loadable, React.HTMLAttributes<HTMLDivElement
          * @param item.index The index of the item in current level.
          * @param item.key The key of the item in the list.
          */
-        item: Item,
+        item: VirtualizerItem,
         /** The key of the parent item in the list. */
         parentKey: Key | undefined,
         /**
@@ -253,7 +255,7 @@ function renderRows({
     getItemSize: (index: number, key?: Key) => number;
     getItemKey: (index: number, key?: Key) => Key;
     renderRow: (
-        item: Item,
+        item: VirtualizerItem,
         parentKey: Key | undefined,
         renderChildren: (options: {count: number; height: number}) => React.ReactNode,
     ) => React.ReactNode;
@@ -300,7 +302,7 @@ function renderRows({
                               }
                     }
                 >
-                    {renderRow(virtualRow as Item, parentKey, ({height, count}) => (
+                    {renderRow(virtualRow as VirtualizerItem, parentKey, ({height, count}) => (
                         <ChildrenVirtualizer
                             key={virtualRow.key}
                             count={count}
@@ -328,7 +330,7 @@ function ChildrenVirtualizer(props: {
     getItemKey: (index: number, key?: Key) => Key;
     parentKey: Key;
     renderRow: (
-        item: Item,
+        item: VirtualizerItem,
         parentKey: Key | undefined,
         renderChildren: (options: {count: number; height: number}) => React.ReactNode,
     ) => React.ReactNode;

--- a/src/components/Virtualizer/index.ts
+++ b/src/components/Virtualizer/index.ts
@@ -1,0 +1,9 @@
+export {Virtualizer} from './Virtualizer';
+export type {
+    VirtualizerProps,
+    VirtualizerItem,
+    VirtualizerApi,
+    ScrollAlignment,
+} from './Virtualizer';
+export {ListVirtualizer} from './ListVirtualizer';
+export type {ListVirtualizerProps} from './ListVirtualizer';

--- a/src/components/Virtualizer/useLoadMore.tsx
+++ b/src/components/Virtualizer/useLoadMore.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {useLayoutEffect} from '../../../hooks';
+import {useLayoutEffect} from '../../hooks/useLayoutEffect';
 
 export interface Loadable {
     /** Whether the items are currently loading. */

--- a/src/components/lab/List/README.md
+++ b/src/components/lab/List/README.md
@@ -583,10 +583,8 @@ estimate. The rest of the props are in [ListVirtualizer](#listvirtualizer).
 > the markup itself.
 
 ```tsx
-import {
-  unstable_List as List,
-  unstable_ListVirtualizer as ListVirtualizer,
-} from '@gravity-ui/uikit/unstable';
+import {unstable_List as List} from '@gravity-ui/uikit/unstable';
+import {ListVirtualizer} from '@gravity-ui/uikit/virtualizer';
 
 function TrackList({tracks}) {
   return (
@@ -667,8 +665,8 @@ keyboard is not supported yet.
 The recommended library. Its wrappers cannot be expressed by the adapter contract, so the
 integration is compositional: `DragDropContext` and `Droppable` go around the list, the row wraps
 itself in `Draggable` inside `renderItem`, and the adapter half carries `draggingId` and the props
-of the drop zone. The state comes from [`useListHelloPangeaDnd`](#uselisthellopangeadnd), exported
-next to the list: it returns `draggingId` for the adapter together with `onDragStart`/`onDragEnd`
+of the drop zone. The state comes from [`useListHelloPangeaDnd`](#uselisthellopangeadnd) of the
+`@gravity-ui/uikit/hello-pangea-dnd` entry point: it returns `draggingId` for the adapter together with `onDragStart`/`onDragEnd`
 for the `DragDropContext`, and translates the `destination.index` of the library into the
 `{toId, position}` pair of `moveItem`. The drop moves your data —
 `moveItem(items, fromId, toId, position, getId?)`
@@ -678,11 +676,8 @@ moved — so treat the result as immutable. The ids are read the way the list re
 
 ```tsx
 import {DragDropContext, Droppable} from '@hello-pangea/dnd';
-import {
-  unstable_List as List,
-  unstable_moveItem as moveItem,
-  unstable_useListHelloPangeaDnd as useListHelloPangeaDnd,
-} from '@gravity-ui/uikit/unstable';
+import {useListHelloPangeaDnd} from '@gravity-ui/uikit/hello-pangea-dnd';
+import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable';
 
 function SortableList({items, setItems}) {
   const {draggingId, onDragStart, onDragEnd} = useListHelloPangeaDnd({
@@ -946,9 +941,10 @@ with the name of its section. What is left to you:
 | ref                 | The ref of the root element                                                                                                |                     `React.Ref<HTMLDivElement>`                     |                                      |
 
 `List.ItemView` is the row view of the default render and `List.SectionHeader` is its section
-header; both are statics of the component and are meant for `renderItem`. The reorder helper and
-the hook of the recommended drag-and-drop library are exported next to the list —
-`unstable_moveItem` and [`unstable_useListHelloPangeaDnd`](#uselisthellopangeadnd).
+header; both are statics of the component and are meant for `renderItem`. The reorder helper is
+exported next to the list as `unstable_moveItem`, and the hook of the recommended drag-and-drop
+library — [`useListHelloPangeaDnd`](#uselisthellopangeadnd) — comes from its own entry point,
+`@gravity-ui/uikit/hello-pangea-dnd`.
 
 ### ListItemContext
 
@@ -1002,7 +998,8 @@ attribute is present or absent rather than set to `"false"`.
 
 ### ListVirtualizer
 
-The wrapper of the [virtualization](#virtualization) layer.
+The wrapper of the [virtualization](#virtualization) layer, imported from
+`@gravity-ui/uikit/virtualizer` (it needs `@tanstack/react-virtual` as an optional peer dependency).
 
 | Name             | Description                                                                                      |            Type             |          Default          |
 | :--------------- | :----------------------------------------------------------------------------------------------- | :-------------------------: | :-----------------------: |
@@ -1025,7 +1022,9 @@ The object of the `dnd` prop — the [drag-and-drop](#drag-and-drop) layer.
 ### useListHelloPangeaDnd
 
 The state half of the [@hello-pangea/dnd](#hello-pangeadnd) integration: `draggingId` for the
-adapter and the handlers of the `DragDropContext`. The options:
+adapter and the handlers of the `DragDropContext`. Imported from
+`@gravity-ui/uikit/hello-pangea-dnd` (`@hello-pangea/dnd` comes with the package).
+The props:
 
 | Name   | Description                                                                                           |                                  Type                                   |
 | :----- | :---------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------: |

--- a/src/components/lab/List/VirtualizationContext.ts
+++ b/src/components/lab/List/VirtualizationContext.ts
@@ -34,7 +34,7 @@ export interface ListVirtualizationContextValue {
 }
 
 /**
- * Defined in the core, provided by lab/Virtualizer/ListVirtualizer: the core never imports tanstack
+ * Defined in the core, provided by Virtualizer/ListVirtualizer: the core never imports tanstack
  */
 export const ListVirtualizationContext = React.createContext<ListVirtualizationContextValue | null>(
     null,

--- a/src/components/lab/List/__stories__/DragAndDropDndKitVirtualizedExample.tsx
+++ b/src/components/lab/List/__stories__/DragAndDropDndKitVirtualizedExample.tsx
@@ -19,8 +19,9 @@
  * - a drag starts from the Grip handle only (the listeners and
  *   setActivatorNodeRef live on it).
  *
- * In an application the list is imported from the package:
+ * In an application:
  * `import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable'`
+ * `import {ListVirtualizer} from '@gravity-ui/uikit/virtualizer'`
  */
 import * as React from 'react';
 
@@ -31,7 +32,7 @@ import {faker} from '@faker-js/faker/locale/en';
 import {Grip} from '@gravity-ui/icons';
 
 import {Icon} from '../../../Icon';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import {moveItem} from '../moveItem';
 import type {ListItemContext, ListItemHelpers} from '../types';

--- a/src/components/lab/List/__stories__/DragAndDropHelloPangeaExample.tsx
+++ b/src/components/lab/List/__stories__/DragAndDropHelloPangeaExample.tsx
@@ -25,21 +25,22 @@
  * - dropTarget is not filled in: the model of the library is shifting the
  *   rows, and the indicator of the list is not needed.
  *
- * In an application the list and the hook are imported from the package:
- * `import {unstable_List as List, unstable_moveItem as moveItem,
- * unstable_useListHelloPangeaDnd as useListHelloPangeaDnd} from '@gravity-ui/uikit/unstable'`
+ * In an application:
+ * `import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable'`
+ * `import {useListHelloPangeaDnd} from '@gravity-ui/uikit/hello-pangea-dnd'`
  */
 import * as React from 'react';
 
 import {faker} from '@faker-js/faker/locale/en';
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
 
+import {useListHelloPangeaDnd} from '../../../HelloPangeaDnd';
 import {Icon} from '../../../Icon';
 import {List} from '../List';
 import {moveItem} from '../moveItem';
 import type {ListItemContext, ListItemHelpers} from '../types';
-import {useListHelloPangeaDnd} from '../useListHelloPangeaDnd';
 
 interface TrackRecord {
     id: string;

--- a/src/components/lab/List/__stories__/DragAndDropHelloPangeaVirtualizedExample.tsx
+++ b/src/components/lab/List/__stories__/DragAndDropHelloPangeaVirtualizedExample.tsx
@@ -24,23 +24,26 @@
  *   listbox/option do, and the numbering of the window travels through
  *   aria-rowcount/aria-rowindex.
  *
- * In an application the list and the hook are imported from the package:
- * `import {unstable_List as List, unstable_moveItem as moveItem,
- * unstable_useListHelloPangeaDnd as useListHelloPangeaDnd} from '@gravity-ui/uikit/unstable'`
+ * In an application:
+ * `import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable'`
+ * `import {useListHelloPangeaDnd} from '@gravity-ui/uikit/hello-pangea-dnd'`
+ * `import {ListVirtualizer} from '@gravity-ui/uikit/virtualizer'`
  */
 import * as React from 'react';
 
 import {faker} from '@faker-js/faker/locale/en';
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import type {DraggableProvidedDragHandleProps} from '@hello-pangea/dnd';
 
+import {useListHelloPangeaDnd} from '../../../HelloPangeaDnd';
 import {Icon} from '../../../Icon';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import {moveItem} from '../moveItem';
 import type {ListItemContext, ListItemHelpers} from '../types';
-import {useListHelloPangeaDnd} from '../useListHelloPangeaDnd';
 
 interface TrackRecord {
     id: string;

--- a/src/components/lab/List/__stories__/DragAndDropPragmaticVirtualizedExample.tsx
+++ b/src/components/lab/List/__stories__/DragAndDropPragmaticVirtualizedExample.tsx
@@ -10,8 +10,9 @@
  * condition for memoizing the rows: dragover then re-renders the insertion
  * target only rather than the whole window.
  *
- * In an application the list is imported from the package:
+ * In an application:
  * `import {unstable_List as List, unstable_moveItem as moveItem} from '@gravity-ui/uikit/unstable'`
+ * `import {ListVirtualizer} from '@gravity-ui/uikit/virtualizer'`
  */
 import * as React from 'react';
 
@@ -19,7 +20,7 @@ import {faker} from '@faker-js/faker/locale/en';
 import {Grip} from '@gravity-ui/icons';
 
 import {Icon} from '../../../Icon';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import {moveItem} from '../moveItem';
 import type {ListItemContext, ListItemHelpers} from '../types';

--- a/src/components/lab/List/__stories__/List.stories.tsx
+++ b/src/components/lab/List/__stories__/List.stories.tsx
@@ -18,9 +18,9 @@ import {Button} from '../../../Button';
 import {Icon} from '../../../Icon';
 import {Label} from '../../../Label';
 import {Text} from '../../../Text';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {TextInput} from '../../../controls';
 import {Flex} from '../../../layout';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import {useListFocusOwner} from '../useListFocusOwner';
 
@@ -578,9 +578,10 @@ export const InteractiveRows: Story = {
 // Drag and drop with @hello-pangea/dnd — the recommended library: the
 // integration is compositional (DragDropContext/Droppable around the list,
 // Draggable inside renderItem), the state of the drag comes from
-// useListHelloPangeaDnd, exported next to the list. The Code panel holds the
-// complete source of the example. The same on top of other libraries lives in
-// the "Drag and drop with other libraries" stories
+// useListHelloPangeaDnd of the @gravity-ui/uikit/hello-pangea-dnd entry
+// point. The Code panel holds the complete source of the example. The same
+// on top of other libraries lives in the "Drag and drop with other
+// libraries" stories
 export const DragAndDrop: Story = {
     render: () => <DragAndDropHelloPangeaExample />,
     parameters: {

--- a/src/components/lab/List/__tests__/ListRangeSelection.test.tsx
+++ b/src/components/lab/List/__tests__/ListRangeSelection.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import {fireEvent, render, screen} from '../../../../../test-utils/utils';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 
 import {ComboboxHarness, GROUPS, mockLayout, scrollTo} from './helpers';

--- a/src/components/lab/List/__tests__/ListRoleFocus.test.tsx
+++ b/src/components/lab/List/__tests__/ListRoleFocus.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import {fireEvent, render, screen} from '../../../../../test-utils/utils';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import type {ListItemContext, ListItemHelpers, ListProps} from '../types';
 import {useListFocusOwner} from '../useListFocusOwner';

--- a/src/components/lab/List/__tests__/ListVirtualization.test.tsx
+++ b/src/components/lab/List/__tests__/ListVirtualization.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 
 import {render, screen} from '../../../../../test-utils/utils';
-import {ListVirtualizer} from '../../Virtualizer/ListVirtualizer';
+import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import type {ListProps} from '../types';
 

--- a/src/components/lab/List/index.ts
+++ b/src/components/lab/List/index.ts
@@ -2,11 +2,6 @@ export {List} from './List';
 export {moveItem} from './moveItem';
 export type {ListSectionHeaderProps} from './SectionHeader';
 export {useListFocusOwner} from './useListFocusOwner';
-export {useListHelloPangeaDnd} from './useListHelloPangeaDnd';
-export type {
-    UseListHelloPangeaDndOptions,
-    UseListHelloPangeaDndResult,
-} from './useListHelloPangeaDnd';
 export type {
     ListProps,
     ListSelectionProps,

--- a/src/components/useList/__stories__/components/ListWithDnd.tsx
+++ b/src/components/useList/__stories__/components/ListWithDnd.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 import {Grip} from '@gravity-ui/icons';
+// eslint-disable-next-line no-restricted-imports
 import {DragDropContext, Draggable, Droppable} from '@hello-pangea/dnd';
+// eslint-disable-next-line no-restricted-imports
 import type {DraggableProvided, DraggableStateSnapshot, DroppableProvided} from '@hello-pangea/dnd';
 
 import {Icon} from '../../../Icon';

--- a/src/hello-pangea-dnd.ts
+++ b/src/hello-pangea-dnd.ts
@@ -1,0 +1,5 @@
+export {useListHelloPangeaDnd} from './components/HelloPangeaDnd';
+export type {
+    UseListHelloPangeaDndProps,
+    UseListHelloPangeaDndResult,
+} from './components/HelloPangeaDnd';

--- a/src/unstable.ts
+++ b/src/unstable.ts
@@ -51,9 +51,6 @@ export {
     List as unstable_List,
     moveItem as unstable_moveItem,
     useListFocusOwner as unstable_useListFocusOwner,
-    useListHelloPangeaDnd as unstable_useListHelloPangeaDnd,
-    type UseListHelloPangeaDndOptions as unstable_UseListHelloPangeaDndOptions,
-    type UseListHelloPangeaDndResult as unstable_UseListHelloPangeaDndResult,
     type ListFocusOwner as unstable_ListFocusOwner,
     type ListFocusOwnerInputProps as unstable_ListFocusOwnerInputProps,
     type ListProps as unstable_ListProps,
@@ -73,11 +70,6 @@ export {
     type ListRole as unstable_ListRole,
     type ListSize as unstable_ListSize,
 } from './components/lab/List';
-
-export {
-    ListVirtualizer as unstable_ListVirtualizer,
-    type ListVirtualizerProps as unstable_ListVirtualizerProps,
-} from './components/lab/Virtualizer/ListVirtualizer';
 
 export {
     ColorPicker as unstable_ColorPicker,

--- a/src/virtualizer.ts
+++ b/src/virtualizer.ts
@@ -1,0 +1,8 @@
+export {Virtualizer, ListVirtualizer} from './components/Virtualizer';
+export type {
+    VirtualizerProps,
+    VirtualizerItem,
+    VirtualizerApi,
+    ScrollAlignment,
+    ListVirtualizerProps,
+} from './components/Virtualizer';


### PR DESCRIPTION
🤖 AI generated

## What's added

Two entry points, alongside the existing `/unstable`, `/legacy`, `/server`, `/i18n`, `/toaster-singleton` and `/styles/*`:

| Entry point | Exports | Source |
| --- | --- | --- |
| `@gravity-ui/uikit/virtualizer` | `Virtualizer`, `ListVirtualizer`, `VirtualizerProps`, `VirtualizerItem`, `VirtualizerApi`, `ScrollAlignment`, `ListVirtualizerProps` | `src/virtualizer.ts` ← `src/components/Virtualizer/` |
| `@gravity-ui/uikit/hello-pangea-dnd` | `useListHelloPangeaDnd`, `UseListHelloPangeaDndOptions`, `UseListHelloPangeaDndResult` | `src/hello-pangea-dnd.ts` ← `src/components/HelloPangeaDnd/` |

## Moved

- `src/components/lab/Virtualizer/` → `src/components/Virtualizer/` (`Virtualizer`, `ListVirtualizer`, the private `useLoadMore`)
- `src/components/lab/List/useListHelloPangeaDnd.ts` and its test → `src/components/HelloPangeaDnd/`

`VirtualizerProps` and the row type (`VirtualizerItem`, previously the private `Item`) are exported now — a public entry point without the types of its props is incomplete. Neither directory is re-exported from `src/components/index.ts`.

## Dependencies

`@tanstack/react-virtual` moves from `dependencies` to `peerDependencies` + `peerDependenciesMeta.optional`, and stays in `devDependencies` for the build, the tests and Storybook. It is imported by `src/components/Virtualizer/Virtualizer.tsx` only, so the main entry point does not need it.

`@hello-pangea/dnd`, `react-window` and `react-virtualized-auto-sizer` stay in `dependencies`: the `List` and the `TableColumnSetup` of the main entry point import them at runtime, and an optional peer would make `npm i @gravity-ui/uikit` a silently broken install. Each of them becomes an optional peer in the release that moves its last consumer out of the main entry.

## Guards

`src/__tests__/entry-isolation.test.ts` builds two import graphs of the sources — runtime (`import type` skipped, those lines are erased from the emit) and types (kept: a consumer with `skipLibCheck: false` must not reference the types of a package that is not installed). For each of the six shared entry points it asserts that neither graph reaches `@tanstack/react-virtual` or a file under `src/components/Virtualizer/` and `src/components/HelloPangeaDnd/`. Verified by hand: an `export * from './Virtualizer'` in `src/components/index.ts` fails four of the tests.

`no-restricted-imports` in `eslint.config.mjs` is the local guard for the same rule, deep imports of both packages included.

## Docs

- `README.md` and `README-ru.md`: an "Entry points" section listing all nine subpaths and what has to be installed
- `contribute/architecture.md` and `contribute/architecture-ru.md`: two new rows in the public surface table
- `src/components/Virtualizer/README.md` and `src/components/HelloPangeaDnd/README.md` — both pass `gravity-readme --component` and ship as AI docs
- `src/components/lab/List/README.md`: the imports in the virtualization and drag-and-drop sections

## Breaking changes

- removed from `@gravity-ui/uikit/unstable`: `unstable_ListVirtualizer`, `unstable_ListVirtualizerProps`, `unstable_useListHelloPangeaDnd`, `unstable_UseListHelloPangeaDndOptions`, `unstable_UseListHelloPangeaDndResult` — import them from the new entry points instead
- `@tanstack/react-virtual` has to be installed alongside the package when importing from `@gravity-ui/uikit/virtualizer`


## Checks

`typecheck`, `lint`, `jest` (1478 tests), `build`, `build-storybook`, `npm pack --dry-run`, `gravity-readme` for both new READMEs.
