### PR TITLE
feat(List): prepare the core for the Select migration

### DIFF
--- a/src/components/lab/List/List.scss
+++ b/src/components/lab/List/List.scss
@@ -9,6 +9,13 @@ $block: '.#{variables.$ns}lab-list';
     margin: 0;
     padding: 0;
 
+    /* The root is a flex column that may have to scroll: a row keeps its own height instead of
+       being squeezed into the viewport (the sizer of the virtualizer forbids the shrink for itself
+       the same way) */
+    > * {
+        flex-shrink: 0;
+    }
+
     /* Indicator on the row itself (works in flat render and inside virtualizer wrappers);
        role + attribute keeps foreign data-* out */
     :is([role='option'], [role='row'])[data-dragging] {

--- a/src/components/lab/List/README.md
+++ b/src/components/lab/List/README.md
@@ -211,6 +211,11 @@ gesture comes third: a `MouseEvent` for a click, a `KeyboardEvent` for a key (`'
 tells them apart). It carries the modifiers of a click and lets the native default be suppressed —
 the [links](#links) recipe is built on it.
 
+A click of the mouse on an option is also published to the `eventBroker` of the kit (subscribers see
+`componentId: 'g-List'` — the broker prefixes the id of a component — and `eventId: 'click'`), the
+way the rest of the analytics of the library is collected. Keys are not published, and neither are
+clicks on a disabled row or on a section header.
+
 ```tsx
 import {Flex, Text} from '@gravity-ui/uikit';
 import {unstable_List as List} from '@gravity-ui/uikit/unstable';
@@ -801,9 +806,16 @@ What changes in the list:
 
 - the rows leave the tab order — the input is the only tab stop, and DOM focus never moves to a row:
   a click on a row applies it and leaves the focus where it is;
-- `↑`/`↓`/`Home`/`End`/`Enter` work from the input, move the active item and scroll it into view;
-- character keys and `Space` belong to the input: typing is filtering, so typeahead is off and
-  `Space` no longer selects. `Ctrl`/`Cmd`+`A` selects the text of the input rather than the items;
+- `↑`/`↓`/`PageUp`/`PageDown`/`Enter` work from the input, move the active item and scroll it into
+  view; `Home`/`End` do too, unless the owner holds a caret — an `input`, a `textarea` or a
+  `contenteditable`. The rule is one: **a key that moves the caret in a text field stays with the
+  field, the rest go to the list**. `Home`/`End` move the caret, so the APG combobox pattern leaves
+  them to an editable combobox (and makes the arrows of the list cycle to compensate); `PageUp`/
+  `PageDown` have no caret meaning in a single-line field, so the list keeps them;
+- `Space` belongs to the owner and no longer selects, and `Ctrl`/`Cmd`+`A` selects the text of the
+  input rather than the items;
+- character keys go to a text owner — typing there is filtering, so typeahead stays off. An owner
+  that holds no caret (the trigger button of a select-only combobox) keeps the typeahead of the list;
 - `Shift`+`↑`/`↓` still extends the range when a multiple selection is on.
 
 What to keep in mind:
@@ -892,18 +904,19 @@ with the name of its section. What is left to you:
 
 ### Keyboard
 
-| Key                                | Action                                                                                                                                                                                                              |
-| :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `↑` / `↓`                          | Move to the previous/next item, cycling at the edges                                                                                                                                                                |
-| `Home` / `End`                     | Move to the first/last item                                                                                                                                                                                         |
-| Character keys                     | Jump to the item whose text starts with what was typed; the buffer resets after a pause, and repeating one character cycles through the items starting with it. With a focus owner the keys go to the input instead |
-| `Enter`                            | Apply the active item (`onItemAction`)                                                                                                                                                                              |
-| `Space`                            | Select the active item (with a selection mode on); part of the typeahead query while it is being typed                                                                                                              |
-| `Shift` + click, `Shift` + `↑`/`↓` | Select a range (`multiple` only); unlike the plain arrows, a `Shift`+arrow stops at the edges instead of cycling                                                                                                    |
-| `Shift` + `Space`                  | Select the range up to the active item (`multiple` only)                                                                                                                                                            |
-| `Ctrl`/`Cmd` + `A`                 | Select every item (`multiple` only; with a focus owner the key belongs to the input)                                                                                                                                |
-| `←` / `→`                          | Step into the interactive content of a cell and back (`role="grid"` only, mirrored in RTL)                                                                                                                          |
-| `Tab`                              | Leave the list: it is a single tab stop                                                                                                                                                                             |
+| Key                                | Action                                                                                                                                                                                                                                                                                                                                         |
+| :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `↑` / `↓`                          | Move to the previous/next item, cycling at the edges                                                                                                                                                                                                                                                                                           |
+| `PageUp` / `PageDown`              | Move ten items up/down; unlike the arrows they do not cycle and stop at the first/last item. With no active item yet, `PageDown` enters the list from the top and `PageUp` from the bottom                                                                                                                                                     |
+| `Home` / `End`                     | Move to the first/last item. With a focus owner that holds a caret (`input`, `textarea`, `contenteditable`) the keys are left to the caret, as the APG combobox pattern prescribes for an editable combobox                                                                                                                                    |
+| Character keys                     | Jump to the item whose text starts with what was typed; the buffer resets a second after the last key, and repeating one character cycles through the items starting with it. A character the list took for its search does not reach the hotkeys of the app around it. With a focus owner that holds a caret the keys go to the field instead |
+| `Enter`                            | Apply the active item (`onItemAction`)                                                                                                                                                                                                                                                                                                         |
+| `Space`                            | Select the active item (with a selection mode on); part of the typeahead query while it is being typed — that also holds with a focus owner that has no caret                                                                                                                                                                                  |
+| `Shift` + click, `Shift` + `↑`/`↓` | Select a range (`multiple` only); unlike the plain arrows, a `Shift`+arrow stops at the edges instead of cycling                                                                                                                                                                                                                               |
+| `Shift` + `Space`                  | Select the range up to the active item (`multiple` only)                                                                                                                                                                                                                                                                                       |
+| `Ctrl`/`Cmd` + `A`                 | Select every item (`multiple` only; with a focus owner the key belongs to the input)                                                                                                                                                                                                                                                           |
+| `←` / `→`                          | Step into the interactive content of a cell and back (`role="grid"` only, mirrored in RTL)                                                                                                                                                                                                                                                     |
+| `Tab`                              | Leave the list: it is a single tab stop                                                                                                                                                                                                                                                                                                        |
 
 ## Properties
 
@@ -941,7 +954,8 @@ with the name of its section. What is left to you:
 | ref                 | The ref of the root element                                                                                                |                     `React.Ref<HTMLDivElement>`                     |                                      |
 
 `List.ItemView` is the row view of the default render and `List.SectionHeader` is its section
-header; both are statics of the component and are meant for `renderItem`. The reorder helper is
+header; both are statics of the component and are meant for `renderItem`. The header keeps its
+label on one line and clips what does not fit with an ellipsis. The reorder helper is
 exported next to the list as `unstable_moveItem`, and the hook of the recommended drag-and-drop
 library — [`useListHelloPangeaDnd`](#uselisthellopangeadnd) — comes from its own entry point,
 `@gravity-ui/uikit/hello-pangea-dnd`.
@@ -985,16 +999,16 @@ for a wrapper over `renderItem`; the props of a dnd adapter as `unstable_ListDnd
 The list marks the rows and the root, so custom markup can be styled with CSS alone. A state
 attribute is present or absent rather than set to `"false"`.
 
-| Attribute          | Where    | When                                                                       |
-| :----------------- | :------- | :------------------------------------------------------------------------- |
-| `data-active`      | a row    | The row is the active one                                                  |
-| `data-disabled`    | a row    | The item is disabled                                                       |
-| `data-selected`    | a row    | The row is selected (a selection mode is on)                               |
-| `data-dragging`    | a row    | The row is being dragged (`dnd` is passed)                                 |
-| `data-drop-target` | a row    | The drop will land on this row; the value is the edge, `before` or `after` |
-| `data-drag-active` | the root | A drag is going on somewhere in the list                                   |
-| `data-first-row`   | a header | The section header is the first row of the list (no spacing above it)      |
-| `data-qa`          | the root | The value of the `qa` prop                                                 |
+| Attribute          | Where    | When                                                                                         |
+| :----------------- | :------- | :------------------------------------------------------------------------------------------- |
+| `data-active`      | a row    | The row is the active one                                                                    |
+| `data-disabled`    | a row    | The item is disabled                                                                         |
+| `data-selected`    | a row    | The row is selected (a selection mode is on)                                                 |
+| `data-dragging`    | a row    | The row is being dragged (`dnd` is passed)                                                   |
+| `data-drop-target` | a row    | The drop will land on this row; the value is the edge, `before` or `after`                   |
+| `data-drag-active` | the root | A drag is going on somewhere in the list                                                     |
+| `data-first-row`   | a header | The section header is the first row of the list (no spacing and no separating line above it) |
+| `data-qa`          | the root | The value of the `qa` prop                                                                   |
 
 ### ListVirtualizer
 

--- a/src/components/lab/List/SectionHeader.scss
+++ b/src/components/lab/List/SectionHeader.scss
@@ -5,24 +5,42 @@ $block: '.#{variables.$ns}lab-list-section-header';
 
 #{$block} {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
 
     padding: var(--g-spacing-1) var(--g-spacing-2);
+    color: var(--g-color-text-primary);
 
-    color: var(--g-color-text-secondary);
+    @include mixins.text-body-1;
+    @include mixins.text-accent;
 
-    @include mixins.text-caption-2;
-
-    &_size_l,
-    &_size_xl {
-        @include mixins.text-caption-1;
+    &__text {
+        /* A flex item does not shrink below its content on its own, and there is nothing to clip
+           without that */
+        min-width: 0;
     }
 
-    /* Spacing above a header that follows other rows. By data rather than
+    &_size_xl {
+        @include mixins.text-body-2;
+        @include mixins.text-accent;
+    }
+
+    /* Spacing and the separating line above a header that follows other rows. By data rather than
        :first-child, and padding rather than margin: under virtualization every
        header is the first child of its own wrapper, and a margin would not be
-       counted by the wrapper measurement */
+       counted by the wrapper measurement. The line is drawn inside that padding,
+       so it costs the row no height of its own */
     &:not([data-first-row]) {
-        padding-block-start: var(--g-spacing-2);
+        position: relative;
+        /* The line sits close to the row above it, the text of the header — well below the line */
+        padding-block-start: var(--g-spacing-3);
+
+        &::before {
+            content: '';
+            position: absolute;
+            inset-block-start: var(--g-spacing-half);
+            inset-inline: 0;
+            height: 1px;
+            background: var(--g-color-line-generic);
+        }
     }
 }

--- a/src/components/lab/List/SectionHeader.tsx
+++ b/src/components/lab/List/SectionHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {Text} from '../../Text';
 import type {QAProps} from '../../types';
 import {block} from '../../utils/cn';
 
@@ -18,7 +19,11 @@ export const ListSectionHeader = React.forwardRef<HTMLDivElement, ListSectionHea
     function ListSectionHeader({size = 'm', className, qa, children, ...restProps}, ref) {
         return (
             <div ref={ref} {...restProps} data-qa={qa} className={b({size}, className)}>
-                {children}
+                {/* The typography stays on the header itself — the text only clips what does not
+                    fit, the way the label of a group did before */}
+                <Text className={b('text')} variant="inherit" ellipsis>
+                    {children}
+                </Text>
             </div>
         );
     },

--- a/src/components/lab/List/__tests__/List.test.tsx
+++ b/src/components/lab/List/__tests__/List.test.tsx
@@ -4,12 +4,24 @@ import userEvent from '@testing-library/user-event';
 
 import {act, fireEvent, render, screen} from '../../../../../test-utils/utils';
 import {Label} from '../../../Label';
+import {eventBroker} from '../../../utils/event-broker';
 import {List} from '../List';
 import type {ListItemViewStateProps} from '../types';
+import {TYPEAHEAD_TIMEOUT} from '../utils';
 
-import {FRUITS, GROUPS, PROJECTS, createTracker, mockTabbableDisplayCheck} from './helpers';
+import {
+    FRUITS,
+    GROUPS,
+    PROJECTS,
+    createTracker,
+    getSectionHeader,
+    mockTabbableDisplayCheck,
+} from './helpers';
 
 mockTabbableDisplayCheck();
+
+/** Longer than the page step of PageUp/PageDown */
+const MANY = Array.from({length: 25}, (_, index) => `Item ${index + 1}`);
 
 describe('lab List', () => {
     describe('rendering and ARIA', () => {
@@ -18,8 +30,8 @@ describe('lab List', () => {
                 <List aria-label="Groups" items={GROUPS} getItemContent={(item) => item.label} />,
             );
 
-            expect(screen.getByText('Recent')).toHaveAttribute('data-first-row', '');
-            expect(screen.getByText('All')).not.toHaveAttribute('data-first-row');
+            expect(getSectionHeader('Recent')).toHaveAttribute('data-first-row', '');
+            expect(getSectionHeader('All')).not.toHaveAttribute('data-first-row');
         });
 
         test('renders a listbox with options from an array of strings', () => {
@@ -37,7 +49,7 @@ describe('lab List', () => {
             );
 
             const option = screen.getByRole('option', {name: 'First'});
-            expect(option).toHaveAttribute('aria-describedby', screen.getByText('Recent').id);
+            expect(option).toHaveAttribute('aria-describedby', getSectionHeader('Recent').id);
             expect(option).toHaveAccessibleDescription('Recent');
         });
 
@@ -210,6 +222,54 @@ describe('lab List', () => {
 
             await user.keyboard('{Home}');
             expect(options[0]).toHaveFocus();
+        });
+
+        test('PageDown and PageUp step over ten options and stop at the edges', async () => {
+            const user = userEvent.setup();
+            render(<List aria-label="Items" items={MANY} />);
+            const options = screen.getAllByRole('option');
+
+            await user.tab();
+            expect(options[0]).toHaveFocus();
+
+            await user.keyboard('{PageDown}');
+            expect(options[10]).toHaveFocus();
+
+            await user.keyboard('{PageDown}');
+            expect(options[20]).toHaveFocus();
+
+            // The page keys do not cycle: the last option is where they stop
+            await user.keyboard('{PageDown}');
+            expect(options[24]).toHaveFocus();
+
+            await user.keyboard('{PageUp}');
+            expect(options[14]).toHaveFocus();
+
+            await user.keyboard('{PageUp}');
+            await user.keyboard('{PageUp}');
+            expect(options[0]).toHaveFocus();
+        });
+
+        test('the page step counts navigable options, not rows', async () => {
+            const user = userEvent.setup();
+            render(
+                <List
+                    aria-label="Items"
+                    items={MANY.map((name, index) => ({
+                        id: name,
+                        name,
+                        disabled: index === 5,
+                    }))}
+                    getItemContent={(item) => item.name}
+                />,
+            );
+            const options = screen.getAllByRole('option');
+
+            await user.tab();
+            await user.keyboard('{PageDown}');
+
+            // The disabled row is out of the count, so the tenth navigable option is the eleventh row
+            expect(options[11]).toHaveFocus();
         });
 
         test('navigation skips section headers and disabled options', async () => {
@@ -405,6 +465,40 @@ describe('lab List', () => {
 
             expect(onInnerClick).toHaveBeenCalledTimes(1);
             expect(onItemAction).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('eventBroker', () => {
+        test('publishes a mouse click on an option, but not on a disabled one and not Enter', async () => {
+            const user = userEvent.setup();
+            const subscription = jest.fn();
+            eventBroker.subscribe(subscription);
+
+            try {
+                render(
+                    <List
+                        aria-label="Projects"
+                        items={PROJECTS}
+                        getItemContent={(project) => project.name}
+                    />,
+                );
+
+                await user.click(screen.getByText('Alpha'));
+
+                expect(subscription).toHaveBeenCalledTimes(1);
+                expect(subscription).toHaveBeenCalledWith(
+                    expect.objectContaining({componentId: 'g-List', eventId: 'click'}),
+                );
+
+                // Disabled rows are silent, and so is the keyboard: the old ListItem published
+                // from the click handler of the row only
+                await user.click(screen.getByText('Beta'));
+                await user.keyboard('{Enter}');
+
+                expect(subscription).toHaveBeenCalledTimes(1);
+            } finally {
+                eventBroker.unsubscribe(subscription);
+            }
         });
     });
 
@@ -836,13 +930,35 @@ describe('lab List', () => {
                 await user.keyboard('b');
                 expect(options[1]).toHaveFocus();
 
-                jest.advanceTimersByTime(600);
+                jest.advanceTimersByTime(TYPEAHEAD_TIMEOUT + 100);
                 await user.keyboard('a');
 
                 expect(options[0]).toHaveFocus();
             } finally {
                 jest.useRealTimers();
             }
+        });
+
+        test('a character taken for the search does not reach the hotkeys around the list', async () => {
+            const user = userEvent.setup();
+            const hotkey = jest.fn();
+            render(
+                // The hotkeys of the app around the list, in their simplest form
+                // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+                <div onKeyDown={hotkey}>
+                    <List aria-label="Fruits" items={FRUITS} />
+                </div>,
+            );
+
+            await user.tab();
+            await user.keyboard('b');
+
+            expect(screen.getByRole('option', {name: 'Banana'})).toHaveAttribute('data-active');
+            expect(hotkey).not.toHaveBeenCalled();
+
+            // A key the list does not take travels on
+            await user.keyboard('{Escape}');
+            expect(hotkey).toHaveBeenCalled();
         });
 
         test('uses getItemTextValue for search', async () => {
@@ -1086,7 +1202,7 @@ describe('lab List', () => {
 
             expect(view.get('recent')).toEqual({size: 'l'});
             expect(view.get('r1')).toEqual({size: 'l', active: false, disabled: false});
-            const header = screen.getByText('Recent');
+            const header = getSectionHeader('Recent');
             expect(header).toHaveClass('g-lab-list-section-header_size_l');
             expect(header).not.toHaveAttribute('active');
             expect(header).not.toHaveAttribute('disabled');

--- a/src/components/lab/List/__tests__/ListDnd.test.tsx
+++ b/src/components/lab/List/__tests__/ListDnd.test.tsx
@@ -6,7 +6,7 @@ import {fireEvent, render, screen} from '../../../../../test-utils/utils';
 import {List} from '../List';
 import type {ListDndAdapter, ListDndProps, ListItemContext, ListItemHelpers} from '../types';
 
-import {FRUITS, GROUPS, createTracker} from './helpers';
+import {FRUITS, GROUPS, createTracker, getSectionHeader} from './helpers';
 
 /** Stable per-id ref callbacks — the obligation of an adapter */
 function createStableRefs(onRef: (id: string, element: HTMLElement | null) => void) {
@@ -104,7 +104,7 @@ describe('lab List: dnd layer', () => {
             expect(ids).toEqual(expect.arrayContaining(['r1', 'a1', 'a2']));
             expect(ids).not.toContain('recent');
             expect(ids).not.toContain('all');
-            expect(screen.getByText('Recent')).not.toHaveAttribute('data-dragging');
+            expect(getSectionHeader('Recent')).not.toHaveAttribute('data-dragging');
         });
 
         test('role, id and tabIndex from the adapter are dropped with a dev warning', () => {

--- a/src/components/lab/List/__tests__/ListRangeSelection.test.tsx
+++ b/src/components/lab/List/__tests__/ListRangeSelection.test.tsx
@@ -6,7 +6,7 @@ import {fireEvent, render, screen} from '../../../../../test-utils/utils';
 import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 
-import {ComboboxHarness, GROUPS, mockLayout, scrollTo} from './helpers';
+import {ComboboxHarness, GROUPS, getSectionHeader, mockLayout, scrollTo} from './helpers';
 import type {Project} from './helpers';
 
 const LETTERS = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
@@ -166,7 +166,7 @@ describe('lab List: range selection (selection layer, phase 7)', () => {
             await shiftClick(user, options[2]);
 
             expect(onSelectedUpdate).toHaveBeenLastCalledWith(['r1', 'a1', 'a2']);
-            expect(screen.getByText('All')).not.toHaveAttribute('aria-selected');
+            expect(getSectionHeader('All')).not.toHaveAttribute('aria-selected');
         });
 
         test('onItemAction fires on Shift+click after the selection update', async () => {

--- a/src/components/lab/List/__tests__/ListRoleFocus.test.tsx
+++ b/src/components/lab/List/__tests__/ListRoleFocus.test.tsx
@@ -12,6 +12,7 @@ import {
     ComboboxHarness,
     GROUPS,
     createTracker,
+    getSectionHeader,
     mockLayout,
     mockTabbableDisplayCheck,
 } from './helpers';
@@ -43,6 +44,22 @@ function renderRowWithControls(ctx: ListItemContext<string>, helpers: ListItemHe
         >
             <span {...helpers.getCellProps()}>{ctx.content}</span>
         </List.ItemView>
+    );
+}
+
+/** An owner without a caret: the trigger of a select-only combobox */
+function TriggerHarness({
+    label = 'Fruit',
+    ...listProps
+}: {label?: string; items: readonly string[]} & Partial<ListProps<string>>) {
+    const focusOwner = useListFocusOwner();
+    return (
+        <React.Fragment>
+            <button type="button" {...focusOwner.getInputProps({'aria-label': label})}>
+                Choose
+            </button>
+            <List aria-label="Options" {...listProps} focusOwner={focusOwner} />
+        </React.Fragment>
     );
 }
 
@@ -300,17 +317,46 @@ describe('lab List: role model x focus strategy', () => {
             expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
         });
 
-        test('Home/End on the active row still scroll it into view', async () => {
+        test('a click on a section header or beside a row leaves the focus with the owner', async () => {
+            const user = userEvent.setup();
+            render(
+                <ComboboxHarness
+                    items={GROUPS as unknown as string[]}
+                    getItemContent={(item: unknown) => (item as {label: string}).label}
+                />,
+            );
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+
+            await user.click(screen.getByText('All'));
+            expect(input).toHaveFocus();
+
+            await user.click(screen.getByRole('listbox'));
+            expect(input).toHaveFocus();
+
+            // And the keyboard still answers
+            await user.keyboard('{ArrowDown}');
+            expect(input).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getAllByRole('option')[0].id,
+            );
+        });
+
+        test('Home/End of an owner without a caret move the activity and scroll the row into view', async () => {
             const scrollIntoViewMock = jest.fn();
             HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
             try {
                 const user = userEvent.setup();
-                render(<ComboboxHarness items={FRUITS} defaultActiveItemId="Cherry" />);
+                render(<TriggerHarness items={FRUITS} defaultActiveItemId="Apple" />);
                 await user.click(screen.getByRole('combobox'));
                 scrollIntoViewMock.mockClear();
 
                 await user.keyboard('{End}');
 
+                expect(screen.getByRole('combobox')).toHaveAttribute(
+                    'aria-activedescendant',
+                    screen.getByRole('option', {name: 'Cherry'}).id,
+                );
                 expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
                 expect(scrollIntoViewMock.mock.instances[0]).toBe(
                     screen.getByRole('option', {name: 'Cherry'}),
@@ -318,6 +364,106 @@ describe('lab List: role model x focus strategy', () => {
             } finally {
                 delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView;
             }
+        });
+
+        test('Home/End in a text owner belong to the caret: the activity stays put', () => {
+            render(<ComboboxHarness items={FRUITS} defaultActiveItemId="Banana" />);
+            const input = screen.getByRole('combobox');
+            const bananaId = screen.getByRole('option', {name: 'Banana'}).id;
+
+            // fireEvent returns false once a handler has called preventDefault
+            expect(fireEvent.keyDown(input, {key: 'End'})).toBe(true);
+            expect(input).toHaveAttribute('aria-activedescendant', bananaId);
+
+            expect(fireEvent.keyDown(input, {key: 'Home'})).toBe(true);
+            expect(input).toHaveAttribute('aria-activedescendant', bananaId);
+        });
+
+        test('an owner without a caret searches the list with the character keys', async () => {
+            const user = userEvent.setup();
+            render(<TriggerHarness items={FRUITS} />);
+            const trigger = screen.getByRole('combobox');
+            await user.click(trigger);
+
+            await user.keyboard('b');
+
+            expect(trigger).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getByRole('option', {name: 'Banana'}).id,
+            );
+        });
+
+        test('a space continues the search of an owner without a caret', async () => {
+            const user = userEvent.setup();
+            const onItemAction = jest.fn();
+            render(
+                <TriggerHarness items={['Blueberry', 'Blue whale']} onItemAction={onItemAction} />,
+            );
+            const trigger = screen.getByRole('combobox');
+            await user.click(trigger);
+
+            await user.keyboard('blue');
+            expect(trigger).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getByRole('option', {name: 'Blueberry'}).id,
+            );
+
+            // The space belongs to the query while it is being typed, so it applies nothing and
+            // the search reaches the label with a space in it
+            await user.keyboard(' w');
+            expect(onItemAction).not.toHaveBeenCalled();
+            expect(trigger).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getByRole('option', {name: 'Blue whale'}).id,
+            );
+        });
+
+        test('a text owner types the space instead of searching with it', async () => {
+            const user = userEvent.setup();
+            const onItemAction = jest.fn();
+            render(<ComboboxHarness items={FRUITS} onItemAction={onItemAction} />);
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+
+            await user.keyboard('a b');
+
+            expect(input).toHaveValue('a b');
+            expect(onItemAction).not.toHaveBeenCalled();
+        });
+
+        test('PageUp with no active option enters the list from its end', async () => {
+            const user = userEvent.setup();
+            render(<TriggerHarness items={FRUITS} />);
+            const trigger = screen.getByRole('combobox');
+            await user.click(trigger);
+
+            await user.keyboard('{PageUp}');
+
+            const options = screen.getAllByRole('option');
+            expect(trigger).toHaveAttribute(
+                'aria-activedescendant',
+                options[options.length - 1].id,
+            );
+        });
+
+        test('PageDown/PageUp move the activity of the owner by ten options', async () => {
+            const user = userEvent.setup();
+            const many = Array.from({length: 25}, (_, index) => `Item ${index + 1}`);
+            render(<ComboboxHarness items={many} defaultActiveItemId="Item 1" />);
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+
+            await user.keyboard('{PageDown}');
+            expect(input).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getByRole('option', {name: 'Item 11'}).id,
+            );
+
+            await user.keyboard('{PageUp}');
+            expect(input).toHaveAttribute(
+                'aria-activedescendant',
+                screen.getByRole('option', {name: 'Item 1'}).id,
+            );
         });
 
         test('navigation moves aria-activedescendant without taking the focus out of the input', async () => {
@@ -341,7 +487,8 @@ describe('lab List: role model x focus strategy', () => {
             expect(options[0]).not.toHaveAttribute('data-active');
             expect(input).toHaveFocus();
 
-            await user.keyboard('{End}');
+            // End is left to the caret of a text owner (see the tests above); the arrows cycle
+            await user.keyboard('{ArrowDown}');
             expect(input).toHaveAttribute('aria-activedescendant', options[2].id);
             expect(input).toHaveFocus();
         });
@@ -416,21 +563,7 @@ describe('lab List: role model x focus strategy', () => {
 
         test('the owner may be a button (a select-only combobox)', async () => {
             const user = userEvent.setup();
-            function TriggerHarness() {
-                const focusOwner = useListFocusOwner();
-                return (
-                    <React.Fragment>
-                        <button
-                            type="button"
-                            {...focusOwner.getInputProps({'aria-label': 'Fruit'})}
-                        >
-                            Choose
-                        </button>
-                        <List aria-label="Options" items={FRUITS} focusOwner={focusOwner} />
-                    </React.Fragment>
-                );
-            }
-            render(<TriggerHarness />);
+            render(<TriggerHarness items={FRUITS} />);
 
             const trigger = screen.getByRole('combobox', {name: 'Fruit'});
             expect(trigger.tagName).toBe('BUTTON');
@@ -526,7 +659,7 @@ describe('lab List: role model x focus strategy', () => {
             );
 
             expect(screen.getAllByRole('row')).toHaveLength(3);
-            const header = screen.getByText('Recent');
+            const header = getSectionHeader('Recent');
             expect(header).toHaveAttribute('role', 'presentation');
             expect(header).toHaveAttribute('aria-hidden', 'true');
             expect(header).not.toHaveAttribute('tabindex');
@@ -593,7 +726,7 @@ describe('lab List: role models under virtualization', () => {
                 expect(node).toHaveAttribute(countAttr, '3');
             }
 
-            const header = screen.getByText('Recent');
+            const header = getSectionHeader('Recent');
             expect(header).toHaveAttribute('aria-hidden', 'true');
             expect(header).not.toHaveAttribute(indexAttr);
             expect(header).not.toHaveAttribute(countAttr);

--- a/src/components/lab/List/__tests__/ListVirtualization.test.tsx
+++ b/src/components/lab/List/__tests__/ListVirtualization.test.tsx
@@ -5,7 +5,7 @@ import {ListVirtualizer} from '../../../Virtualizer/ListVirtualizer';
 import {List} from '../List';
 import type {ListProps} from '../types';
 
-import {GROUPS, mockLayout, scrollTo} from './helpers';
+import {GROUPS, getSectionHeader, mockLayout, scrollTo} from './helpers';
 
 const VIEWPORT_HEIGHT = 400;
 const ROW_HEIGHT = 36;
@@ -216,7 +216,7 @@ describe('lab List: virtualization layer', () => {
 
             scrollTo(listbox, ROW_HEIGHT * 150);
 
-            const header = screen.getByText('Logs');
+            const header = getSectionHeader('Logs');
             const option = screen.getByRole('option', {name: 'Log 151'});
             expect(option).toHaveAttribute('aria-describedby', header.id);
             expect(option).toHaveAccessibleDescription('Logs');
@@ -241,7 +241,7 @@ describe('lab List: virtualization layer', () => {
             const firstOptionWrapper = screen.getByRole('option', {name: 'First'}).parentElement;
             expect(firstOptionWrapper).toHaveStyle({top: `${SECTION_HEIGHT}px`});
             // eslint-disable-next-line testing-library/no-node-access
-            const secondHeaderWrapper = screen.getByText('All').parentElement;
+            const secondHeaderWrapper = getSectionHeader('All').parentElement;
             expect(secondHeaderWrapper).toHaveStyle({top: `${SECTION_HEIGHT + ROW_HEIGHT}px`});
         });
 
@@ -283,7 +283,7 @@ describe('lab List: virtualization layer', () => {
             const firstOptionWrapper = screen.getByRole('option', {name: 'First'}).parentElement;
             expect(firstOptionWrapper).toHaveStyle({top: `${SECTION_HEIGHT}px`});
             // eslint-disable-next-line testing-library/no-node-access
-            const secondHeaderWrapper = screen.getByText('All').parentElement;
+            const secondHeaderWrapper = getSectionHeader('All').parentElement;
             expect(secondHeaderWrapper).toHaveStyle({top: `${SECTION_HEIGHT + ROW_HEIGHT}px`});
         });
     });

--- a/src/components/lab/List/__tests__/helpers.tsx
+++ b/src/components/lab/List/__tests__/helpers.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as tabbable from 'tabbable';
 
-import {fireEvent} from '../../../../../test-utils/utils';
+import {fireEvent, screen} from '../../../../../test-utils/utils';
 import {List} from '../List';
 import type {ListItemContext, ListItemViewStateProps, ListProps} from '../types';
 import {useListFocusOwner} from '../useListFocusOwner';
@@ -93,6 +93,21 @@ export function mockLayout({
         offsetHeightSpy.mockRestore();
         offsetWidthSpy.mockRestore();
     });
+}
+
+/**
+ * The header row of a section: the label itself lives in an element of its own inside the row (the
+ * one that clips a label too long for the popup), so the text node is not the row
+ */
+export function getSectionHeader(label: string): HTMLElement {
+    const text = screen.getByText(label);
+    const header = text.closest('[role="presentation"]');
+
+    if (!(header instanceof HTMLElement)) {
+        throw new Error(`No section header around the text "${label}"`);
+    }
+
+    return header;
 }
 
 /** jsdom does not scroll: scrollTop is set directly and the event is fired by hand */

--- a/src/components/lab/List/useList.ts
+++ b/src/components/lab/List/useList.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {useControlledState, useLayoutEffect, useUniqId} from '../../../hooks';
 import {useDirection} from '../../theme';
+import {eventBroker} from '../../utils/event-broker';
 import {warnOnce} from '../../utils/warn';
 
 import {ListVirtualizationContext} from './VirtualizationContext';
@@ -28,7 +29,7 @@ import type {
 import {useItemElementRegistry} from './useItemElementRegistry';
 import {useListSelection} from './useListSelection';
 import {useListTypeahead} from './useListTypeahead';
-import {flattenItems, getNextActiveId, isNavigable} from './utils';
+import {flattenItems, getNextActiveId, isDragTarget, isNavigable, isTextInputTarget} from './utils';
 import type {ListNavigationCommand, ListRow} from './utils';
 
 export type ListContainerDOMProps = React.HTMLAttributes<HTMLElement> & {
@@ -62,7 +63,11 @@ const NAVIGATION_COMMANDS: Record<string, ListNavigationCommand> = {
     ArrowUp: 'prev',
     Home: 'first',
     End: 'last',
+    PageDown: 'pageNext',
+    PageUp: 'pagePrev',
 };
+
+const publishClick = eventBroker.withEventPublisher('List');
 
 export function useList<T>(props: ListProps<T>): ListInstance<T> {
     const {
@@ -352,15 +357,19 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
             if (event.ctrlKey || event.metaKey || event.altKey) {
                 return;
             }
-            if (focusStrategy === 'activedescendant') {
-                return;
-            }
-            // APG: a space is part of the typeahead query while the buffer is not empty
-            event.preventDefault();
+            // APG: a space is part of the typeahead query while the buffer is not empty — otherwise
+            // the search would stop at the first space of a label. A text owner never gets here:
+            // characters go into the text instead of the search, so its query is always empty
             if (typeahead.hasQuery()) {
+                event.preventDefault();
+                event.stopPropagation();
                 typeahead.handleChar(' ');
                 return;
             }
+            if (focusStrategy === 'activedescendant') {
+                return;
+            }
+            event.preventDefault();
             if (!selectionMode) {
                 return;
             }
@@ -370,14 +379,19 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
             return;
         }
 
+        // Typeahead runs unless the characters belong to a caret: a text owner is a filtering
+        // combobox, while a select-only trigger has nothing to type into and searches the list
         if (
-            focusStrategy === 'roving' &&
+            !isTextInputTarget(event.target) &&
             event.key.length === 1 &&
             !event.ctrlKey &&
             !event.metaKey &&
             !event.altKey
         ) {
             event.preventDefault();
+            // A character the list took for its search must not reach the hotkeys of the app
+            // around it: while the list is open, typing belongs to the list
+            event.stopPropagation();
             typeahead.handleChar(event.key);
         }
     };
@@ -414,6 +428,10 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
 
     const handleFocusOwnerKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
         if (event.defaultPrevented) {
+            return;
+        }
+        // APG editable combobox: in a text field Home/End belong to the caret, not to the list
+        if ((event.key === 'Home' || event.key === 'End') && isTextInputTarget(event.target)) {
             return;
         }
         setCursorVisible(true);
@@ -458,6 +476,19 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
             'aria-multiselectable': selectionMode === 'multiple' || undefined,
             'aria-rowcount': role === 'grid' && virtualized ? optionsCount : undefined,
             'data-drag-active': dragActive ? '' : undefined,
+            // A press anywhere in the list — a section header, the padding of the root, the
+            // wrapper of a virtualized row — keeps the focus with the owner, the same way a press
+            // on a row does. Without it a click beside a row takes the keyboard away from the
+            // input and the list stops answering the arrows
+            ...(focusStrategy === 'activedescendant'
+                ? {
+                      onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
+                          if (!isDragTarget(event.target)) {
+                              event.preventDefault();
+                          }
+                      },
+                  }
+                : undefined),
             onKeyDown: handleContainerKeyDown,
             // Cursor is owned by the list holding DOM focus; moves within the root are not a departure
             onFocus: (event: React.FocusEvent<HTMLElement>) => {
@@ -550,7 +581,7 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
             ...(focusStrategy === 'activedescendant'
                 ? {
                       onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
-                          if (!event.currentTarget.hasAttribute('draggable')) {
+                          if (!isDragTarget(event.target)) {
                               event.preventDefault();
                           }
                       },
@@ -570,6 +601,15 @@ export function useList<T>(props: ListProps<T>): ListInstance<T> {
                 };
                 document.addEventListener('pointerup', restore, true);
                 document.addEventListener('pointercancel', restore, true);
+            },
+            // Capture, so that the event reaches the subscribers even if a handler of the row
+            // content stops the propagation later; a click of a key is not published
+            onClickCapture: (event: React.MouseEvent<HTMLElement>) => {
+                const currentRow = latestRef.current.rowById.get(id);
+                if (!currentRow || currentRow.disabled) {
+                    return;
+                }
+                publishClick({domEvent: event, eventId: 'click'});
             },
             onClick: (event: React.MouseEvent<HTMLElement>) => {
                 const latest = latestRef.current;

--- a/src/components/lab/List/utils.ts
+++ b/src/components/lab/List/utils.ts
@@ -4,7 +4,48 @@ import {warnOnce} from '../../utils/warn';
 
 import type {ListItemGetters} from './types';
 
-export const TYPEAHEAD_TIMEOUT = 500;
+/** How long the typed query lives after the last key (APG: "the buffer resets after a pause") */
+export const TYPEAHEAD_TIMEOUT = 1000;
+
+/** How many navigable rows PageUp/PageDown step over (APG recommends "about 10") */
+export const PAGE_STEP = 10;
+
+const NON_TEXT_INPUT_TYPES = new Set([
+    'button',
+    'checkbox',
+    'color',
+    'file',
+    'hidden',
+    'image',
+    'radio',
+    'range',
+    'reset',
+    'submit',
+]);
+
+/**
+ * Whether the event target holds a text caret: such a target keeps the keys that move the caret
+ * (APG editable combobox — there Home/End belong to the text, not to the activity of the list)
+ */
+export function isTextInputTarget(target: EventTarget | null): boolean {
+    if (target instanceof HTMLTextAreaElement) {
+        return true;
+    }
+    if (target instanceof HTMLInputElement) {
+        return !NON_TEXT_INPUT_TYPES.has(target.type);
+    }
+    // A rich text field is a caret as much as an input is
+    return target instanceof HTMLElement && target.isContentEditable;
+}
+
+/**
+ * Whether a press lands inside a native drag source: such a press keeps the default of the browser,
+ * since a drag starts from `mousedown` (a `draggable="false"` handle of a drag-and-drop library
+ * counts too — its sensor drops a press whose default was prevented)
+ */
+export function isDragTarget(target: EventTarget | null): boolean {
+    return target instanceof HTMLElement && target.closest('[draggable]') !== null;
+}
 
 export interface ListRow<T> {
     id: string;
@@ -141,11 +182,11 @@ export function flattenItems<T>(
     return {rows, rowById, domIdToId, optionsCount};
 }
 
-export type ListNavigationCommand = 'next' | 'prev' | 'first' | 'last';
+export type ListNavigationCommand = 'next' | 'prev' | 'first' | 'last' | 'pageNext' | 'pagePrev';
 
 /**
  * Navigable = non-disabled options. next/prev wrap unless `wrap: false` (Shift+arrow range
- * gestures)
+ * gestures); the page commands never wrap and stop at the edges
  */
 export function getNextActiveId<T>(
     command: ListNavigationCommand,
@@ -166,6 +207,17 @@ export function getNextActiveId<T>(
             return navigable[0].id;
         case 'last':
             return navigable[navigable.length - 1].id;
+        case 'pageNext':
+            if (currentIndex === -1) {
+                return navigable[0].id;
+            }
+            return navigable[Math.min(currentIndex + PAGE_STEP, navigable.length - 1)].id;
+        case 'pagePrev':
+            if (currentIndex === -1) {
+                // A page up from nowhere enters the list from its end, the way ArrowUp does
+                return navigable[navigable.length - 1].id;
+            }
+            return navigable[Math.max(currentIndex - PAGE_STEP, 0)].id;
         case 'next':
             if (currentIndex === -1) {
                 return navigable[0].id;

--- a/src/components/lab/ListItemView/ListItemView.scss
+++ b/src/components/lab/ListItemView/ListItemView.scss
@@ -293,7 +293,7 @@ $block: '.#{variables.$ns}lab-list-item-view';
 
         width: var(--_--controls-size);
         height: var(--_--controls-size);
-        color: var(--g-color-base-brand);
+        color: var(--g-color-text-brand);
     }
 
     &__icon {


### PR DESCRIPTION
🤖 AI generated

`Select` is moving onto the new list. This PR brings the core to the state that migration needs, so that the component lands on a core that is already merged and green. The new list has no consumers yet, so nothing here breaks anyone — these are just changes, each with the reason it was made.

## The two ways the list is driven

By default the focus stands on a row. Arrows move it from row to row, and the user is inside the list.

A combobox does it differently. The focus stays on the element that owns the list — the trigger button of a select, or the input of a filterable one — and never enters the list. The active row is only pointed at, with `aria-activedescendant`. The owner forwards keys to the list (`useListFocusOwner`). `Select` works this way.

The second way is where keys collide: one element gets the key, and both the list and (if the owner is a text field) the text caret want it.

## Keys

The rule: **a key that moves the caret in a text field stays with the field. Everything else goes to the list.**

| Key | Focus on a row | Owner is a button | Owner is a text field |
| --- | --- | --- | --- |
| `PageUp` / `PageDown` | ten rows up or down | the same | the same |
| `Home` / `End` | first / last row | first / last row | the caret jumps to the start or the end of the text, the list does not move |
| Letters and digits | jump to the row that starts with what was typed | the same | go into the field — typing there is filtering |
| `Space` | selects the row | applies the row | goes into the field |

Why: a select needs page keys, and a filterable select needs both a working caret and a working list. The [APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) gives `Home`/`End` to the caret of an editable combobox, and explains its own wrapping of the arrows by it. It says nothing about the page keys, and in a single-line field they move nothing — so the list keeps them.

Details: the page step is ten rows (the APG says "about 10") and counts only rows that can be active, so headers and disabled options do not eat it; at the ends the step stops instead of jumping to the other side; with nothing active yet, `PageDown` enters the list from the top and `PageUp` from the bottom.

## The search by the first letters

- **The typed query now lives a second after the last key** (it was half a second). Why: half a second is a blind-typing pace; a list is read with the eyes and typed into with pauses, and the query fell apart into single letters.
- **A space continues the query** instead of selecting, while the query is being typed. Why: without it the search stops at the first space, and "Blue whale" is unreachable.
- **A letter the list took for the search no longer travels further up the page.** Why: an application hotkey used to fire on it. In our Storybook, typing `1` into an open `Select` moved the focus to the sidebar and closed the popup.

## The mouse

- **A press anywhere in the list keeps the focus with the owner** — on a header, on the padding of the root, on the wrapper of a virtualized row. Only a press on a row did that before. Why: a click beside a row took the keyboard away from the input, and the list stopped answering the arrows.
- **A press inside a draggable element keeps the browser default.** Why: a drag starts from `mousedown`. Both handlers now use one check — any element with a `draggable` attribute, whatever its value — because a drag handle of a drag-and-drop library carries `draggable="false"` and its sensor ignores a press whose default was taken away.

## Analytics

**A click on an option is published to the `eventBroker` of the kit** — `componentId: 'g-List'`, `eventId: 'click'`. Why: the legacy `List` publishes exactly this, so a component that migrates from one list to the other keeps its numbers. Keys are not published, and neither are clicks on a disabled row or a header.

## The look

- **A header that follows other rows gets a separating line and more space above its text.** Why: that is how a group looks in the design system. The line is drawn inside the padding the header already has, so a virtualized row does not grow because of it.
- **The header takes the colour of the primary text explicitly.** Why: it inherited the colour from whatever it was put into, and the row beside it sets its colour itself.
- **The header keeps its label on one line and clips the rest with an ellipsis.** Why: a long group name used to wrap to two lines, and with a fixed row height it was cut through the middle of a letter.
- **A row of a scrolling list keeps its own height.** Why: when the popup ran out of height, the headers were squeezed from 30 to 12 pixels.
- **The check mark of a selected row is painted with `--g-color-text-brand` instead of `--g-color-base-brand`.** Why: the old one is a fill token — the same colour in all four themes, 1.64:1 against the surface of a popup, where WCAG asks 3:1 of an icon. The text token is adjusted per theme: 2.94:1 in light, 11.73:1 in dark. The check mark renders for `selectionMode="multiple"` only, so `lab/Menu` and `Breadcrumbs` are not affected.

## Checks

`typecheck`, `eslint`, `stylelint`, `prettier`, `jest` (1346 tests), `playwright` (512 visual tests) — run on this branch alone, in a separate worktree.
